### PR TITLE
docs: Validation Agent and internal logic validation wiring

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -39,6 +39,8 @@ This repo is a **platform for building editors**. When adding or changing a feat
 
 ### 4. 다른 역할만 쓰고 싶을 때
 
+- **내부 로직 검증**: "Act as Validation Agent. 내부 로직 검증해줘." / "내부 로직 검증해줘."  
+  → **`docs/internal-logic-validation.md`** 순서대로 패키지별 `test:run` 실행, 실패 시 수정 또는 보고. 기능 추가 전에 내부 로직을 단단히 할 때 사용.
 - **README 정리**: "Act as README Agent. README 업데이트해줘." / "패키지 README 맞춰줘."
 - **문서 사이트만**: "Act as Docs Agent. docs만 업데이트해줘."
 - **PR 리뷰**: "Act as Review Agent. 이 PR 리뷰해줘."
@@ -117,9 +119,10 @@ Work can be split by **role** so that different agents (or the same agent acting
 | **Release** | Package release (changeset, version, publish) | User request or post-merge | Version PR or npm publish |
 | **Security** | Dependency / security | User request or schedule | Audit report, dependency update PR |
 | **Refactor** | Refactoring only (no new features) | User request or scope | Refactored code; Test Agent must pass after |
+| **Validation** | Internal logic validation (package tests in order) | User request or "내부 로직 검증해줘" | Per-package test:run in order; pass/fail report; fix or escalate |
 | **README** | README only (root + packages/*/README.md) | User request or new package/feature | Updated root README.md, updated packages/*/README.md |
 
-**How to invoke by role**: Say “Act as **Spec Agent** …” (e.g. "이슈 만들어줘", "백로그 정리해줘" for Backlog; "다른 에디터 조사해서 추가할 만한 기능 알려줘" for Research), or Implementation / Test / E2E / GitHub Agent) and give the input (e.g. “For issue #123, implement per the checklist”). Each role only does its scope; handoff is defined in the doc above. **Role files**: **`.cursor/roles/`** — `BACKLOG_AGENT.md`, `RESEARCH_AGENT.md`, `SPEC_AGENT.md`, `IMPLEMENTATION_AGENT.md`, `TEST_AGENT.md`, `E2E_AGENT.md`, `GITHUB_AGENT.md`, `DOCS_AGENT.md`, `REVIEW_AGENT.md`, `RELEASE_AGENT.md`, `SECURITY_AGENT.md`, `REFACTOR_AGENT.md`, `README_AGENT.md` (short scope per role; @-mention when invoking). For **automation**, use triggers (e.g. issue labels `spec-ready`, `ready-for-test`, `unit-pass`, `e2e-pass`) as the contract; see `docs/agent-roles-and-orchestration.md` §4.2.
+**How to invoke by role**: Say “Act as **Spec Agent** …” (e.g. "이슈 만들어줘", "백로그 정리해줘" for Backlog; "다른 에디터 조사해서 추가할 만한 기능 알려줘" for Research), or Implementation / Test / E2E / GitHub Agent) and give the input (e.g. “For issue #123, implement per the checklist”). Each role only does its scope; handoff is defined in the doc above. **Role files**: **`.cursor/roles/`** — `BACKLOG_AGENT.md`, `RESEARCH_AGENT.md`, `SPEC_AGENT.md`, `IMPLEMENTATION_AGENT.md`, `TEST_AGENT.md`, `E2E_AGENT.md`, `GITHUB_AGENT.md`, `DOCS_AGENT.md`, `REVIEW_AGENT.md`, `RELEASE_AGENT.md`, `SECURITY_AGENT.md`, `REFACTOR_AGENT.md`, `VALIDATION_AGENT.md`, `README_AGENT.md` (short scope per role; @-mention when invoking). For **automation**, use triggers (e.g. issue labels `spec-ready`, `ready-for-test`, `unit-pass`, `e2e-pass`) as the contract; see `docs/agent-roles-and-orchestration.md` §4.2.
 
 ---
 
@@ -136,6 +139,8 @@ Details on layers, patterns, and verification are in **`docs/platform-for-agent.
 
 ## Where to do what
 
+- **Internal logic validation (패키지별 검증 순서·테스트)**: **`docs/internal-logic-validation.md`**  
+  - 패키지별 검증 순서(shared → schema → … → devtool), 각 패키지에서 검증할 내부 로직, 테스트 실행 방법. "내부 로직 검증해줘" / "Act as Validation Agent" 시 이 문서를 따른다.
 - **Package / app / flow skills**: **`.cursor/skills/README.md`**  
   - Which skill to use per package, cross-cutting flows (e.g. adding operations, selection), and app roles (editor-test, editor-react) in a table.
 - **Adding an operation**: **`.cursor/skills/model-operation-creation/SKILL.md`**  
@@ -162,6 +167,7 @@ When you ask the agent to change this repo, phrase the request so the agent know
 | Add **only E2E** for existing behavior | “Add an E2E test in editor-react for toggleBold: select text, press Mod+b, assert bold.” | Add or extend `apps/editor-react/tests/*.spec.ts`, run `pnpm test:e2e:react`. |
 | **Fix or change** one layer | “In insertParagraph, ensure selectionAfter.nodeId is always a text node.” | Edit the relevant package (e.g. model), run that package’s tests and, if needed, E2E. |
 | **Verify** after changes | “Run unit tests for model and extensions and then E2E for React.” | Run `pnpm --filter @barocss/model test:run`, `pnpm --filter @barocss/extensions test:run`, then `pnpm test:e2e:react`. |
+| **Internal logic validation** (패키지별 검증) | "내부 로직 검증해줘." / "Act as Validation Agent. 내부 로직 검증해줘." | Follow **`docs/internal-logic-validation.md`**: run `pnpm --filter @barocss/<package> test:run` in the documented order (shared → schema → … → devtool); report pass/fail; fix or escalate. |
 
 ### What to include in a command
 

--- a/.cursor/roles/README.md
+++ b/.cursor/roles/README.md
@@ -1,6 +1,6 @@
 # Agent roles
 
-Each file in this directory defines one **role** for sub-agent invocation. When you say “Act as **Backlog Agent**” (or Research / Spec / Implementation / Test / E2E / GitHub / Docs / Review / Release / Security / Refactor / README Agent), read the corresponding file and **`docs/agent-roles-and-orchestration.md`** for full scope, inputs, outputs, and handoff.
+Each file in this directory defines one **role** for sub-agent invocation. When you say “Act as **Backlog Agent**” (or Research / Spec / Implementation / Test / E2E / GitHub / Docs / Review / Release / Security / Refactor / Validation / README Agent), read the corresponding file and **`docs/agent-roles-and-orchestration.md`** for full scope, inputs, outputs, and handoff.
 
 | File | Role | Focus |
 |------|------|--------|
@@ -16,8 +16,9 @@ Each file in this directory defines one **role** for sub-agent invocation. When 
 | **RELEASE_AGENT.md** | Release Agent | Package release (changeset, version, publish). No implement, no merge. |
 | **SECURITY_AGENT.md** | Security Agent | Dependency/security. No feature implement. |
 | **REFACTOR_AGENT.md** | Refactor Agent | Refactoring only; no new features. Test Agent runs after. |
+| **VALIDATION_AGENT.md** | Validation Agent | Internal logic validation: run package tests in order per `docs/internal-logic-validation.md`. No new features, no spec. |
 | **README_AGENT.md** | README Agent | README only (root + packages/*/README.md). No implement, no apps/docs-site. |
 
-**Flow**: Spec → Implementation → Test → E2E → GitHub. Backlog feeds issues; Research feeds report → user or Backlog. Docs, Review, Release, Security, Refactor, README are on-demand (docs only, review PR, release, audit deps, refactor). Handback to Implementation when tests fail due to code.
+**Flow**: Spec → Implementation → Test → E2E → GitHub. Backlog feeds issues; Research feeds report → user or Backlog. Docs, Review, Release, Security, Refactor, Validation, README are on-demand (docs only, review PR, release, audit deps, refactor). Handback to Implementation when tests fail due to code.
 
 **Orchestration**: Manual (“Act as X Agent …”) or trigger-based (issue labels, PR events); see `docs/agent-roles-and-orchestration.md` §4.

--- a/.cursor/roles/VALIDATION_AGENT.md
+++ b/.cursor/roles/VALIDATION_AGENT.md
@@ -1,0 +1,13 @@
+# Validation Agent
+
+**Role**: Internal logic validation — run package tests in dependency order. Use **`docs/internal-logic-validation.md`** as the single source. Do not add features or change spec; only run tests and fix or report failures.
+
+**Input**: User request (e.g. "내부 로직 검증해줘", "Act as Validation Agent. 내부 로직 검증해줘", "패키지별 테스트 순서대로 돌려줘").
+
+**Output**:
+- For each package in the order in **`docs/internal-logic-validation.md`**, run `pnpm --filter @barocss/<package> test:run`. Report pass/fail per package. If fail: fix code or test in that package and re-run; or escalate.
+- No new features or spec changes.
+
+**Do not**: Implement new behavior; change spec; open PR. When all packages in scope pass, validation is done.
+
+**Full definition**: `docs/agent-roles-and-orchestration.md` §2.14. See **`docs/internal-logic-validation.md`** (validation order, per-package scope, run commands), `.cursor/AGENTS.md` § Where to do what.

--- a/docs/agent-roles-and-orchestration.md
+++ b/docs/agent-roles-and-orchestration.md
@@ -32,6 +32,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 | **Release** | Package release (changeset, version, publish) | User request or post-merge | Version PR or npm publish | — |
 | **Security** | Dependency / security | User request or schedule | Audit report, dependency update PR | — |
 | **Refactor** | Refactoring only (no new features) | User request or scope | Refactored code; Test Agent must pass after | Test |
+| **Validation** | Internal logic validation (package tests in order) | User request or "내부 로직 검증해줘" | Per-package test:run in order; pass/fail report; fix or escalate | — |
 | **README** | README only (root + packages/*/README.md) | User request or new package/feature | Updated root README.md, updated packages/*/README.md | — |
 
 ---
@@ -266,6 +267,25 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 **Handoff**: None. README Agent does **not** implement, change spec/code, or edit apps/docs-site.
 
 **References**: Root `README.md`, `packages/*/README.md`, `packages/*/SPEC.md` (for package contract summary), `docs/docs-site-integration.md` (docs-site is separate; README is repo-level).
+
+---
+
+### 2.14 Validation Agent
+
+**Focus**: Internal logic validation — run package tests in dependency order so that each package’s behavior is verified before adding features. Uses **`docs/internal-logic-validation.md`** as the single source of order and scope. Does not add features or change spec; only runs tests and fixes or reports failures.
+
+**Input**:
+- User request (e.g. “내부 로직 검증해줘”, “Act as Validation Agent. 내부 로직 검증해줘”, “패키지별 테스트 순서대로 돌려줘”).
+- **`docs/internal-logic-validation.md`**: validation order (shared → schema → … → devtool), per-package scope, and run commands.
+
+**Output**:
+- **Test runs**: For each package in the documented order, run `pnpm --filter @barocss/<package> test:run`. If a package has no `test:run`, skip or note.
+- **Report**: Pass/fail per package. If fail: fix the code or test in that package and re-run; or escalate (e.g. “model tests fail: …”).
+- **No new features**: Validation Agent does **not** implement new behavior or change specs; it only validates existing logic with tests.
+
+**Handoff**: None. When all packages in scope pass, validation is done. If the user asked for “내부 로직 검증 후 기능 추가”, hand off to Spec/Implementation Agent after validation passes.
+
+**References**: **`docs/internal-logic-validation.md`** (validation order, per-package scope, run commands), `.cursor/AGENTS.md` § Where to do what (Internal logic validation), `docs/testing-verification.md`.
 
 ---
 

--- a/docs/internal-logic-validation.md
+++ b/docs/internal-logic-validation.md
@@ -1,0 +1,141 @@
+# 내부 로직 검증 순서 및 테스트 전략
+
+**원칙**: 패키지별로 내부 로직을 단단히 검증한 뒤 기능 추가를 진행한다. 검증은 **테스트 코드를 최대한 활용**한다.
+
+---
+
+## 1. 검증 순서 (의존성 하단 → 상단)
+
+아래 패키지는 다른 `@barocss/*` 패키지에 의존하지 않거나, 이미 검증된 패키지에만 의존한다. **이 순서대로** 검증하면, 상위 패키지 검증 시 하위가 이미 안정되어 있다.
+
+| 순서 | 패키지 | 의존(@barocss) | 검증 시점 |
+|------|--------|----------------|-----------|
+| **1** | **shared** | 없음 | 유틸·상수·키 문자열 등 단위 테스트로 검증 |
+| **2** | **schema** | 없음 | 스키마 정의·getNodeType·그룹 검증 |
+| **3** | **text-analyzer** | 없음 | 텍스트 변경 분석·유니코드 분석 테스트 |
+| **4** | **text-run-index** | 없음 | 텍스트 런 인덱스·오프셋 변환 테스트 |
+| **5** | **dsl** | 없음 | DSL 함수·레지스트리·템플릿 빌더 테스트 |
+| **6** | **datastore** | schema, model(타입) | CRUD·트랜잭션·락·오버레이·마크·쿼리 테스트 |
+| **7** | **converter** | datastore | 변환·로드/저장 로직 테스트 |
+| **8** | **dom-observer** | text-analyzer | MutationObserver·변경 분류 테스트 |
+| **9** | **renderer-dom** | dsl, text-run-index | 리콘실·VNode·DOM 매핑·마크 렌더 테스트 |
+| **10** | **renderer-react** | dsl | React 빌드·렌더러 테스트 |
+| **11** | **model** | datastore, editor-core(타입), schema | 트랜잭션·DSL·오퍼레이션 실행 테스트 |
+| **12** | **editor-core** | datastore, model, renderer-dom, shared, schema | 키바인딩·컨텍스트·명령 실행·selectionManager 테스트 |
+| **13** | **extensions** | editor-core, model, converter | 확장 명령·before/after 훅 테스트 |
+| **14** | **editor-view-dom** | dsl, datastore, dom-observer, editor-core, renderer-dom, schema, shared, text-analyzer | 입력·선택·DOM 동기화 테스트 |
+| **15** | **editor-view-react** | dsl, editor-core, renderer-react, shared, text-analyzer, text-run-index | EditorView·selection·input-handler 테스트 (필요 시 추가) |
+| **16** | **collaboration** | datastore | 협업 어댑터·동기화 테스트 |
+| **17** | **devtool** | editor-core, model | 트레이싱·UI 연동 테스트 (선택) |
+
+---
+
+## 2. 패키지별 검증 범위 및 테스트 활용
+
+각 패키지에서 **어떤 내부 로직을 검증할지**와 **어떤 테스트를 쓸지**를 정리한다. 기존 `vitest` 테스트가 있으면 `pnpm --filter @barocss/<패키지> test:run`으로 실행한다.
+
+### Tier 0 (외부 의존 없음)
+
+- **shared**  
+  - 검증: 키 문자열·상수·공용 타입·유틸 함수  
+  - 테스트: 단위 테스트로 입력/출력·엣지 케이스 검증  
+
+- **schema**  
+  - 검증: 스키마 등록·getNodeType·group·content 규칙  
+  - 테스트: `packages/schema` 내 vitest 테스트 활용·커버리지 확인  
+
+- **text-analyzer**  
+  - 검증: `analyzeTextChanges`, 유니코드/조합 문자 처리  
+  - 테스트: `packages/text-analyzer/test/` (smart-text-analyzer, unicode-text-analysis)  
+
+- **text-run-index**  
+  - 검증: `buildTextRunIndex`, `binarySearchRun`, 오프셋↔DOM 매핑  
+  - 테스트: 해당 패키지에 테스트 추가 후 `test:run`  
+
+- **dsl**  
+  - 검증: DSL 함수·레지스트리·템플릿 빌더  
+  - 테스트: `packages/dsl/tests/` (dsl-functions 등)  
+
+### Tier 1 (datastore / converter / DOM·React 렌더 기초)
+
+- **datastore**  
+  - 검증: getNode/setNode·트랜잭션·락·오버레이·마크·content 조작·쿼리·방문자  
+  - 테스트: `packages/datastore/test/` 전반 (data-store-*.test.ts, iterator, lock, mark 등) — **기존 테스트 최대 활용**  
+
+- **converter**  
+  - 검증: 문서↔저장 형식 변환·로드/저장 일관성  
+  - 테스트: `packages/converter` 내 vitest 테스트  
+
+- **dom-observer**  
+  - 검증: MutationObserver 설정·변경 수집·분류  
+  - 테스트: `packages/dom-observer` vitest  
+
+- **renderer-dom**  
+  - 검증: 리콘실·VNode↔DOM·마크/데코레이터·data-bc-sid 부여  
+  - 테스트: `packages/renderer-dom/test/` (reconciler, mark, decorator 등)  
+
+- **renderer-react**  
+  - 검증: build→React 노드·렌더러 인스턴스 동작  
+  - 테스트: 필요 시 단위 테스트 추가 후 `test:run`  
+
+### Tier 2 (model·editor-core·extensions)
+
+- **model**  
+  - 검증: 트랜잭션 실행·DSL 시퀀스·오퍼레이션별 부작용·selectionContext  
+  - 테스트: `packages/model/test/` — `transaction/`, `operations/*.exec.test.ts`, `operations/*.test.ts` **전부 실행**해 회귀 방지  
+
+- **editor-core**  
+  - 검증: keybindings resolve·context 갱신·executeCommand·selectionManager·updateSelection  
+  - 테스트: `packages/editor-core/test/` (selection-manager, editor, keybinding 등)  
+
+- **extensions**  
+  - 검증: 명령 등록·실행·before/after 훅·converter 연동  
+  - 테스트: `packages/extensions/test/`  
+
+### Tier 3 (view·협업·도구)
+
+- **editor-view-dom**  
+  - 검증: 입력→모델 반영·선택 DOM↔모델 동기화·키다운/beforeinput  
+  - 테스트: `packages/editor-view-dom/test/` (event-handlers, integration, selection 등) — **기존 테스트 최대 활용**  
+
+- **editor-view-react**  
+  - 검증: EditorView 마운트·selectionchange·input-handler·contentEditable 이벤트 연결  
+  - 테스트: 단위 테스트 추가 또는 apps/editor-react E2E와 연계 (E2E는 내부 로직 안정화 후 재활성화)  
+
+- **collaboration**  
+  - 검증: 어댑터·동기화 프로토콜·datastore 연동  
+  - 테스트: collaboration, collaboration-yjs, collaboration-liveblocks 각각 test:run  
+
+- **devtool**  
+  - 검증: 필요 시 트레이싱·이벤트 수집 로직만 단위 테스트 (선택)  
+
+---
+
+## 3. 실행 방법
+
+- **단일 패키지**  
+  ```bash
+  pnpm --filter @barocss/<패키지명> test:run
+  ```
+  예: `pnpm --filter @barocss/datastore test:run`, `pnpm --filter @barocss/model test:run`
+
+- **순서대로 전체 검증** (Tier 0 → 3)  
+  ```bash
+  pnpm --filter @barocss/shared test:run
+  pnpm --filter @barocss/schema test:run
+  pnpm --filter @barocss/text-analyzer test:run
+  # … 위 표 순서대로 반복
+  ```
+
+- **CI에서 한 번에**  
+  루트 또는 워크스페이스에서 `pnpm -r test:run` (각 패키지 script에 `test:run`이 있을 때).  
+  필요하면 `docs/internal-logic-validation.md` 순서를 CI 스크립트나 체크리스트에 반영한다.
+
+---
+
+## 4. 정리
+
+- **내부 로직 검증**: 위 **1→2→…→17 순서**를 지키면, 하위 패키지가 안정된 상태에서 상위를 검증할 수 있다.  
+- **테스트 활용**: 이미 있는 vitest 테스트를 **최대한 활용**하고, 커버리지가 부족한 패키지(예: editor-view-react, text-run-index, renderer-react)에는 **필요한 단위 테스트를 추가**한다.  
+- **기능 추가**: 해당 기능이 건드리는 패키지의 검증(테스트 통과)이 끝난 뒤 진행한다.  
+- **E2E**: 리스트/인용 등 E2E는 view 레이어(keydown·beforeinput 연결 등)가 안정된 뒤 다시 활성화한다.

--- a/docs/platform-for-agent.md
+++ b/docs/platform-for-agent.md
@@ -122,11 +122,12 @@ A **“How to give commands”** section with a table and examples lives in **`.
 ## 5. References
 
 - **Agent entry point and command phrasing**: `.cursor/AGENTS.md`
+- **Internal logic validation (패키지별 검증 순서·테스트)**: `docs/internal-logic-validation.md` — 패키지별 검증 순서(shared → … → devtool), 검증 범위, 테스트 실행. "내부 로직 검증해줘" / Validation Agent 시 이 문서를 따른다.
 - **Specs (editor-wide and package-level)**: `docs/specs/README.md`, `docs/specs/editor.md`, `packages/model/SPEC.md`
 - **Testing and verification**: `docs/testing-verification.md`
 - **GitHub integration (issue, PR, CI, merge, deploy)**: `docs/github-agent-integration.md`
 - **Docs-site (spec → implementation → documentation → test → verify)**: `docs/docs-site-integration.md`
-- **Agent roles and orchestration (Spec / Implementation / Test / E2E / GitHub)**: `docs/agent-roles-and-orchestration.md`
+- **Agent roles and orchestration (Spec / Implementation / Test / E2E / GitHub / Validation)**: `docs/agent-roles-and-orchestration.md`
 - **Skills list and roles**: `.cursor/skills/README.md`
 - **Operation-add pattern**: `.cursor/skills/model-operation-creation/SKILL.md`
 - **Package relationships**: `docs/architecture-package-relationships.md`


### PR DESCRIPTION
## 변경 사항
- **docs/internal-logic-validation.md**: 패키지별 검증 순서(shared → … → devtool), 검증 범위, test:run 실행 방법
- **AGENTS.md**: Validation 역할, '내부 로직 검증해줘' 명령, Where to do what 링크
- **docs/agent-roles-and-orchestration.md**: Validation Agent §2.14, 역할 테이블
- **docs/platform-for-agent.md**: internal-logic-validation 참조
- **.cursor/roles/VALIDATION_AGENT.md**: Validation Agent 역할 파일
- **.cursor/roles/README.md**: 역할 목록·테이블에 Validation 추가

Made with [Cursor](https://cursor.com)