### PR TITLE
fix(test): dsl - defineMark className expectations, registry.get API

### DIFF
--- a/packages/dsl/src/registry.ts
+++ b/packages/dsl/src/registry.ts
@@ -42,9 +42,18 @@ export class RendererRegistry {
     this._renderers.set(renderer.nodeType, renderer);
   }
   
-  // get() is removed - use getComponent() instead
-  // Everything defined with define() is component-only, so only use getComponent()
-  
+  /**
+   * Get renderer definition by node type.
+   * Returns from _renderers (node/component templates) or _components (external components).
+   */
+  get(nodeType: TNodeType): RendererDefinition | undefined {
+    const def = this._renderers.get(nodeType);
+    if (def) return def;
+    const comp = this.getComponent(nodeType);
+    if (comp) return { type: 'renderer', nodeType, template: comp };
+    return undefined;
+  }
+
   // Get all renderers (deprecated - use getComponent instead)
   getAll(): RendererDefinition[] {
     return Array.from(this._renderers.values());

--- a/packages/dsl/tests/dsl-functions.test.ts
+++ b/packages/dsl/tests/dsl-functions.test.ts
@@ -232,9 +232,9 @@ describe('DSL Functions Tests', () => {
       // Since define() now wraps ElementTemplate as ComponentTemplate, we need to call the component function
       if (definition.template.type === 'component' && typeof definition.template.component === 'function') {
         const elementTemplate = definition.template.component({}, {} as any);
-        expect(elementTemplate.attributes?.className).toBe('mark-bold mark-bold');
+        expect(elementTemplate.attributes?.className).toBe('mark-bold');
       } else {
-        expect(definition.template.attributes?.className).toBe('mark-bold mark-bold');
+        expect(definition.template.attributes?.className).toBe('mark-bold');
       }
     });
 
@@ -250,9 +250,9 @@ describe('DSL Functions Tests', () => {
       // Since define() now wraps ElementTemplate as ComponentTemplate, we need to call the component function
       if (definition.template.type === 'component' && typeof definition.template.component === 'function') {
         const elementTemplate = definition.template.component({}, {} as any);
-        expect(elementTemplate.attributes?.className).toBe('mark-italic mark-italic');
+        expect(elementTemplate.attributes?.className).toBe('mark-italic');
       } else {
-        expect(definition.template.attributes?.className).toBe('mark-italic mark-italic');
+        expect(definition.template.attributes?.className).toBe('mark-italic');
       }
     });
   });


### PR DESCRIPTION
Resolves #11

- registry: add get(nodeType) returning RendererDefinition from _renderers or _components
- dsl-functions.test: expect defineMark className 'mark-bold' / 'mark-italic' (addMarkClassAttribute does not duplicate existing class)

Made with [Cursor](https://cursor.com)