### PR TITLE
test(dom-observer): add minimal smoke test

### DIFF
--- a/packages/dom-observer/test/mutation-observer-manager.test.ts
+++ b/packages/dom-observer/test/mutation-observer-manager.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { MutationObserverManagerImpl } from '../src/mutation-observer-manager';
+
+describe('MutationObserverManagerImpl', () => {
+  it('instantiates and exposes setup/disconnect', () => {
+    const manager = new MutationObserverManagerImpl();
+    expect(manager.setup).toBeDefined();
+    expect(typeof manager.setup).toBe('function');
+    expect(manager.disconnect).toBeDefined();
+    expect(typeof manager.disconnect).toBe('function');
+    expect(manager.handleMutation).toBeDefined();
+    expect(typeof manager.handleMutation).toBe('function');
+  });
+});


### PR DESCRIPTION
Per internal-logic-validation §3.1: package had `test:run` but no test files. Add `test/mutation-observer-manager.test.ts` that imports and asserts `MutationObserverManagerImpl` exposes setup/disconnect/handleMutation.

Made with [Cursor](https://cursor.com)