### PR TITLE
docs(agent): English-only rule and translate agent/docs to English

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -4,81 +4,82 @@ This repo is a **platform for building editors**. When adding or changing a feat
 
 ---
 
-## 시작하기 (코드 없이)
+## Getting started (no code)
 
-우리가 만든 플로우만으로 시작하려면, **아래 순서**만 따라하면 된다.
+To start with the flow only, follow the **steps below** in order.
 
-### 1. 할 일이 하나 있어야 한다 (백로그 = GitHub 이슈)
+### 1. Have one task (backlog = GitHub issue)
 
-- **열린 이슈가 이미 있으면** → 2번으로.
-- **열린 이슈가 없으면** → 먼저 이슈를 하나 만든다.
-  - **에이전트로 진행할 때**: "이번에 해야할을 알려주고 진행해줘"라고 하면, 에이전트가 **규칙**에 따라 새 자료 조사를 시작하고 필요한 것들을 이슈로 남긴 뒤 첫 이슈를 진행한다. (Research Agent → Backlog Agent → 이슈 생성 → 진행.)
-  - **직접 만들 때**: GitHub에서 **New issue** → "Feature (model / extension / E2E)" 또는 "Bug fix" 템플릿 선택 → 제목·본문 채우고 생성.
-  - 또는 에이전트에게: **"Act as Backlog Agent. 이슈 만들어줘: [원하는 기능 한 줄]."** (예: "이슈 만들어줘: insertList 기능 추가")
+- **If there is already an open issue** → go to step 2.
+- **If there is no open issue** → create one first.
+  - **With the agent**: Say "What needs to be done? Proceed." and the agent will run Research Agent → Backlog Agent → create issue(s) → proceed with the first issue.
+  - **Manually**: On GitHub, **New issue** → choose "Feature (model / extension / E2E)" or "Bug fix" template → fill title and body.
+  - Or tell the agent: **"Act as Backlog Agent. Create an issue: [one-line description]."** (e.g. "Create an issue: add insertList")
 
-### 2. 한 문장으로 진행 시키기
+### 2. Proceed with one sentence
 
-에이전트에게 이렇게만 말한다:
+Tell the agent:
 
-- **"이번에 해야할을 알려주고 진행해줘"**  
-  (또는 "할 일 알려주고 진행해줘" / "What needs to be done? Proceed.")
+- **"What needs to be done? Proceed."**  
+  (or "What needs to be done? Proceed." if the user prefers.)
 
-에이전트가 **열린 이슈 중 첫 번째**를 골라서:
+The agent will pick the **first open issue** and:
 
-1. **"이번에 할 일: [이슈 제목] (issue #N)"** 이라고 알려주고  
-2. **Spec → Implementation → Test → E2E → GitHub** 순서로 진행한다.  
-   (이슈가 버그 수정이면 Implementation부터, E2E만 추가면 그에 맞게 진행.)
+1. Report **"Current task: [issue title] (issue #N)"**  
+2. Run **Spec → Implementation → Test → E2E → GitHub** in order.  
+   (For a bug fix, start from Implementation; for E2E-only, run the matching flow.)
 
-코드는 보지 않아도 된다. 에이전트가 스펙·구현·테스트·문서·PR까지 처리한다.
+No need to read code. The agent handles spec, implementation, tests, docs, and PR.
 
-### 3. (선택) 아이디어부터 넣고 싶을 때
+### 3. (Optional) Start from ideas
 
-- **"Act as Research Agent. 다른 에디터 조사해서 우리에 추가할 만한 기능 알려줘."**  
-  → 보고서 + 이슈 초안이 나오면, 그걸 바탕으로 Backlog Agent로 이슈 생성.
-- 그 다음 **"이번에 해야할을 알려주고 진행해줘"** 로 진행.
+- **"Act as Research Agent. Research other editors and suggest features we could add."**  
+  → You get a report + draft issue(s); use Backlog Agent to create issues from the draft.
+- Then say **"What needs to be done? Proceed."**
 
-### 4. 다른 역할만 쓰고 싶을 때
+### 4. Use a single role only
 
-- **내부 로직 검증**: "Act as Validation Agent. 내부 로직 검증해줘." / "내부 로직 검증해줘."  
-  → **`docs/internal-logic-validation.md`** 순서대로 패키지별 `test:run` 실행, 실패 시 수정 또는 보고. 기능 추가 전에 내부 로직을 단단히 할 때 사용.
-- **README 정리**: "Act as README Agent. README 업데이트해줘." / "패키지 README 맞춰줘."
-- **문서 사이트만**: "Act as Docs Agent. docs만 업데이트해줘."
-- **PR 리뷰**: "Act as Review Agent. 이 PR 리뷰해줘."
-- **릴리스**: "Act as Release Agent. 릴리스 해줘."
-- **의존성/보안**: "Act as Security Agent. 의존성 업데이트해줘." / "보안 점검해줘."
-- **리팩터만**: "Act as Refactor Agent. [패키지명] 패키지 리팩터해줘."
+- **Internal logic validation**: "Act as Validation Agent. Validate internal logic."  
+  → Follow **`docs/internal-logic-validation.md`**: run `test:run` per package in order; fix or report on failure. Use before adding features.
+- **README**: "Act as README Agent. Update README." / "Align package READMEs."
+- **Docs site only**: "Act as Docs Agent. Update docs only."
+- **PR review**: "Act as Review Agent. Review this PR."
+- **Release**: "Act as Release Agent. Release."
+- **Dependencies / security**: "Act as Security Agent. Update dependencies." / "Security audit."
+- **Refactor only**: "Act as Refactor Agent. Refactor [package name]."
 
-역할 전체 목록과 호출 방법: 아래 "Agent roles (sub-agents)" 섹션과 **`docs/agent-roles-and-orchestration.md`**. 여러 sub-agent 분리·병렬 vs 직렬: **`docs/agent-roles-and-orchestration.md`** §3.1.
-
----
-
-## 규칙 (Rules)
-
-- **GitHub에 열린 이슈가 없을 때**: 새 자료 조사를 시작하고, 우리에게 필요한 것들을 이슈로 남긴다. 이슈가 없다고 해서 멈추지 않는다. (Research Agent → Backlog Agent로 이슈 생성 → 생성된 첫 이슈로 진행.)
-- **백로그 = GitHub 이슈**: 로컬 백로그 파일은 사용하지 않는다. 할 일은 항상 열린 이슈에서 가져온다.
-- **한 번에 한 이슈**: "이번에 해야할을 알려주고 진행해줘"에서는 열린 이슈 중 하나(첫 번째 또는 `next` 라벨)만 골라 전체 플로우(Spec → Implementation → … → PR)를 진행한다.
-- **화면(채팅) 토큰 최소화**: 에이전트는 채팅에 긴 설명을 쓰지 않는다. 꼭 필요한 내용은 **이슈 본문, 커밋 메시지, PR 설명/코멘트, docs, docs/specs, apps/docs-site**에 남긴다. 응답은 한두 문장·불릿 수준으로 끝낸다.
+Full role list and invocation: see "Agent roles (sub-agents)" below and **`docs/agent-roles-and-orchestration.md`**. For splitting/parallel vs serial: **`docs/agent-roles-and-orchestration.md`** §3.1.
 
 ---
 
-## Single command: "이번에 해야할을 알려주고 진행해줘"
+## Rules
 
-When the user says **"이번에 해야할을 알려주고 진행해줘"** (or "What needs to be done? Proceed." / "할 일 알려주고 진행해줘"), do the following in order.
+- **English only**: All agent output (commit messages, PR/issue titles and body, comments, documentation, chat replies) must be in **English**. Do not use Korean or other languages unless the user explicitly requests it.
+- **No open issues**: When there are no open GitHub issues, do not stop. Run Research Agent (gather ideas, suggest features), then Backlog Agent to create issue(s); proceed with the first created issue.
+- **Backlog = GitHub issues**: Do not use local backlog files. Work always comes from open issues.
+- **One issue at a time**: For "What needs to be done? Proceed.", pick a single open issue (first or labeled `next`) and run the full flow (Spec → Implementation → … → PR).
+- **Minimize chat tokens**: Keep chat replies short (one or two sentences or bullets). Put detail in **issue body, commit message, PR description/comments, docs, docs/specs, apps/docs-site**.
+
+---
+
+## Single command: "What needs to be done? Proceed."
+
+When the user says **"What needs to be done? Proceed."** (or equivalent), do the following in order.
 
 ### 1. Determine "what needs to be done"
 
 **Backlog = GitHub issues.** Use open issues as the backlog.
 
 1. **List open issues**: `gh issue list --state open --limit 10`. Pick the **first open issue** (or one labeled `next` if you use that). The issue title + body is the task.
