### PR TITLE
chore: selectionchange listener + keep list/blockquote E2E skipped

### DIFF
--- a/apps/editor-react/tests/blockquote.spec.ts
+++ b/apps/editor-react/tests/blockquote.spec.ts
@@ -4,7 +4,6 @@ const blockquoteShortcut = process.platform === 'darwin' ? 'Meta+Shift+b' : 'Con
 
 test.describe('React Editor – blockquote (wrapInBlockquote)', () => {
   test.skip('toggleBlockquote wraps paragraph in blockquote', async ({ page }) => {
-    // Skip: keybinding/selection sync in CI (same as list E2E)
     await page.goto('/');
     const content = page.locator('[data-bc-layer="content"], [data-testid="editor-content"]').first();
     await expect(content).toBeVisible();

--- a/apps/editor-react/tests/list.spec.ts
+++ b/apps/editor-react/tests/list.spec.ts
@@ -4,7 +4,6 @@ const bulletListShortcut = process.platform === 'darwin' ? 'Meta+Shift+8' : 'Con
 
 test.describe('React Editor – list (wrapInList / splitListItem)', () => {
   test.skip('toggleBulletList wraps paragraph in list; Enter in list item creates new list item', async ({ page }) => {
-    // Skip: keybinding/selection sync may need focus/context verification in CI; implementation verified by model exec tests.
     await page.goto('/');
 
     const content = page.locator('[data-bc-layer="content"], [data-testid="editor-content"]').first();

--- a/packages/editor-view-react/src/EditorViewContext.tsx
+++ b/packages/editor-view-react/src/EditorViewContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo, useRef, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, type ReactNode } from 'react';
 import type { Editor } from '@barocss/editor-core';
 import type { ReactSelectionHandler } from './selection-handler';
 import type { ReactInputHandler } from './input-handler';
@@ -83,6 +83,12 @@ export function EditorViewContextProvider({ editor, children }: { editor: Editor
     },
     [mutationObserverManager]
   );
+
+  useEffect(() => {
+    const onSelectionChange = () => selectionHandler.handleSelectionChange();
+    document.addEventListener('selectionchange', onSelectionChange);
+    return () => document.removeEventListener('selectionchange', onSelectionChange);
+  }, [selectionHandler]);
 
   const value = useMemo<EditorViewContextValue>(
     () => ({


### PR DESCRIPTION
## 변경 사항
- **EditorViewContext**: `document` `selectionchange` 리스너 추가 → 클릭/캐럿 이동 시 `selectionHandler.handleSelectionChange()` 호출로 모델 selection 동기화
- **list.spec.ts / blockquote.spec.ts**: 리스트·인용 블록 토글 E2E는 그대로 `test.skip` 유지 (editor-view-react에 keydown/beforeinput 미연결로 단축키 미동작; 추후 contentEditable에 이벤트 연결 후 재검토 예정)

## 배경
E2E 실패 원인: editor-view-react에서 contentEditable에 keydown/beforeinput 리스너가 없어 단축키가 동작하지 않음. selectionchange 동기화는 적용해 두고, E2E는 전체 검토 시 다시 활성화할 예정.

Made with [Cursor](https://cursor.com)