### PR TITLE
docs(agent): 테스트 파일 없는 패키지에 최소 테스트 파일 생성 규칙 추가

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -291,6 +291,7 @@ Use this when you need a fixed sequence to confirm the change.
 | Failure | What to do |
 |--------|------------|
 | **Unit test fails** in a package | Fix the code or the test in that package; re-run `pnpm --filter @barocss/<package> test:run` until it passes. Do not run E2E until unit passes. |
+| **Package has no test files** (vitest reports "No test files found") | Create a minimal test file in that package (e.g. `test/<name>.test.ts` with one smoke test that imports and asserts core behavior). Then re-run `pnpm --filter @barocss/<package> test:run`. See **`docs/internal-logic-validation.md`** §3.1. |
 | **E2E fails** (e.g. selector, timeout) | 1) Run unit tests for the same feature (model + extensions); if unit passes, the issue is likely DOM/timing or selector. 2) Run E2E in headed mode (`pnpm --filter @barocss/editor-react test:e2e -- --headed`) and watch the run; adjust selectors or waits in the spec. 3) If the app’s initial content changed, update the spec to match. |
 | **Only one E2E file fails** | Run that file alone: `pnpm --filter @barocss/editor-react test:e2e -- tests/<name>.spec.ts`; fix assertions or selectors in that file. |
 | **Manual behavior wrong** but tests pass | Add or extend a unit test (e.g. exec test) or E2E test that asserts the expected behavior; then fix the implementation until the new test passes. |

--- a/.cursor/roles/TEST_AGENT.md
+++ b/.cursor/roles/TEST_AGENT.md
@@ -6,6 +6,7 @@
 
 **Output**:
 - Add or update unit tests (exec tests, extension tests). Run `pnpm --filter @barocss/<package> test:run` for each touched package. Report pass/fail. If fail, fix tests or hand back to Implementation.
+- **No test files**: If a touched package has a `test`/`test:run` script but vitest exits with "No test files found", create a minimal test file in that package (e.g. one smoke test that imports and asserts core behavior), then re-run `test:run` for that package.
 
 **Do not**: Run E2E; open PR; change spec docs.
 

--- a/.cursor/roles/VALIDATION_AGENT.md
+++ b/.cursor/roles/VALIDATION_AGENT.md
@@ -6,6 +6,7 @@
 
 **Output**:
 - For each package in the order in **`docs/internal-logic-validation.md`**, run `pnpm --filter @barocss/<package> test:run`. Report pass/fail per package. If fail: fix code or test in that package and re-run; or escalate.
+- **No test files**: If a package has a `test`/`test:run` script but vitest exits with "No test files found", create a minimal test file in that package (e.g. `test/<name>.test.ts` with one smoke test that imports and asserts core behavior), then re-run `test:run` for that package.
 - No new features or spec changes.
 
 **Do not**: Implement new behavior; change spec; open PR. When all packages in scope pass, validation is done.

--- a/docs/agent-roles-and-orchestration.md
+++ b/docs/agent-roles-and-orchestration.md
@@ -86,6 +86,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 
 **Output**:
 - **Test code**: Add or update unit tests (e.g. exec tests, extension tests) so that the spec and behavior are covered. Fix failing tests by changing tests or escalating to Implementation (e.g. spec violation).
+- **No test files**: If a touched package has a `test`/`test:run` script but vitest exits with "No test files found", create a minimal test file in that package (e.g. one smoke test that imports and asserts core behavior), then re-run `test:run` for that package.
 - **Test results**: Run `pnpm --filter @barocss/<package> test:run` for each touched package. Report pass/fail. If fail, fix or hand back to Implementation.
 
 **Handoff**: If all unit tests pass, E2E Agent runs. If tests fail and the failure is in implementation, hand back to Implementation Agent. Test Agent does **not** run E2E or open PRs.
@@ -280,6 +281,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 
 **Output**:
 - **Test runs**: For each package in the documented order, run `pnpm --filter @barocss/<package> test:run`. If a package has no `test:run`, skip or note.
+- **No test files**: If a package has a `test`/`test:run` script but vitest exits with "No test files found", create a minimal test file in that package (e.g. one smoke test that imports and asserts core behavior), then re-run `test:run` for that package.
 - **Report**: Pass/fail per package. If fail: fix the code or test in that package and re-run; or escalate (e.g. “model tests fail: …”).
 - **No new features**: Validation Agent does **not** implement new behavior or change specs; it only validates existing logic with tests.
 

--- a/docs/github-agent-integration.md
+++ b/docs/github-agent-integration.md
@@ -10,7 +10,7 @@ This doc describes how to tie the editor development flow (and AI agents) to Git
 |------|-----|------|
 | **Issue** | User or agent | Create an issue from a template (feature / bug / E2E). Agent uses it as the spec. |
 | **Branch** | Agent | Create branch from `main` (e.g. `feat/insert-list`, `fix/insert-paragraph-selection`). |
-| **Implement** | Agent | Follow `.cursor/AGENTS.md` feature loop; run verification (`.cursor/AGENTS.md` § How to verify). |
+| **Implement** | Agent | Follow `.cursor/AGENTS.md` feature loop; run verification (`.cursor/AGENTS.md` § How to verify). If a package has a test script but no test files ("No test files found"), create a minimal test file per **`docs/internal-logic-validation.md`** §3.1, then re-run verification. |
 | **PR** | Agent | Push branch, open PR with template filled; CI runs automatically. |
 | **Merge** | Human or automation | Merge when CI passes (and optional review). |
 | **Deploy** | GitHub Actions | Docs deploy on push to `main`; package release via changesets (see below). |

--- a/docs/internal-logic-validation.md
+++ b/docs/internal-logic-validation.md
@@ -131,6 +131,14 @@
   루트 또는 워크스페이스에서 `pnpm -r test:run` (각 패키지 script에 `test:run`이 있을 때).  
   필요하면 `docs/internal-logic-validation.md` 순서를 CI 스크립트나 체크리스트에 반영한다.
 
+### 3.1 패키지에 테스트 파일이 없을 때
+
+패키지에 `test` 또는 `test:run` 스크립트가 있는데 **테스트 파일이 없어** vitest가 "No test files found"로 종료하는 경우, 에이전트는 **해당 패키지에 최소 한 개의 테스트 파일을 생성**한 뒤 `test:run`을 다시 실행한다.
+
+- **위치**: 해당 패키지의 `test/` 또는 `tests/` 디렉터리 (기존 패키지 규칙 따름). 예: `packages/dom-observer/test/mutation-observer-manager.test.ts`.
+- **내용**: 패키지 진입점 또는 핵심 모듈을 import하고, 동작이 있음을 검증하는 최소 한 개의 테스트(예: 인스턴스 생성·메서드 호출·반환값 검증). 구체적 사실과 동작 결과만 기술한다.
+- **재실행**: 테스트 파일 추가 후 `pnpm --filter @barocss/<패키지> test:run`을 다시 실행해 통과할 때까지 진행한다.
+
 ---
 
 ## 4. 정리


### PR DESCRIPTION
## 변경 사항
- `docs/internal-logic-validation.md`: §3.1 패키지에 테스트 파일이 없을 때 (No test files found → 최소 테스트 파일 생성 후 test:run 재실행)
- Validation Agent / Test Agent: Output에 No test files 규칙 추가
- `.cursor/AGENTS.md` §7 When something fails: Package has no test files 행 추가
- `docs/github-agent-integration.md`: Implement 단계에 동일 규칙 반영

Made with [Cursor](https://cursor.com)