-2. **Nothing found (열린 이슈 없음)**: 이슈가 없으면 **멈추지 말고** 아래를 수행한다.
-   - **Research Agent**: 다른 에디터·자료를 조사하고, 우리 에디터에 추가하면 좋을 기능·개선을 제안한다. 보고서 + **이슈 초안**(제목·본문)을 출력한다. (예: ProseMirror / Slate / Lexical / TipTap 등 리스트·블록·입력 처리 비교, 우리에 넣을 만한 항목 추천.)
-   - **Backlog Agent**: Research Agent가 낸 이슈 초안을 바탕으로 GitHub에 **이슈를 생성**한다. (`gh issue create` 또는 웹으로 생성.) 생성된 이슈 중 **첫 번째**를 이번 할 일로 선택한다.
-   - **이후**: step 2(Report)로 가서 "이번에 할 일: [첫 번째 이슈 제목] (issue #N)"라고 알린 뒤 step 3(Proceed)로 진행한다.
-   - **`gh`를 쓸 수 없을 때**: Research Agent만 실행하고, 이슈 초안(제목·본문)을 사용자에게 보여준 뒤 "위 초안으로 GitHub에서 New issue를 만들어 주시면, 다음에 '이번에 해야할을 알려주고 진행해줘'로 진행할 수 있습니다."라고 안내한다.
+2. **Nothing found (no open issues)**: Do **not** stop. Run:
+   - **Research Agent**: Research other editors and materials; suggest features or improvements for our editor. Output a report + **draft issue(s)** (title + body). (e.g. compare ProseMirror / Slate / Lexical / TipTap list/block/input handling; recommend items to add.)
+   - **Backlog Agent**: Create GitHub issue(s) from the Research draft (`gh issue create` or web). Pick the **first** created issue as the current task.
+   - **Then**: Go to step 2 (Report), say "Current task: [first issue title] (issue #N)", then step 3 (Proceed).
+   - **When `gh` is not available**: Run Research Agent only; show the user the draft issue(s) and say: "Create a New issue on GitHub from the draft above, then run 'What needs to be done? Proceed.' again."
 
 ### 2. Report
 
-Reply with one short line: **"이번에 할 일: [issue title] (issue #N)"** (e.g. "이번에 할 일: Add insertList (issue #5)"). Then continue to step 3.
+Reply with one short line: **"Current task: [issue title] (issue #N)"** (e.g. "Current task: Add insertList (issue #5)"). Then continue to step 3.
 
 ### 3. Proceed
 
@@ -97,7 +98,7 @@ Run the **full flow** for that task, in role order:
 - **E2E Agent**: Run `pnpm test:e2e:react` (or `pnpm test:e2e`); add/update E2E spec if needed; report pass/fail.
 - **GitHub Agent**: Open PR with template, link issue. Do not edit spec or code.
 
-If the user only said "이번에 해야할을 알려주고 진행해줘" with no other context, use the **first open issue** and run the full flow. After each role, continue to the next role without asking unless a handback is needed (e.g. tests fail → fix or report). When the PR is merged, the issue is closed (e.g. "Closes #N"); no separate backlog file to update.
+If the user only said "What needs to be done? Proceed." with no other context, use the **first open issue** and run the full flow. After each role, continue to the next role without asking unless a handback is needed (e.g. tests fail → fix or report). When the PR is merged, the issue is closed (e.g. "Closes #N"); no separate backlog file to update.
 
 ---
 
@@ -119,10 +120,10 @@ Work can be split by **role** so that different agents (or the same agent acting
 | **Release** | Package release (changeset, version, publish) | User request or post-merge | Version PR or npm publish |
 | **Security** | Dependency / security | User request or schedule | Audit report, dependency update PR |
 | **Refactor** | Refactoring only (no new features) | User request or scope | Refactored code; Test Agent must pass after |
-| **Validation** | Internal logic validation (package tests in order) | User request or "내부 로직 검증해줘" | Per-package test:run in order; pass/fail report; fix or escalate |
+| **Validation** | Internal logic validation (package tests in order) | User request or "Validate internal logic" | Per-package test:run in order; pass/fail report; fix or escalate |
 | **README** | README only (root + packages/*/README.md) | User request or new package/feature | Updated root README.md, updated packages/*/README.md |
 
-**How to invoke by role**: Say “Act as **Spec Agent** …” (e.g. "이슈 만들어줘", "백로그 정리해줘" for Backlog; "다른 에디터 조사해서 추가할 만한 기능 알려줘" for Research), or Implementation / Test / E2E / GitHub Agent) and give the input (e.g. “For issue #123, implement per the checklist”). Each role only does its scope; handoff is defined in the doc above. **Role files**: **`.cursor/roles/`** — `BACKLOG_AGENT.md`, `RESEARCH_AGENT.md`, `SPEC_AGENT.md`, `IMPLEMENTATION_AGENT.md`, `TEST_AGENT.md`, `E2E_AGENT.md`, `GITHUB_AGENT.md`, `DOCS_AGENT.md`, `REVIEW_AGENT.md`, `RELEASE_AGENT.md`, `SECURITY_AGENT.md`, `REFACTOR_AGENT.md`, `VALIDATION_AGENT.md`, `README_AGENT.md` (short scope per role; @-mention when invoking). For **automation**, use triggers (e.g. issue labels `spec-ready`, `ready-for-test`, `unit-pass`, `e2e-pass`) as the contract; see `docs/agent-roles-and-orchestration.md` §4.2.
+**How to invoke by role**: Say “Act as **Spec Agent** …” (e.g. "Create an issue", "Triage backlog" for Backlog; "Research other editors and suggest features" for Research), or Implementation / Test / E2E / GitHub Agent) and give the input (e.g. “For issue #123, implement per the checklist”). Each role only does its scope; handoff is defined in the doc above. **Role files**: **`.cursor/roles/`** — `BACKLOG_AGENT.md`, `RESEARCH_AGENT.md`, `SPEC_AGENT.md`, `IMPLEMENTATION_AGENT.md`, `TEST_AGENT.md`, `E2E_AGENT.md`, `GITHUB_AGENT.md`, `DOCS_AGENT.md`, `REVIEW_AGENT.md`, `RELEASE_AGENT.md`, `SECURITY_AGENT.md`, `REFACTOR_AGENT.md`, `VALIDATION_AGENT.md`, `README_AGENT.md` (short scope per role; @-mention when invoking). For **automation**, use triggers (e.g. issue labels `spec-ready`, `ready-for-test`, `unit-pass`, `e2e-pass`) as the contract; see `docs/agent-roles-and-orchestration.md` §4.2.
 
 ---
 
@@ -139,8 +140,8 @@ Details on layers, patterns, and verification are in **`docs/platform-for-agent.
 
 ## Where to do what
 
-- **Internal logic validation (패키지별 검증 순서·테스트)**: **`docs/internal-logic-validation.md`**  
-  - 패키지별 검증 순서(shared → schema → … → devtool), 각 패키지에서 검증할 내부 로직, 테스트 실행 방법. "내부 로직 검증해줘" / "Act as Validation Agent" 시 이 문서를 따른다.
+- **Internal logic validation (per-package order and tests)**: **`docs/internal-logic-validation.md`**  
+  - Validation order (shared → schema → … → devtool), what to validate per package, how to run tests. Follow this doc when "Validate internal logic" / "Act as Validation Agent".
 - **Package / app / flow skills**: **`.cursor/skills/README.md`**  
   - Which skill to use per package, cross-cutting flows (e.g. adding operations, selection), and app roles (editor-test, editor-react) in a table.
 - **Adding an operation**: **`.cursor/skills/model-operation-creation/SKILL.md`**  
@@ -167,7 +168,7 @@ When you ask the agent to change this repo, phrase the request so the agent know
 | Add **only E2E** for existing behavior | “Add an E2E test in editor-react for toggleBold: select text, press Mod+b, assert bold.” | Add or extend `apps/editor-react/tests/*.spec.ts`, run `pnpm test:e2e:react`. |
 | **Fix or change** one layer | “In insertParagraph, ensure selectionAfter.nodeId is always a text node.” | Edit the relevant package (e.g. model), run that package’s tests and, if needed, E2E. |
 | **Verify** after changes | “Run unit tests for model and extensions and then E2E for React.” | Run `pnpm --filter @barocss/model test:run`, `pnpm --filter @barocss/extensions test:run`, then `pnpm test:e2e:react`. |
-| **Internal logic validation** (패키지별 검증) | "내부 로직 검증해줘." / "Act as Validation Agent. 내부 로직 검증해줘." | Follow **`docs/internal-logic-validation.md`**: run `pnpm --filter @barocss/<package> test:run` in the documented order (shared → schema → … → devtool); report pass/fail; fix or escalate. |
+| **Internal logic validation** (per-package) | "Validate internal logic." / "Act as Validation Agent. Validate internal logic." | Follow **`docs/internal-logic-validation.md`**: run `pnpm --filter @barocss/<package> test:run` in the documented order (shared → schema → … → devtool); report pass/fail; fix or escalate. |
 
 ### What to include in a command
 

--- a/.cursor/backlog.md
+++ b/.cursor/backlog.md
@@ -1,9 +1,9 @@
 # Backlog = GitHub issues
 
-할 일(백로그)은 **GitHub 이슈**로 관리합니다.
+Tasks (backlog) are managed as **GitHub issues**.
 
-- "이번에 해야할을 알려주고 진행해줘"라고 하면 에이전트가 **열린 이슈** 중 첫 번째(또는 `next` 라벨)를 골라 진행합니다.
-- 새 할 일: GitHub에서 **New issue** → Feature / Bug fix / E2E 템플릿 선택 후 작성.
-- 완료: PR에서 "Closes #N"으로 머지하면 이슈가 자동으로 닫힙니다.
+- Say "What needs to be done? Proceed." and the agent picks the **first open issue** (or one labeled `next`) and proceeds.
+- New task: On GitHub, **New issue** → choose Feature / Bug fix / E2E template and fill it.
+- Done: When a PR is merged with "Closes #N", the issue is closed automatically.
 
-자세한 절차: **`.cursor/AGENTS.md`** § "Single command: 이번에 해야할을 알려주고 진행해줘".
+Full procedure: **`.cursor/AGENTS.md`** § "Single command: What needs to be done? Proceed.".

--- a/.cursor/roles/BACKLOG_AGENT.md
+++ b/.cursor/roles/BACKLOG_AGENT.md
@@ -2,7 +2,7 @@
 
 **Role**: GitHub issue lifecycle as backlog — create, label, order, triage. Do not implement or write spec/code.
 
-**Input**: User request (e.g. "이슈 만들어줘: insertList 기능", "백로그 정리해줘", "다음에 할 이슈에 next 라벨 달아줘", "열린 이슈 목록 보여줘"). Optionally: Research Agent report (draft issue bodies) to turn into issues.
+**Input**: User request (e.g. "Create an issue: add insertList", "Triage backlog", "Add next label to the issue to do next", "List open issues"). Optionally: Research Agent report (draft issue bodies) to turn into issues.
 
 **Output**:
 - New issues from `.github/ISSUE_TEMPLATE/` (feature / bug_fix / e2e_test). Fill title and body from user or Research draft.

--- a/.cursor/roles/DOCS_AGENT.md
+++ b/.cursor/roles/DOCS_AGENT.md
@@ -2,7 +2,7 @@
 
 **Role**: Documentation only — update `apps/docs-site` (api, architecture, guides, examples) when spec or code changed. Do not implement or write spec/code.
 
-**Input**: User request (e.g. "docs만 업데이트해줘", "api/model-operations 문서 맞춰줘"). Or spec/code change (sync docs-site to match).
+**Input**: User request (e.g. "Update docs only", "Align api/model-operations docs"). Or spec/code change (sync docs-site to match).
 
 **Output**: Add or update `apps/docs-site/docs/` (api/model-operations, architecture/model, guides, examples) and `sidebars.ts` per `docs/docs-site-integration.md`. Build with `pnpm --filter @barocss/docs-site build` to verify.
 

--- a/.cursor/roles/README_AGENT.md
+++ b/.cursor/roles/README_AGENT.md
@@ -2,7 +2,7 @@
 
 **Role**: README documentation only — root **README.md** and per-package **packages/*/README.md**. Important for open source: first impression, package discovery, usage. Does not implement or change spec/code; does not touch apps/docs-site (that is Docs Agent).
 
-**Input**: User request (e.g. "README 업데이트해줘", "패키지 README 맞춰줘", "루트 README에 새 패키지 추가해줘"). Or new package/feature (sync root README packages list and package README to match current API/usage).
+**Input**: User request (e.g. "Update README", "Align package READMEs", "Add new package to root README"). Or new package/feature (sync root README packages list and package README to match current API/usage).
 
 **Output**:
 - **Root README.md**: Project overview, features, packages list (with links to packages/*/README.md), quick start, contribution/development, links to docs. Keep in sync with actual packages and apps.

--- a/.cursor/roles/REFACTOR_AGENT.md
+++ b/.cursor/roles/REFACTOR_AGENT.md
@@ -2,7 +2,7 @@
 
 **Role**: Refactoring only — improve structure, naming, patterns without changing behavior. No new features. Test Agent must pass after.
 
-**Input**: User request (e.g. "이 패키지 리팩터해줘", "model 패키지 네이밍 정리해줘") or scope (e.g. `packages/model`).
+**Input**: User request (e.g. "Refactor this package", "Clean up naming in model package") or scope (e.g. `packages/model`).
 
 **Output**: Refactored code (same behavior, improved structure/naming/patterns). Run `pnpm --filter @barocss/<package> test:run` after; if fail, fix or hand back. Do not add new features or change spec.
 

--- a/.cursor/roles/RELEASE_AGENT.md
+++ b/.cursor/roles/RELEASE_AGENT.md
@@ -2,7 +2,7 @@
 
 **Role**: Package release — changeset add, version-packages, publish (npm). Separate from GitHub Agent (merge/deploy docs).
 
-**Input**: User request (e.g. "릴리스 해줘", "버전 올리고 publish 해줘") or trigger after merge to `main`.
+**Input**: User request (e.g. "Release", "Bump version and publish") or trigger after merge to `main`.
 
 **Output**: Run `pnpm changeset` (or add changeset file); run `pnpm version-packages` (commit and push or open "Version packages" PR); run `pnpm release` when ready to publish to npm. Requires npm token in environment.
 

--- a/.cursor/roles/RESEARCH_AGENT.md
+++ b/.cursor/roles/RESEARCH_AGENT.md
@@ -2,11 +2,11 @@
 
 **Role**: Research other editors and suggest new features to add. Do not implement or write code.
 
-**Input**: User request (e.g. "다른 에디터 조사해서 우리에 추가할 만한 기능 알려줘", "list 편집 기능 다른 에디터에서 어떻게 하는지 조사해줘", "ProseMirror / Slate / Lexical / TipTap 중 리스트 기능 비교해줘").
+**Input**: User request (e.g. "Research other editors and suggest features we could add", "Research how other editors handle list editing", "Compare list features in ProseMirror / Slate / Lexical / TipTap").
 
 **Output**:
 - Report (markdown or comment): editors reviewed, features found, recommendation (what to add, priority, brief rationale). Optionally: draft issue title + body for each suggestion so Backlog Agent or user can create issues.
-- Do not create issues directly unless user asks (e.g. "조사해서 이슈까지 만들어줘" → then coordinate with Backlog Agent or create via `gh issue create`).
+- Do not create issues directly unless user asks (e.g. "Research and create issues" → then coordinate with Backlog Agent or create via `gh issue create`).
 
 **Do not**: Implement, write spec/code, or run tests.
 

--- a/.cursor/roles/SECURITY_AGENT.md
+++ b/.cursor/roles/SECURITY_AGENT.md
@@ -2,7 +2,7 @@
 
 **Role**: Dependency and security — audit, suggest or apply updates. Do not implement features.
 
-**Input**: User request (e.g. "의존성 업데이트해줘", "보안 점검해줘") or schedule (e.g. weekly).
+**Input**: User request (e.g. "Update dependencies", "Security audit") or schedule (e.g. weekly).
 
 **Output**: Run `pnpm audit`; report vulnerabilities and suggest fixes. Run `pnpm update` or update specific packages; run tests; open PR with dependency bumps if requested. Do not change application code beyond dependency versions.
 

--- a/.cursor/roles/VALIDATION_AGENT.md
+++ b/.cursor/roles/VALIDATION_AGENT.md
@@ -2,7 +2,7 @@
 
 **Role**: Internal logic validation — run package tests in dependency order. Use **`docs/internal-logic-validation.md`** as the single source. Do not add features or change spec; only run tests and fix or report failures.
 
-**Input**: User request (e.g. "내부 로직 검증해줘", "Act as Validation Agent. 내부 로직 검증해줘", "패키지별 테스트 순서대로 돌려줘").
+**Input**: User request (e.g. "Validate internal logic", "Act as Validation Agent. Validate internal logic", "Run package tests in order").
 
 **Output**:
 - For each package in the order in **`docs/internal-logic-validation.md`**, run `pnpm --filter @barocss/<package> test:run`. Report pass/fail per package. If fail: fix code or test in that package and re-run; or escalate.

--- a/.cursor/skills/README.md
+++ b/.cursor/skills/README.md
@@ -41,6 +41,6 @@ These skills apply to the apps in `apps/` that run and test the editor in the br
 | Skill directory | App | Purpose |
 |-----------------|-----|---------|
 | `app-editor-test` | apps/editor-test | Full editor (DOM view), Playwright E2E, bootstrap, Devtool; `pnpm test:e2e` |
-| `app-editor-react` | apps/editor-react | React editor, Playwright E2E로 datastore→model→operation→extension→editor-view 기능 검증; `pnpm test:e2e:react` |
+| `app-editor-react` | apps/editor-react | React editor, Playwright E2E validates datastore→model→operation→extension→editor-view; `pnpm test:e2e:react` |
 | `app-editor-decorator-test` | apps/editor-decorator-test | Decorator system (layer/inline/block, pattern, defineDecorator) |
 | `app-docs-site` | apps/docs-site | Docusaurus docs, embedded editor demo (initEditorDemo) |

--- a/.cursor/skills/app-editor-decorator-test/SKILL.md
+++ b/.cursor/skills/app-editor-decorator-test/SKILL.md
@@ -9,7 +9,7 @@ description: Decorator-focused test app (layer, inline, block, pattern decorator
 
 - **Purpose**: Test the EditorViewDOM decorator system in isolation. Schema includes `decorators` (comment, highlight, linkDecorator, status) with dataSchema and render position. No Playwright; dev/preview only.
 - **Entry**: `src/main.ts` → `bootstrap()`: createSchema (with decorators), DataStore, Editor, extensions, define/defineMark/defineDecorator, EditorViewDOM, then `addDecorators()` to attach target, pattern, and custom-generator decorators.
-- **Decorator types**: (1) **Target decorators**: fixed target (node or range), e.g. comment, highlight, linkDecorator, status; (2) **Pattern decorators**: URL, email, color-chip with pattern + createDecorator; (3) **Custom generator**: function that returns decorators from model/text (e.g. "테스트" → chip); (4) **Inline before/after**: chip before "Hello", chip after "World" on text-14.
+- **Decorator types**: (1) **Target decorators**: fixed target (node or range), e.g. comment, highlight, linkDecorator, status; (2) **Pattern decorators**: URL, email, color-chip with pattern + createDecorator; (3) **Custom generator**: function that returns decorators from model/text (e.g. "test" → chip); (4) **Inline before/after**: chip before "Hello", chip after "World" on text-14.
 - **Templates**: `defineDecorator(name, template)` for comment, comment-tooltip, comment-popup, highlight, linkDecorator, status, url-link, email-link, color-chip, chip. Portal usage in `portal-test` node (define with portal(document.body, ...)).
 - **Sample data**: `src/decorator-samples.ts` exports sample decorator data (comments, highlights, etc.); main.ts uses its own `addDecorators()` list rather than importing decorator-samples for the live UI.
 

--- a/.cursor/skills/model-operation-creation/SKILL.md
+++ b/.cursor/skills/model-operation-creation/SKILL.md
@@ -5,52 +5,52 @@ description: Add a new model operation with DSL and exec tests. Use when creatin
 
 # Model Operation Creation
 
-새 operation을 추가할 때 **operation 구현**, **DSL**, **exec 테스트**를 한 세트로 만들고, 테스트를 실행해 검증한다.
+When adding a new operation, implement **operation**, **DSL**, and **exec test** as one set, then run tests to verify.
 
 ## Workflow
 
-1. **Operation** — `packages/model/src/operations/<name>.ts` 에 `defineOperation` 으로 구현.
-2. **DSL** — `packages/model/src/operations-dsl/<name>.ts` 에 `defineOperationDSL` 로 descriptor 빌더.
-3. **등록** — `register-operations.ts` 에 import 추가, `operations-dsl/index.ts` 에 export 추가.
-4. **테스트** — `packages/model/test/operations/<name>.exec.test.ts` 에서 DSL로 descriptor 만들고 `globalOperationRegistry.get('<name>').execute(...)` 로 실행 검증.
-5. **실행** — `pnpm --filter @barocss/model test -- test/operations/<name>.exec.test.ts`
+1. **Operation** — Implement in `packages/model/src/operations/<name>.ts` with `defineOperation`.
+2. **DSL** — Add descriptor builder in `packages/model/src/operations-dsl/<name>.ts` with `defineOperationDSL`.
+3. **Registration** — Add import in `register-operations.ts`, export in `operations-dsl/index.ts`.
+4. **Test** — In `packages/model/test/operations/<name>.exec.test.ts`, build descriptor via DSL and verify with `globalOperationRegistry.get('<name>').execute(...)`.
+5. **Run** — `pnpm --filter @barocss/model test -- test/operations/<name>.exec.test.ts`
 
 ## File locations
 
-| 역할 | 경로 |
+| Role | Path |
 |------|------|
-| Operation 구현 | `packages/model/src/operations/<opName>.ts` |
+| Operation | `packages/model/src/operations/<opName>.ts` |
 | DSL | `packages/model/src/operations-dsl/<opName>.ts` |
-| 등록 | `packages/model/src/operations/register-operations.ts` (import 한 줄) |
-| DSL export | `packages/model/src/operations-dsl/index.ts` (export 한 줄) |
-| Exec 테스트 | `packages/model/test/operations/<opName>.exec.test.ts` |
+| Registration | `packages/model/src/operations/register-operations.ts` (one import line) |
+| DSL export | `packages/model/src/operations-dsl/index.ts` (one export line) |
+| Exec test | `packages/model/test/operations/<opName>.exec.test.ts` |
 
-## Operation 구현 (defineOperation)
+## Operation (defineOperation)
 
-- **반환 타입**: `void` 또는 `{ ok?, data?, inverse?, selectionAfter? }`. `define-operation.ts` 의 `OperationResult` 타입에 맞춘다.
-- **selectionAfter**: 캐럿을 옮길 때 반환. `nodeId` 는 **반드시 text node**(inline-text) id. block은 offset을 가지지 않으므로 block id를 주면 안 된다. 새 블록만 만드는 경우, 블록 안에 빈 inline-text 노드를 하나 넣고 그 id를 `selectionAfter.nodeId` 로 쓴다.
-- **$alias**: 새로 만든 노드 id를 나중에 참조할 때 datastore `attributes.$alias` 에 문자열을 넣으면, transaction 쪽에서 `resolveAlias(alias)` 로 실제 id를 얻는다. `selectionAfter.nodeId` 에 alias를 넣어도 transaction이 resolve 후 `setCaret` 한다.
-- **context**: `TransactionContext` — `dataStore`, `schema`, `selection`(current/before), `lastCreatedBlock` 등. selection 기반 오퍼레이션은 `context.selection.current` 로 위치를 해석한다.
-- **inverse**: 되돌리기용 operation descriptor `{ type, payload }` 를 반환하면 transaction이 기록한다.
+- **Return type**: `void` or `{ ok?, data?, inverse?, selectionAfter? }`. Must match `OperationResult` in `define-operation.ts`.
+- **selectionAfter**: Return when moving the caret. `nodeId` must be a **text node** (inline-text) id. Do not use a block id (blocks have no offset). When creating only a new block, add one empty inline-text node inside and use its id for `selectionAfter.nodeId`.
+- **$alias**: Put a string in datastore `attributes.$alias` for a newly created node to reference it later; the transaction uses `resolveAlias(alias)` to get the real id. You can put an alias in `selectionAfter.nodeId`; the transaction resolves it then calls `setCaret`.
+- **context**: `TransactionContext` — `dataStore`, `schema`, `selection` (current/before), `lastCreatedBlock`, etc. Selection-based operations interpret position via `context.selection.current`.
+- **inverse**: Return undo operation descriptor `{ type, payload }` and the transaction records it.
 
-## DSL 구현 (defineOperationDSL)
+## DSL (defineOperationDSL)
 
-- **형태**: `defineOperationDSL((...args) => ({ type: '<opName>', payload: { ... } }), { atom?, category? })`.
-- **payload**: operation의 `execute(operation, context)` 에서 쓰는 `operation.payload` 와 동일한 형태. optional 인자는 DSL 인자로만 받고, 있을 때만 payload에 넣는다 (예: `...(x != null && { x })`).
-- **타입**: `Operation` 인터페이스로 `type`과 `payload` 타입을 export 해두면 테스트/호출부에서 재사용 가능.
+- **Shape**: `defineOperationDSL((...args) => ({ type: '<opName>', payload: { ... } }), { atom?, category? })`.
+- **payload**: Same shape as `operation.payload` used in `execute(operation, context)`. Optional args are only in DSL; add to payload when present (e.g. `...(x != null && { x })`).
+- **Types**: Export `type` and `payload` types via an `Operation` interface for reuse in tests and callers.
 
-## Exec 테스트 패턴
+## Exec test pattern
 
-- **setup**: `beforeEach` 에서 `Schema`, `DataStore`, `SelectionManager`, `createTransactionContext` 로 `context` 생성.
-- **실행**: `globalOperationRegistry.get('<opName>')` 로 정의 조회 후 `op.execute({ type: '<opName>', payload: dsl.payload }, context)` 호출. descriptor는 DSL 함수로 만든 뒤 `.payload` 만 넘겨도 되고, `{ type, payload: dsl.payload }` 로 넘긴다.
-- **검증**: 반환값의 `ok`, `data`, `selectionAfter`, `context.lastCreatedBlock` 등 기대값 단언. selection 기반이면 테스트 전에 `context.selection.setCaret(nodeId, offset)` 으로 캐럿을 세팅.
-- **DSL 단위 테스트**: `expect(dsl()).toEqual({ type: '<opName>', payload: { ... } })` 로 인자별 payload 형태 검증.
+- **setup**: In `beforeEach`, create `context` with `Schema`, `DataStore`, `SelectionManager`, `createTransactionContext`.
+- **run**: Get definition via `globalOperationRegistry.get('<opName>')`, then call `op.execute({ type: '<opName>', payload: dsl.payload }, context)`. Build descriptor with DSL and pass `.payload` only, or pass `{ type, payload: dsl.payload }`.
+- **assert**: Assert expected values on return (`ok`, `data`, `selectionAfter`, `context.lastCreatedBlock`, etc.). For selection-based ops, set caret before test with `context.selection.setCaret(nodeId, offset)`.
+- **DSL unit test**: `expect(dsl()).toEqual({ type: '<opName>', payload: { ... } })` to verify payload shape per args.
 
-## 체크리스트
+## Checklist
 
-- [ ] `operations/<name>.ts` 에 defineOperation, `register-operations.ts` 에 import
-- [ ] `operations-dsl/<name>.ts` 에 defineOperationDSL, `operations-dsl/index.ts` 에 export
-- [ ] `test/operations/<name>.exec.test.ts` 에서 register-operations 로드, context 생성, DSL로 execute 호출 후 결과 단언
-- [ ] selectionAfter를 쓸 경우 `nodeId` 는 text node id (필요하면 빈 inline-text 노드 추가)
-- [ ] `pnpm --filter @barocss/model test -- test/operations/<name>.exec.test.ts` 로 통과 확인
-- [ ] **브라우저 기능 테스트**: extension에서 해당 operation을 쓰는 command가 있으면 `apps/editor-react/tests/` 에 E2E 스펙 추가 후 `pnpm test:e2e:react` 로 통과 확인 (datastore → model → operation → extension → editor-view 전체 경로 검증)
+- [ ] defineOperation in `operations/<name>.ts`, import in `register-operations.ts`
+- [ ] defineOperationDSL in `operations-dsl/<name>.ts`, export in `operations-dsl/index.ts`
+- [ ] In `test/operations/<name>.exec.test.ts`: load register-operations, create context, call execute via DSL, assert result
+- [ ] If using selectionAfter, `nodeId` must be a text node id (add empty inline-text node if needed)
+- [ ] Run `pnpm --filter @barocss/model test -- test/operations/<name>.exec.test.ts` and ensure it passes
+- [ ] **Browser/E2E**: If an extension command uses this operation, add E2E spec in `apps/editor-react/tests/` and run `pnpm test:e2e:react` (validates datastore → model → operation → extension → editor-view)

--- a/docs/agent-roles-and-orchestration.md
+++ b/docs/agent-roles-and-orchestration.md
@@ -4,15 +4,15 @@ This doc defines **role-based sub-agents** so that work can be split and run in 
 
 ---
 
-## 0. Single entry: "이번에 해야할을 알려주고 진행해줘"
+## 0. Single entry: "What needs to be done? Proceed."
 
-When the user says **"이번에 해야할을 알려주고 진행해줘"** (or "What needs to be done? Proceed."), the agent should:
+When the user says **"What needs to be done? Proceed."** (or equivalent), the agent should:
 
-1. **Determine next task**: **Backlog = GitHub issues.** List open issues (`gh issue list --state open`). Pick the first open issue (or one labeled `next`). **If none (열린 이슈 없음)**: do **not** stop. Run **Research Agent** (다른 에디터·자료 조사, 우리에게 필요한 것 제안, 이슈 초안 출력) → **Backlog Agent** (초안을 바탕으로 GitHub 이슈 생성) → pick the **first new issue**, then continue to step 2. If `gh` is not available, run Research Agent only and show draft issue bodies so the user can create issues manually.
-2. **Report**: "이번에 할 일: [issue title] (issue #N)".
+1. **Determine next task**: **Backlog = GitHub issues.** List open issues (`gh issue list --state open`). Pick the first open issue (or one labeled `next`). **If none (no open issues)**: do **not** stop. Run **Research Agent** (research other editors and materials, suggest what we need, output draft issues) → **Backlog Agent** (create GitHub issues from draft) → pick the **first new issue**, then continue to step 2. If `gh` is not available, run Research Agent only and show draft issue bodies so the user can create issues manually.
+2. **Report**: "Current task: [issue title] (issue #N)".
 3. **Proceed**: Run the full flow for that task (Spec → Implementation → Test → E2E → GitHub, or Implementation → Test → E2E → GitHub if the issue already has a checklist). Use the role definitions in this doc (§2). Do not stop between roles unless a handback is needed (e.g. tests fail). When the PR is merged with "Closes #N", the issue is closed automatically.
 
-Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해야할을 알려주고 진행해줘".
+Full procedure is in **`.cursor/AGENTS.md`** § "Single command: What needs to be done? Proceed.".
 
 ---
 
@@ -32,7 +32,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 | **Release** | Package release (changeset, version, publish) | User request or post-merge | Version PR or npm publish | — |
 | **Security** | Dependency / security | User request or schedule | Audit report, dependency update PR | — |
 | **Refactor** | Refactoring only (no new features) | User request or scope | Refactored code; Test Agent must pass after | Test |
-| **Validation** | Internal logic validation (package tests in order) | User request or "내부 로직 검증해줘" | Per-package test:run in order; pass/fail report; fix or escalate | — |
+| **Validation** | Internal logic validation (package tests in order) | User request or "Validate internal logic" | Per-package test:run in order; pass/fail report; fix or escalate | — |
 | **README** | README only (root + packages/*/README.md) | User request or new package/feature | Updated root README.md, updated packages/*/README.md | — |
 
 ---
@@ -137,13 +137,13 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 **Focus**: GitHub issue lifecycle as backlog — create, label, order, triage. Does not implement or write spec/code.
 
 **Input**:
-- User request (e.g. “이슈 만들어줘: insertList 기능”, “백로그 정리해줘”, “다음에 할 이슈에 next 라벨 달아줘”, “열린 이슈 목록 보여줘”).
+- User request (e.g. “Create an issue: add insertList”, “Triage backlog”, “Add next label to the issue to do next”, “List open issues”).
 - Optionally: Research Agent report (draft issue bodies) to turn into issues.
 
 **Output**:
 - **New issues**: Create issues from `.github/ISSUE_TEMPLATE/` (feature / bug_fix / e2e_test). Fill title and body from user or from Research draft.
 - **Labels**: Add or remove labels (e.g. `next`, `backlog`, `priority:high`) to order or triage.
-- **Report**: List open issues with labels (e.g. “Open: #5 next, #6 #7 backlog”). Optionally suggest “다음에 할 일: #5”.
+- **Report**: List open issues with labels (e.g. “Open: #5 next, #6 #7 backlog”). Optionally suggest “Next task: #5”.
 
 **Handoff**: Spec Agent or Implementation Agent consumes issues. Backlog Agent does **not** implement or write spec docs.
 
@@ -156,11 +156,11 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 **Focus**: Research other editors and suggest new features to add. Does not implement or write code.
 
 **Input**:
-- User request (e.g. “다른 에디터 조사해서 우리에 추가할 만한 기능 알려줘”, “list 편집 기능 다른 에디터에서 어떻게 하는지 조사해줘”, “ProseMirror / Slate / Lexical / TipTap 중 리스트 기능 비교해줘”).
+- User request (e.g. “Research other editors and suggest features we could add”, “Research how other editors handle list editing”, “Compare list features in ProseMirror / Slate / Lexical / TipTap”).
 
 **Output**:
 - **Report** (markdown or comment): Editors reviewed, features found, recommendation (what to add, priority, brief rationale). Optionally: draft issue title + body for each suggestion so Backlog Agent or user can create issues.
-- Does **not** create issues directly unless user asks (e.g. “조사해서 이슈까지 만들어줘” → then coordinate with Backlog Agent or create via `gh issue create`).
+- Does **not** create issues directly unless user asks (e.g. “Research and create issues” → then coordinate with Backlog Agent or create via `gh issue create`).
 
 **Handoff**: Report → user (to decide) or Backlog Agent (to create issues from suggestions). Research Agent does **not** implement.
 
@@ -173,7 +173,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 **Focus**: Documentation only — update `apps/docs-site` (api, architecture, guides, examples) when spec or code changed. Does not implement or write spec/code.
 
 **Input**:
-- User request (e.g. “docs만 업데이트해줘”, “api/model-operations 문서 맞춰줘”).
+- User request (e.g. “Update docs only”, “Align api/model-operations docs”).
 - Spec or code change (e.g. new operation added; Docs Agent syncs docs-site to match).
 
 **Output**:
@@ -207,7 +207,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 **Focus**: Package release — changeset add, version-packages, publish (npm). Separate from GitHub Agent (merge/deploy docs).
 
 **Input**:
-- User request (e.g. “릴리스 해줘”, “버전 올리고 publish 해줘”) or trigger after merge to `main`.
+- User request (e.g. “Release”, “Bump version and publish”) or trigger after merge to `main`.
 
 **Output**:
 - **Changeset**: Run `pnpm changeset` (or add changeset file) to describe the change and version bump type.
@@ -225,7 +225,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 **Focus**: Dependency and security — audit, suggest or apply updates. Does not implement features.
 
 **Input**:
-- User request (e.g. “의존성 업데이트해줘”, “보안 점검해줘”) or schedule (e.g. weekly).
+- User request (e.g. “Update dependencies”, “Security audit”) or schedule (e.g. weekly).
 
 **Output**:
 - **Audit**: Run `pnpm audit`; report vulnerabilities and suggest fixes.
@@ -242,7 +242,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 **Focus**: Refactoring only — improve structure, naming, patterns without changing behavior. No new features. Test Agent must pass after.
 
 **Input**:
-- User request (e.g. “이 패키지 리팩터해줘”, “model 패키지 네이밍 정리해줘”) or scope (e.g. `packages/model`).
+- User request (e.g. “Refactor this package”, “Clean up naming in model package”) or scope (e.g. `packages/model`).
 
 **Output**:
 - **Refactored code**: Same behavior, improved structure/naming/patterns. Run `pnpm --filter @barocss/<package> test:run` after; if fail, fix or hand back. Does **not** add new features or change spec.
@@ -258,7 +258,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 **Focus**: README documentation only — root **README.md** and per-package **packages/*/README.md**. Important for open source: first impression, package discovery, usage. Does not implement or change spec/code; does not touch apps/docs-site (that is Docs Agent).
 
 **Input**:
-- User request (e.g. “README 업데이트해줘”, “패키지 README 맞춰줘”, “루트 README에 새 패키지 추가해줘”).
+- User request (e.g. “Update README”, “Align package READMEs”, “Add new package to root README”).
 - New package or feature (sync root README packages list and package README to match current API/usage).
 
 **Output**:
@@ -276,7 +276,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 **Focus**: Internal logic validation — run package tests in dependency order so that each package’s behavior is verified before adding features. Uses **`docs/internal-logic-validation.md`** as the single source of order and scope. Does not add features or change spec; only runs tests and fixes or reports failures.
 
 **Input**:
-- User request (e.g. “내부 로직 검증해줘”, “Act as Validation Agent. 내부 로직 검증해줘”, “패키지별 테스트 순서대로 돌려줘”).
+- User request (e.g. “Validate internal logic”, “Act as Validation Agent. Validate internal logic”, “Run package tests in order”).
 - **`docs/internal-logic-validation.md`**: validation order (shared → schema → … → devtool), per-package scope, and run commands.
 
 **Output**:
@@ -285,7 +285,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: 이번에 해�
 - **Report**: Pass/fail per package. If fail: fix the code or test in that package and re-run; or escalate (e.g. “model tests fail: …”).
 - **No new features**: Validation Agent does **not** implement new behavior or change specs; it only validates existing logic with tests.
 
-**Handoff**: None. When all packages in scope pass, validation is done. If the user asked for “내부 로직 검증 후 기능 추가”, hand off to Spec/Implementation Agent after validation passes.
+**Handoff**: None. When all packages in scope pass, validation is done. If the user asked for “validate then add features”, hand off to Spec/Implementation Agent after validation passes.
 
 **References**: **`docs/internal-logic-validation.md`** (validation order, per-package scope, run commands), `.cursor/AGENTS.md` § Where to do what (Internal logic validation), `docs/testing-verification.md`.
 
@@ -330,20 +330,20 @@ User / Trigger
 
 ---
 
-### 3.1 Orchestrator: parallel vs serial (여러 sub-agent 분리)
+### 3.1 Orchestrator: parallel vs serial (splitting work across sub-agents)
 
-**오케스트레이터**가 여러 sub-agent에게 일을 나눌 때:
+When the **orchestrator** splits work across sub-agents:
 
-| 구간 | 병렬 여부 | 이유 |
-|------|-----------|------|
-| **Research** | ✅ 병렬 OK | 읽기 전용(다른 에디터·자료 조사). N명이 각자 주제 받아 보고서/이슈 초안 출력 → 오케스트레이터가 합쳐서 이슈 3개 등 선정. |
-| **Backlog** | 직렬 권장 | Research 결과를 모은 뒤 이슈 생성. 한 번에 한 Backlog Agent가 이슈 생성. |
-| **Spec** | 이슈당 1명 | 이슈 N개면 Spec N번 호출 가능하지만, 출력이 같은 docs/specs를 건드리면 충돌. 이슈별로 직렬 또는 파일/스코프 나눠서 할당. |
-| **Implementation** | ❌ 직렬 권장 | 동시에 같은 repo/같은 패키지 수정 시 충돌·스타일 불일치. **한 번에 한 이슈(한 브랜치)** 씩 Implementation → Test → E2E → GitHub. |
-| **Test** | 조건부 | 서로 다른 패키지/다른 spec 파일만 담당하면 병렬 가능. 같은 `*.spec.ts`/같은 패키지면 직렬. |
-| **E2E** | 조건부 | 이슈별로 다른 `*.spec.ts` 추가면 병렬 가능. 같은 파일 수정 시 직렬. |
+| Phase | Parallel? | Reason |
+|-------|-----------|--------|
+| **Research** | ✅ Parallel OK | Read-only (other editors, materials). N agents each take a topic and output report/draft issues → orchestrator merges and picks e.g. 3 issues. |
+| **Backlog** | Serial preferred | After Research results are collected, create issues. One Backlog Agent creates issues at a time. |
+| **Spec** | One per issue | N issues can trigger N Spec calls, but touching the same docs/specs causes conflicts. Serial per issue or split by file/scope. |
+| **Implementation** | ❌ Serial preferred | Editing the same repo/package concurrently causes conflicts and style drift. **One issue (one branch)** at a time: Implementation → Test → E2E → GitHub. |
+| **Test** | Conditional | Parallel if different packages/spec files. Serial if same `*.spec.ts` or same package. |
+| **E2E** | Conditional | Parallel if different `*.spec.ts` per issue. Serial if editing the same file. |
 
-**권장 패턴**: 오케스트레이터가 (1) Research 3명 병렬 → 결과 조합 → 이슈 3개 선정 (2) 이슈 1 → Spec → Implementation → Test → E2E → GitHub (3) 이슈 2 동일 (4) 이슈 3 동일. **구현은 이슈당 직렬.** 자료 조사만 병렬로 돌리고, 실제 코드/테스트는 이슈 단위로 한 에이전트씩 순차 진행하면 소스 유지에 유리하다.
+**Recommended pattern**: Orchestrator (1) runs 3 Research agents in parallel → merge results → pick e.g. 3 issues (2) Issue 1 → Spec → Implementation → Test → E2E → GitHub (3) Issue 2 same (4) Issue 3 same. **Implementation is serial per issue.** Run research in parallel; run code/tests one issue per agent in sequence for easier source maintenance.
 
 ---
 
@@ -360,14 +360,14 @@ Invoke by **role name** so the agent behaves as that role only:
 | **Test Agent** | “Act as **Test Agent**. For the current branch: run unit tests for [packages]. If any fail, add or fix tests (or report that Implementation must fix). Do not run E2E or open PR.” |
 | **E2E Agent** | “Act as **E2E Agent**. For the current branch: run E2E (pnpm test:e2e:react). Add or update E2E spec if needed. Report pass/fail. Do not open PR.” |
 | **GitHub Agent** | “Act as **GitHub Agent**. For the current branch (unit + E2E passed): open PR with template, link issue #N. Do not edit spec or code.” |
-| **Backlog Agent** | "Act as **Backlog Agent**. [이슈 만들어줘 / 백로그 정리해줘 / 열린 이슈 목록 보여줘]. Do not implement or write spec." |
-| **Research Agent** | "Act as **Research Agent**. [다른 에디터 조사해서 추가할 만한 기능 알려줘]. Output report; optionally draft issue bodies. Do not implement." |
-| **Docs Agent** | "Act as **Docs Agent**. [docs만 업데이트해줘 / api 문서 맞춰줘]. Update apps/docs-site only; do not implement or change spec/code." |
-| **Review Agent** | "Act as **Review Agent**. [이 PR 리뷰해줘 / 이 브랜치 리뷰해줘]. Check against spec, patterns, tests; output review comment. Do not implement or merge." |
-| **Release Agent** | "Act as **Release Agent**. [릴리스 해줘 / 버전 올리고 publish 해줘]. Run changeset, version-packages, release. Do not implement or merge PR." |
-| **Security Agent** | "Act as **Security Agent**. [의존성 업데이트해줘 / 보안 점검해줘]. Run pnpm audit; suggest or open PR for dependency updates. Do not implement features." |
-| **Refactor Agent** | "Act as **Refactor Agent**. [이 패키지 리팩터해줘 / model 패키지 네이밍 정리해줘]. Improve structure/naming only; no new features. Run tests after. Do not open PR." |
-| **README Agent** | "Act as **README Agent**. [README 업데이트해줘 / 패키지 README 맞춰줘 / 루트 README에 새 패키지 추가해줘]. Update root README.md and packages/*/README.md only; do not implement or touch apps/docs-site." |
+| **Backlog Agent** | "Act as **Backlog Agent**. [Create an issue / Triage backlog / List open issues]. Do not implement or write spec." |
+| **Research Agent** | "Act as **Research Agent**. [Research other editors and suggest features]. Output report; optionally draft issue bodies. Do not implement." |
+| **Docs Agent** | "Act as **Docs Agent**. [Update docs only / Align api docs]. Update apps/docs-site only; do not implement or change spec/code." |
+| **Review Agent** | "Act as **Review Agent**. [Review this PR / Review this branch]. Check against spec, patterns, tests; output review comment. Do not implement or merge." |
+| **Release Agent** | "Act as **Release Agent**. [Release / Bump version and publish]. Run changeset, version-packages, release. Do not implement or merge PR." |
+| **Security Agent** | "Act as **Security Agent**. [Update dependencies / Security audit]. Run pnpm audit; suggest or open PR for dependency updates. Do not implement features." |
+| **Refactor Agent** | "Act as **Refactor Agent**. [Refactor this package / Clean up naming in model package]. Improve structure/naming only; no new features. Run tests after. Do not open PR." |
+| **README Agent** | "Act as **README Agent**. [Update README / Align package READMEs / Add new package to root README]. Update root README.md and packages/*/README.md only; do not implement or touch apps/docs-site." |
 
 The **orchestrator** (human or another agent) can run these in sequence: first Spec, then Implementation, then Test, then E2E, then GitHub. Backlog, Research, Docs, Review, Release, Security, Refactor, README are invoked when the user wants to manage issues, get feature suggestions, update docs only, review PR, release, audit deps, refactor, or update READMEs.
 

--- a/docs/github-agent-integration.md
+++ b/docs/github-agent-integration.md
@@ -49,7 +49,7 @@ When there are **no open GitHub issues**, the agent must not stop. It must:
 2. **Backlog Agent**: Create GitHub issue(s) from those drafts (`gh issue create` or equivalent).
 3. Then treat the **first created (or first open) issue** as the current task and run the full flow (Spec → Implementation → … → PR).
 
-See `.cursor/AGENTS.md` § 규칙 (Rules) and § Single command step 1 "Nothing found".
+See `.cursor/AGENTS.md` § Rules and § Single command step 1 "Nothing found".
 
 ---
 

--- a/docs/internal-logic-validation.md
+++ b/docs/internal-logic-validation.md
@@ -1,149 +1,149 @@
-# 내부 로직 검증 순서 및 테스트 전략
+# Internal Logic Validation Order and Test Strategy
 
-**원칙**: 패키지별로 내부 로직을 단단히 검증한 뒤 기능 추가를 진행한다. 검증은 **테스트 코드를 최대한 활용**한다.
-
----
-
-## 1. 검증 순서 (의존성 하단 → 상단)
-
-아래 패키지는 다른 `@barocss/*` 패키지에 의존하지 않거나, 이미 검증된 패키지에만 의존한다. **이 순서대로** 검증하면, 상위 패키지 검증 시 하위가 이미 안정되어 있다.
-
-| 순서 | 패키지 | 의존(@barocss) | 검증 시점 |
-|------|--------|----------------|-----------|
-| **1** | **shared** | 없음 | 유틸·상수·키 문자열 등 단위 테스트로 검증 |
-| **2** | **schema** | 없음 | 스키마 정의·getNodeType·그룹 검증 |
-| **3** | **text-analyzer** | 없음 | 텍스트 변경 분석·유니코드 분석 테스트 |
-| **4** | **text-run-index** | 없음 | 텍스트 런 인덱스·오프셋 변환 테스트 |
-| **5** | **dsl** | 없음 | DSL 함수·레지스트리·템플릿 빌더 테스트 |
-| **6** | **datastore** | schema, model(타입) | CRUD·트랜잭션·락·오버레이·마크·쿼리 테스트 |
-| **7** | **converter** | datastore | 변환·로드/저장 로직 테스트 |
-| **8** | **dom-observer** | text-analyzer | MutationObserver·변경 분류 테스트 |
-| **9** | **renderer-dom** | dsl, text-run-index | 리콘실·VNode·DOM 매핑·마크 렌더 테스트 |
-| **10** | **renderer-react** | dsl | React 빌드·렌더러 테스트 |
-| **11** | **model** | datastore, editor-core(타입), schema | 트랜잭션·DSL·오퍼레이션 실행 테스트 |
-| **12** | **editor-core** | datastore, model, renderer-dom, shared, schema | 키바인딩·컨텍스트·명령 실행·selectionManager 테스트 |
-| **13** | **extensions** | editor-core, model, converter | 확장 명령·before/after 훅 테스트 |
-| **14** | **editor-view-dom** | dsl, datastore, dom-observer, editor-core, renderer-dom, schema, shared, text-analyzer | 입력·선택·DOM 동기화 테스트 |
-| **15** | **editor-view-react** | dsl, editor-core, renderer-react, shared, text-analyzer, text-run-index | EditorView·selection·input-handler 테스트 (필요 시 추가) |
-| **16** | **collaboration** | datastore | 협업 어댑터·동기화 테스트 |
-| **17** | **devtool** | editor-core, model | 트레이싱·UI 연동 테스트 (선택) |
+**Principle**: Validate each package's internal logic firmly before adding features. Validation **maximizes use of test code**.
 
 ---
 
-## 2. 패키지별 검증 범위 및 테스트 활용
+## 1. Validation order (dependency bottom → top)
 
-각 패키지에서 **어떤 내부 로직을 검증할지**와 **어떤 테스트를 쓸지**를 정리한다. 기존 `vitest` 테스트가 있으면 `pnpm --filter @barocss/<패키지> test:run`으로 실행한다.
+The packages below do not depend on other `@barocss/*` packages, or depend only on already-validated packages. Validating **in this order** keeps lower layers stable when validating upper ones.
 
-### Tier 0 (외부 의존 없음)
+| Order | Package | Deps (@barocss) | What to validate |
+|-------|---------|-----------------|------------------|
+| **1** | **shared** | none | Utils, constants, key strings via unit tests |
+| **2** | **schema** | none | Schema definition, getNodeType, groups |
+| **3** | **text-analyzer** | none | Text change analysis, Unicode analysis tests |
+| **4** | **text-run-index** | none | Text run index, offset conversion tests |
+| **5** | **dsl** | none | DSL functions, registry, template builders |
+| **6** | **datastore** | schema, model(types) | CRUD, transaction, lock, overlay, marks, queries |
+| **7** | **converter** | datastore | Conversion, load/save logic |
+| **8** | **dom-observer** | text-analyzer | MutationObserver, change classification |
+| **9** | **renderer-dom** | dsl, text-run-index | Reconciler, VNode↔DOM mapping, mark render |
+| **10** | **renderer-react** | dsl | React build, renderer behavior |
+| **11** | **model** | datastore, editor-core(types), schema | Transaction, DSL, operation execution |
+| **12** | **editor-core** | datastore, model, renderer-dom, shared, schema | Keybindings, context, command execution, selectionManager |
+| **13** | **extensions** | editor-core, model, converter | Extension commands, before/after hooks |
+| **14** | **editor-view-dom** | dsl, datastore, dom-observer, editor-core, renderer-dom, schema, shared, text-analyzer | Input, selection, DOM sync |
+| **15** | **editor-view-react** | dsl, editor-core, renderer-react, shared, text-analyzer, text-run-index | EditorView, selection, input-handler (add tests as needed) |
+| **16** | **collaboration** | datastore | Collaboration adapter, sync |
+| **17** | **devtool** | editor-core, model | Tracing, UI integration (optional) |
+
+---
+
+## 2. Per-package validation scope and test usage
+
+For each package, **what to validate** and **which tests to use** are described below. If vitest tests exist, run `pnpm --filter @barocss/<package> test:run`.
+
+### Tier 0 (no external deps)
 
 - **shared**  
-  - 검증: 키 문자열·상수·공용 타입·유틸 함수  
-  - 테스트: 단위 테스트로 입력/출력·엣지 케이스 검증  
+  - Validate: key strings, constants, shared types, util functions  
+  - Tests: unit tests for input/output and edge cases  
 
 - **schema**  
-  - 검증: 스키마 등록·getNodeType·group·content 규칙  
-  - 테스트: `packages/schema` 내 vitest 테스트 활용·커버리지 확인  
+  - Validate: schema registration, getNodeType, group, content rules  
+  - Tests: vitest in `packages/schema`, coverage as needed  
 
 - **text-analyzer**  
-  - 검증: `analyzeTextChanges`, 유니코드/조합 문자 처리  
-  - 테스트: `packages/text-analyzer/test/` (smart-text-analyzer, unicode-text-analysis)  
+  - Validate: `analyzeTextChanges`, Unicode/composing-char handling  
+  - Tests: `packages/text-analyzer/test/` (smart-text-analyzer, unicode-text-analysis)  
 
 - **text-run-index**  
-  - 검증: `buildTextRunIndex`, `binarySearchRun`, 오프셋↔DOM 매핑  
-  - 테스트: 해당 패키지에 테스트 추가 후 `test:run`  
+  - Validate: `buildTextRunIndex`, `binarySearchRun`, offset↔DOM mapping  
+  - Tests: add tests in package then `test:run`  
 
 - **dsl**  
-  - 검증: DSL 함수·레지스트리·템플릿 빌더  
-  - 테스트: `packages/dsl/tests/` (dsl-functions 등)  
+  - Validate: DSL functions, registry, template builders  
+  - Tests: `packages/dsl/tests/` (dsl-functions etc.)  
 
-### Tier 1 (datastore / converter / DOM·React 렌더 기초)
+### Tier 1 (datastore / converter / DOM·React render base)
 
 - **datastore**  
-  - 검증: getNode/setNode·트랜잭션·락·오버레이·마크·content 조작·쿼리·방문자  
-  - 테스트: `packages/datastore/test/` 전반 (data-store-*.test.ts, iterator, lock, mark 등) — **기존 테스트 최대 활용**  
+  - Validate: getNode/setNode, transaction, lock, overlay, marks, content ops, queries, visitors  
+  - Tests: `packages/datastore/test/` (data-store-*.test.ts, iterator, lock, mark, etc.) — **reuse existing tests**  
 
 - **converter**  
-  - 검증: 문서↔저장 형식 변환·로드/저장 일관성  
-  - 테스트: `packages/converter` 내 vitest 테스트  
+  - Validate: doc↔storage format conversion, load/save consistency  
+  - Tests: vitest in `packages/converter`  
 
 - **dom-observer**  
-  - 검증: MutationObserver 설정·변경 수집·분류  
-  - 테스트: `packages/dom-observer` vitest  
+  - Validate: MutationObserver setup, change collection, classification  
+  - Tests: vitest in `packages/dom-observer`  
 
 - **renderer-dom**  
-  - 검증: 리콘실·VNode↔DOM·마크/데코레이터·data-bc-sid 부여  
-  - 테스트: `packages/renderer-dom/test/` (reconciler, mark, decorator 등)  
+  - Validate: reconciler, VNode↔DOM, marks/decorators, data-bc-sid assignment  
+  - Tests: `packages/renderer-dom/test/` (reconciler, mark, decorator, etc.)  
 
 - **renderer-react**  
-  - 검증: build→React 노드·렌더러 인스턴스 동작  
-  - 테스트: 필요 시 단위 테스트 추가 후 `test:run`  
+  - Validate: build→React nodes, renderer instance behavior  
+  - Tests: add unit tests as needed then `test:run`  
 
-### Tier 2 (model·editor-core·extensions)
+### Tier 2 (model, editor-core, extensions)
 
 - **model**  
-  - 검증: 트랜잭션 실행·DSL 시퀀스·오퍼레이션별 부작용·selectionContext  
-  - 테스트: `packages/model/test/` — `transaction/`, `operations/*.exec.test.ts`, `operations/*.test.ts` **전부 실행**해 회귀 방지  
+  - Validate: transaction execution, DSL sequence, per-operation side effects, selectionContext  
+  - Tests: `packages/model/test/` — run **all** of `transaction/`, `operations/*.exec.test.ts`, `operations/*.test.ts` to prevent regressions  
 
 - **editor-core**  
-  - 검증: keybindings resolve·context 갱신·executeCommand·selectionManager·updateSelection  
-  - 테스트: `packages/editor-core/test/` (selection-manager, editor, keybinding 등)  
+  - Validate: keybindings resolve, context update, executeCommand, selectionManager, updateSelection  
+  - Tests: `packages/editor-core/test/` (selection-manager, editor, keybinding, etc.)  
 
 - **extensions**  
-  - 검증: 명령 등록·실행·before/after 훅·converter 연동  
-  - 테스트: `packages/extensions/test/`  
+  - Validate: command registration, execution, before/after hooks, converter integration  
+  - Tests: `packages/extensions/test/`  
 
-### Tier 3 (view·협업·도구)
+### Tier 3 (view, collaboration, tools)
 
 - **editor-view-dom**  
-  - 검증: 입력→모델 반영·선택 DOM↔모델 동기화·키다운/beforeinput  
-  - 테스트: `packages/editor-view-dom/test/` (event-handlers, integration, selection 등) — **기존 테스트 최대 활용**  
+  - Validate: input→model, selection DOM↔model sync, keydown/beforeinput  
+  - Tests: `packages/editor-view-dom/test/` (event-handlers, integration, selection, etc.) — **reuse existing tests**  
 
 - **editor-view-react**  
-  - 검증: EditorView 마운트·selectionchange·input-handler·contentEditable 이벤트 연결  
-  - 테스트: 단위 테스트 추가 또는 apps/editor-react E2E와 연계 (E2E는 내부 로직 안정화 후 재활성화)  
+  - Validate: EditorView mount, selectionchange, input-handler, contentEditable event wiring  
+  - Tests: add unit tests or tie to apps/editor-react E2E (re-enable E2E after internal logic is stable)  
 
 - **collaboration**  
-  - 검증: 어댑터·동기화 프로토콜·datastore 연동  
-  - 테스트: collaboration, collaboration-yjs, collaboration-liveblocks 각각 test:run  
+  - Validate: adapter, sync protocol, datastore integration  
+  - Tests: collaboration, collaboration-yjs, collaboration-liveblocks each `test:run`  
 
 - **devtool**  
-  - 검증: 필요 시 트레이싱·이벤트 수집 로직만 단위 테스트 (선택)  
+  - Validate: tracing, event collection logic only when needed (optional)  
 
 ---
 
-## 3. 실행 방법
+## 3. How to run
 
-- **단일 패키지**  
+- **Single package**  
   ```bash
-  pnpm --filter @barocss/<패키지명> test:run
+  pnpm --filter @barocss/<package> test:run
   ```
-  예: `pnpm --filter @barocss/datastore test:run`, `pnpm --filter @barocss/model test:run`
+  Example: `pnpm --filter @barocss/datastore test:run`, `pnpm --filter @barocss/model test:run`
 
-- **순서대로 전체 검증** (Tier 0 → 3)  
+- **Full validation in order** (Tier 0 → 3)  
   ```bash
   pnpm --filter @barocss/shared test:run
   pnpm --filter @barocss/schema test:run
   pnpm --filter @barocss/text-analyzer test:run
-  # … 위 표 순서대로 반복
+  # … repeat in table order above
   ```
 
-- **CI에서 한 번에**  
-  루트 또는 워크스페이스에서 `pnpm -r test:run` (각 패키지 script에 `test:run`이 있을 때).  
-  필요하면 `docs/internal-logic-validation.md` 순서를 CI 스크립트나 체크리스트에 반영한다.
+- **All at once (e.g. CI)**  
+  From repo root or workspace: `pnpm -r test:run` (when each package has a `test:run` script).  
+  Optionally reflect the order in this doc in CI scripts or checklists.
 
-### 3.1 패키지에 테스트 파일이 없을 때
+### 3.1 When a package has no test files
 
-패키지에 `test` 또는 `test:run` 스크립트가 있는데 **테스트 파일이 없어** vitest가 "No test files found"로 종료하는 경우, 에이전트는 **해당 패키지에 최소 한 개의 테스트 파일을 생성**한 뒤 `test:run`을 다시 실행한다.
+When a package has a `test` or `test:run` script but **no test files** and vitest exits with "No test files found", the agent must **create at least one test file** in that package, then re-run `test:run`.
 
-- **위치**: 해당 패키지의 `test/` 또는 `tests/` 디렉터리 (기존 패키지 규칙 따름). 예: `packages/dom-observer/test/mutation-observer-manager.test.ts`.
-- **내용**: 패키지 진입점 또는 핵심 모듈을 import하고, 동작이 있음을 검증하는 최소 한 개의 테스트(예: 인스턴스 생성·메서드 호출·반환값 검증). 구체적 사실과 동작 결과만 기술한다.
-- **재실행**: 테스트 파일 추가 후 `pnpm --filter @barocss/<패키지> test:run`을 다시 실행해 통과할 때까지 진행한다.
+- **Location**: The package's `test/` or `tests/` directory (follow existing package convention). Example: `packages/dom-observer/test/mutation-observer-manager.test.ts`.
+- **Content**: Import the package entry or a core module and add at least one test that verifies behavior (e.g. instance creation, method call, return value). Describe only concrete facts and observed behavior.
+- **Re-run**: After adding the test file, run `pnpm --filter @barocss/<package> test:run` again until it passes.
 
 ---
 
-## 4. 정리
+## 4. Summary
 
-- **내부 로직 검증**: 위 **1→2→…→17 순서**를 지키면, 하위 패키지가 안정된 상태에서 상위를 검증할 수 있다.  
-- **테스트 활용**: 이미 있는 vitest 테스트를 **최대한 활용**하고, 커버리지가 부족한 패키지(예: editor-view-react, text-run-index, renderer-react)에는 **필요한 단위 테스트를 추가**한다.  
-- **기능 추가**: 해당 기능이 건드리는 패키지의 검증(테스트 통과)이 끝난 뒤 진행한다.  
-- **E2E**: 리스트/인용 등 E2E는 view 레이어(keydown·beforeinput 연결 등)가 안정된 뒤 다시 활성화한다.
+- **Internal logic validation**: Following the **1→2→…→17 order** above lets you validate upper packages with lower ones already stable.  
+- **Test usage**: **Reuse** existing vitest tests; add unit tests where coverage is low (e.g. editor-view-react, text-run-index, renderer-react).  
+- **Feature work**: Proceed only after the packages touched by the feature pass validation (tests pass).  
+- **E2E**: Re-enable list/block E2E after the view layer (keydown, beforeinput wiring, etc.) is stable.


### PR DESCRIPTION
## Summary
- Add **English only** rule: all agent output (commit messages, PR/issue body, comments, documentation, chat) must be in English.
- Translate agent entry and docs to English: `.cursor/AGENTS.md`, `backlog.md`, `roles/*.md`, `docs/internal-logic-validation.md`, `docs/agent-roles-and-orchestration.md`, `docs/github-agent-integration.md`, `.cursor/skills/model-operation-creation/SKILL.md` and related.

## Verification
- Docs/agent files only; no code or test changes.

Made with [Cursor](https://cursor.com)