### PR TITLE
fix(test): model transaction/DSL tests — mock editor, stype assertions

### DIFF
--- a/packages/model/test/transaction/dsl-basic-syntax.test.ts
+++ b/packages/model/test/transaction/dsl-basic-syntax.test.ts
@@ -8,7 +8,7 @@ describe('DSL Basic Syntax', () => {
       const result = node('paragraph');
       
       expect(result).toEqual({
-        type: 'paragraph'
+        stype: 'paragraph'
       });
     });
 
@@ -16,7 +16,7 @@ describe('DSL Basic Syntax', () => {
       const result = node('paragraph', { class: 'content' });
       
       expect(result).toEqual({
-        type: 'paragraph',
+        stype: 'paragraph',
         attributes: { class: 'content' }
       });
     });
@@ -28,11 +28,11 @@ describe('DSL Basic Syntax', () => {
       ]);
       
       expect(result).toEqual({
-        type: 'paragraph',
+        stype: 'paragraph',
         attributes: {},
         content: [
-          { type: 'inline-text', text: 'Hello' },
-          { type: 'inline-text', text: 'World' }
+          { stype: 'inline-text', text: 'Hello' },
+          { stype: 'inline-text', text: 'World' }
         ]
       });
     });
@@ -43,10 +43,10 @@ describe('DSL Basic Syntax', () => {
       ]);
       
       expect(result).toEqual({
-        type: 'heading',
+        stype: 'heading',
         attributes: { level: 1 },
         content: [
-          { type: 'inline-text', text: 'Title' }
+          { stype: 'inline-text', text: 'Title' }
         ]
       });
     });
@@ -55,7 +55,7 @@ describe('DSL Basic Syntax', () => {
       const result = node('paragraph', {}, []);
       
       expect(result).toEqual({
-        type: 'paragraph',
+        stype: 'paragraph',
         attributes: {},
         content: []
       });
@@ -67,9 +67,9 @@ describe('DSL Basic Syntax', () => {
       ]);
       
       expect(result).toEqual({
-        type: 'paragraph',
+        stype: 'paragraph',
         content: [
-          { type: 'inline-text', text: 'Text' }
+          { stype: 'inline-text', text: 'Text' }
         ]
       });
     });
@@ -85,18 +85,18 @@ describe('DSL Basic Syntax', () => {
       ]);
       
       expect(result).toEqual({
-        type: 'list',
+        stype: 'list',
         attributes: { type: 'ordered' },
         content: [
           {
-            type: 'listItem',
+            stype: 'listItem',
             attributes: {},
-            content: [{ type: 'inline-text', text: 'First item' }]
+            content: [{ stype: 'inline-text', text: 'First item' }]
           },
           {
-            type: 'listItem',
+            stype: 'listItem',
             attributes: {},
-            content: [{ type: 'inline-text', text: 'Second item' }]
+            content: [{ stype: 'inline-text', text: 'Second item' }]
           }
         ]
       });
@@ -108,7 +108,7 @@ describe('DSL Basic Syntax', () => {
       const result = textNode('inline-text', 'Hello World');
       
       expect(result).toEqual({
-        type: 'inline-text',
+        stype: 'inline-text',
         text: 'Hello World'
       });
     });
@@ -117,7 +117,7 @@ describe('DSL Basic Syntax', () => {
       const result = textNode('inline-text', 'Hello', { class: 'highlight' });
       
       expect(result).toEqual({
-        type: 'inline-text',
+        stype: 'inline-text',
         text: 'Hello',
         attributes: { class: 'highlight' }
       });
@@ -127,9 +127,9 @@ describe('DSL Basic Syntax', () => {
       const result = textNode('inline-text', 'Bold text', [mark('bold')]);
       
       expect(result).toEqual({
-        type: 'inline-text',
+        stype: 'inline-text',
         text: 'Bold text',
-        marks: [{ type: 'bold', attrs: {}, range: undefined }]
+        marks: [{ stype: 'bold', attrs: {}, range: undefined }]
       });
     });
 
@@ -137,10 +137,10 @@ describe('DSL Basic Syntax', () => {
       const result = textNode('inline-text', 'Styled text', [mark('bold')], { class: 'highlight' });
       
       expect(result).toEqual({
-        type: 'inline-text',
+        stype: 'inline-text',
         text: 'Styled text',
         attributes: { class: 'highlight' },
-        marks: [{ type: 'bold', attrs: {}, range: undefined }]
+        marks: [{ stype: 'bold', attrs: {}, range: undefined }]
       });
     });
 
@@ -148,7 +148,7 @@ describe('DSL Basic Syntax', () => {
       const result = textNode('codeBlock', 'const x = 1;', { language: 'javascript' });
       
       expect(result).toEqual({
-        type: 'codeBlock',
+        stype: 'codeBlock',
         text: 'const x = 1;',
         attributes: { language: 'javascript' }
       });
@@ -161,11 +161,11 @@ describe('DSL Basic Syntax', () => {
       ]);
       
       expect(result).toEqual({
-        type: 'inline-text',
+        stype: 'inline-text',
         text: 'Bold and italic',
         marks: [
-          { type: 'bold', attrs: {}, range: undefined },
-          { type: 'italic', attrs: {}, range: undefined }
+          { stype: 'bold', attrs: {}, range: undefined },
+          { stype: 'italic', attrs: {}, range: undefined }
         ]
       });
     });
@@ -313,7 +313,7 @@ describe('DSL Basic Syntax', () => {
         type: 'create',
         payload: {
           node: {
-            type: 'inline-text',
+            stype: 'inline-text',
             text: 'Hello'
           },
           options: undefined
@@ -332,11 +332,11 @@ describe('DSL Basic Syntax', () => {
         type: 'create',
         payload: {
           node: {
-            type: 'paragraph',
+            stype: 'paragraph',
             attributes: { class: 'content' },
             content: [
-              { type: 'inline-text', text: 'Hello' },
-              { type: 'inline-text', text: 'World' }
+              { stype: 'inline-text', text: 'Hello' },
+              { stype: 'inline-text', text: 'World' }
             ]
           },
           options: undefined
@@ -352,7 +352,7 @@ describe('DSL Basic Syntax', () => {
         type: 'create',
         payload: {
           node: {
-            type: 'inline-text',
+            stype: 'inline-text',
             text: 'Hello'
           },
           options: { position: 'after' }
@@ -368,9 +368,9 @@ describe('DSL Basic Syntax', () => {
         type: 'create',
         payload: {
           node: {
-            type: 'inline-text',
+            stype: 'inline-text',
             text: 'Bold text',
-            marks: [{ type: 'bold', attrs: {}, range: undefined }]
+            marks: [{ stype: 'bold', attrs: {}, range: undefined }]
           },
           options: undefined
         }
@@ -392,27 +392,27 @@ describe('DSL Basic Syntax', () => {
       ]);
       
       expect(result).toEqual({
-        type: 'document',
+        stype: 'document',
         attributes: {},
         content: [
           {
-            type: 'heading',
+            stype: 'heading',
             attributes: { level: 1 },
             content: [
-              { type: 'inline-text', text: 'Title' }
+              { stype: 'inline-text', text: 'Title' }
             ]
           },
           {
-            type: 'paragraph',
+            stype: 'paragraph',
             attributes: {},
             content: [
-              { type: 'inline-text', text: 'Content with ' },
+              { stype: 'inline-text', text: 'Content with ' },
               {
-                type: 'inline-text',
+                stype: 'inline-text',
                 text: 'bold',
-                marks: [{ type: 'bold', attrs: {}, range: undefined }]
+                marks: [{ stype: 'bold', attrs: {}, range: undefined }]
               },
-              { type: 'inline-text', text: ' text' }
+              { stype: 'inline-text', text: ' text' }
             ]
           }
         ]
@@ -426,11 +426,11 @@ describe('DSL Basic Syntax', () => {
       ]);
       
       expect(result).toEqual({
-        type: 'inline-text',
+        stype: 'inline-text',
         text: 'Styled text',
         marks: [
-          { type: 'bold', attrs: { weight: 'bold' }, range: undefined },
-          { type: 'italic', attrs: { style: 'italic' }, range: undefined }
+          { stype: 'bold', attrs: { weight: 'bold' }, range: undefined },
+          { stype: 'italic', attrs: { style: 'italic' }, range: undefined }
         ]
       });
     });

--- a/packages/model/test/transaction/dsl-control.test.ts
+++ b/packages/model/test/transaction/dsl-control.test.ts
@@ -36,13 +36,17 @@ describe('DSL Control Operations', () => {
       _dataStore: dataStore,
       getActiveSchema: () => schema,
       selectionManager: {
+        getCurrentSelection: () => null,
         clone: () => ({
           getCurrentSelection: () => null,
+          setSelection: () => {},
           selectRange: () => {},
           selectNode: () => {},
           clearSelection: () => {}
         })
-      }
+      },
+      historyManager: { push: () => {} },
+      emit: () => {}
     };
   });
 
@@ -382,14 +386,14 @@ describe('DSL Control Operations', () => {
 
       const controlResult = await transaction(mockEditor, [
         ...control(paragraphId, [
-          { type: 'addChild', payload: { child: { type: 'inline-text', text: 'New child' } } }
+          { type: 'addChild', payload: { child: { stype: 'inline-text', text: 'New child' } } }
         ])
       ]).commit();
 
       expect(controlResult.success).toBe(true);
       expect(controlResult.operations?.[0].type).toBe('addChild');
       expect(controlResult.operations?.[0].payload.nodeId).toBe(paragraphId);
-      expect(controlResult.operations?.[0].payload.child.type).toBe('inline-text');
+      expect(controlResult.operations?.[0].payload.child.stype).toBe('inline-text');
       expect(controlResult.operations?.[0].payload.child.text).toBe('New child');
     });
 

--- a/packages/model/test/transaction/dsl-create.test.ts
+++ b/packages/model/test/transaction/dsl-create.test.ts
@@ -40,13 +40,17 @@ describe('DSL Create Operations', () => {
       _dataStore: dataStore,
       getActiveSchema: () => schema,
       selectionManager: {
+        getCurrentSelection: () => null,
         clone: () => ({
           getCurrentSelection: () => null,
+          setSelection: () => {},
           selectRange: () => {},
           selectNode: () => {},
           clearSelection: () => {}
         })
-      }
+      },
+      historyManager: { push: () => {} },
+      emit: () => {}
     };
   });
 
@@ -61,7 +65,7 @@ describe('DSL Create Operations', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('paragraph');
+      expect(result.operations?.[0].result.data.stype).toBe('paragraph');
       // Filter out undefined values from content array
       const validContent = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
       expect(validContent).toHaveLength(1);
@@ -74,7 +78,7 @@ describe('DSL Create Operations', () => {
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(childNodeId);
       expect(childNode).toBeDefined();
-      expect(childNode?.type).toBe('inline-text');
+      expect(childNode?.stype).toBe('inline-text');
       expect(childNode?.text).toBe('Hello World');
       expect(childNode?.sid).toBeDefined();
     });
@@ -92,7 +96,7 @@ describe('DSL Create Operations', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('paragraph');
+      expect(result.operations?.[0].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -105,7 +109,7 @@ describe('DSL Create Operations', () => {
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(childNodeId);
       expect(childNode).toBeDefined();
-      expect(childNode?.type).toBe('inline-text');
+      expect(childNode?.stype).toBe('inline-text');
       expect(childNode?.text).toBe('text text');
     });
 
@@ -124,7 +128,7 @@ describe('DSL Create Operations', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('paragraph');
+      expect(result.operations?.[0].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -136,9 +140,9 @@ describe('DSL Create Operations', () => {
       const child3 = dataStore.getNode(validContent[2]);
       
       expect(child1?.text).toBe('Hello ');
-      expect(child1?.marks).toEqual([{ type: 'italic', attrs: {}, range: undefined }]);
+      expect(child1?.marks).toEqual([{ stype: 'italic', attrs: {}, range: undefined }]);
       expect(child2?.text).toBe('World');
-      expect(child2?.marks).toEqual([{ type: 'bold', attrs: {}, range: undefined }]);
+      expect(child2?.marks).toEqual([{ stype: 'bold', attrs: {}, range: undefined }]);
       expect(child3?.text).toBe('!');
       expect(child3?.marks).toEqual([]);
     });
@@ -158,7 +162,7 @@ describe('DSL Create Operations', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('heading');
+      expect(result.operations?.[0].result.data.stype).toBe('heading');
       expect(result.operations?.[0].result.data.attributes.level).toBe(1);
     });
 
@@ -173,7 +177,7 @@ describe('DSL Create Operations', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('codeBlock');
+      expect(result.operations?.[0].result.data.stype).toBe('codeBlock');
       expect(result.operations?.[0].result.data.attributes.language).toBe('typescript');
       expect(result.operations?.[0].result.data.text).toBe('const x = 1;');
     });
@@ -195,7 +199,7 @@ describe('DSL Create Operations', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('list');
+      expect(result.operations?.[0].result.data.stype).toBe('list');
       expect(result.operations?.[0].result.data.attributes.type).toBe('bullet');
     });
   });
@@ -214,7 +218,7 @@ describe('DSL Create Operations', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('heading');
+      expect(result.operations?.[0].result.data.stype).toBe('heading');
       expect(result.operations?.[0].result.data.attributes.level).toBe(1);
       
       // Filter out undefined values from content array
@@ -223,7 +227,7 @@ describe('DSL Create Operations', () => {
       
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
-      expect(childNode?.type).toBe('inline-text');
+      expect(childNode?.stype).toBe('inline-text');
       expect(childNode?.text).toBe('Deep Heading Text');
     });
 
@@ -253,7 +257,7 @@ describe('DSL Create Operations', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('list');
+      expect(result.operations?.[0].result.data.stype).toBe('list');
       
       // Filter out undefined values from content array
       const validContent = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -261,13 +265,13 @@ describe('DSL Create Operations', () => {
       
       // Get the second list item and verify it contains a nested list
       const secondListItem = dataStore.getNode(validContent[1]);
-      expect(secondListItem?.type).toBe('listItem');
+      expect(secondListItem?.stype).toBe('listItem');
       
       const nestedContent = secondListItem?.content?.filter((item: any) => item !== undefined);
       expect(nestedContent).toHaveLength(1);
       
       const nestedList = dataStore.getNode(nestedContent?.[0] as unknown as string);
-      expect(nestedList?.type).toBe('list');
+      expect(nestedList?.stype).toBe('list');
     });
   });
 
@@ -293,7 +297,7 @@ describe('DSL Create Operations', () => {
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
       expect(childNode?.text).toBe('Hello');
-      expect(childNode?.marks).toEqual([{ type: 'bold', attrs: {}, range: undefined }]);
+      expect(childNode?.marks).toEqual([{ stype: 'bold', attrs: {}, range: undefined }]);
     });
 
     it('should create text with multiple marks', async () => {
@@ -319,9 +323,9 @@ describe('DSL Create Operations', () => {
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
       expect(childNode?.marks).toHaveLength(2);
-      expect(childNode?.marks?.[0]?.type).toBe('bold');
+      expect(childNode?.marks?.[0]?.stype).toBe('bold');
       expect(childNode?.marks?.[0]?.attrs?.weight).toBe('bold');
-      expect(childNode?.marks?.[1]?.type).toBe('italic');
+      expect(childNode?.marks?.[1]?.stype).toBe('italic');
       expect(childNode?.marks?.[1]?.attrs?.style).toBe('italic');
     });
 
@@ -346,7 +350,7 @@ describe('DSL Create Operations', () => {
       
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
-      expect(childNode?.marks?.[0]?.type).toBe('link');
+      expect(childNode?.marks?.[0]?.stype).toBe('link');
       expect(childNode?.marks?.[0]?.attrs?.href).toBe('https://example.com');
       expect(childNode?.marks?.[0]?.attrs?.title).toBe('Example');
     });
@@ -363,7 +367,7 @@ describe('DSL Create Operations', () => {
       }
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
-      expect(result.operations?.[0].result.data.type).toBe('pageBreak');
+      expect(result.operations?.[0].result.data.stype).toBe('pageBreak');
     });
 
     it('should create inline image with attributes', async () => {
@@ -385,7 +389,7 @@ describe('DSL Create Operations', () => {
       
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
-      expect(childNode?.type).toBe('inline-image');
+      expect(childNode?.stype).toBe('inline-image');
       expect(childNode?.attributes?.src).toBe('image.jpg');
       expect(childNode?.attributes?.alt).toBe('Sample image');
     });

--- a/packages/model/test/transaction/dsl-scenarios.test.ts
+++ b/packages/model/test/transaction/dsl-scenarios.test.ts
@@ -43,7 +43,9 @@ describe('DSL Scenarios', () => {
       dataStore,
       _dataStore: dataStore,
       getActiveSchema: () => schema,
-      selectionManager
+      selectionManager,
+      historyManager: { push: () => {} },
+      emit: () => {}
     };
   });
 
@@ -58,7 +60,7 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('paragraph');
+      expect(result.operations?.[0].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -66,7 +68,7 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
-      expect(childNode?.type).toBe('inline-text');
+      expect(childNode?.stype).toBe('inline-text');
       expect(childNode?.text).toBe('Hello World');
     });
 
@@ -80,7 +82,7 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('heading');
+      expect(result.operations?.[0].result.data.stype).toBe('heading');
       expect(result.operations?.[0].result.data.attributes.level).toBe(1);
       
       // Filter out undefined values from content array
@@ -89,7 +91,7 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
-      expect(childNode?.type).toBe('inline-text');
+      expect(childNode?.stype).toBe('inline-text');
       expect(childNode?.text).toBe('Document Title');
     });
 
@@ -105,7 +107,7 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('paragraph');
+      expect(result.operations?.[0].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -113,10 +115,10 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
-      expect(childNode?.type).toBe('inline-text');
+      expect(childNode?.stype).toBe('inline-text');
       expect(childNode?.text).toBe('Bold text');
       expect(childNode?.marks).toHaveLength(1);
-      expect(childNode?.marks?.[0].type).toBe('bold');
+      expect(childNode?.marks?.[0].stype).toBe('bold');
     });
   });
 
@@ -218,7 +220,7 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('list');
+      expect(result.operations?.[0].result.data.stype).toBe('list');
       expect(result.operations?.[0].result.data.attributes.type).toBe('bullet');
       
       // Filter out undefined values from content array
@@ -227,18 +229,18 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child nodes from DataStore
       const firstListItem = dataStore.getNode(validContent[0]);
-      expect(firstListItem?.type).toBe('listItem');
+      expect(firstListItem?.stype).toBe('listItem');
       
       const firstListItemContent = firstListItem?.content?.filter((item: any) => item !== undefined);
       expect(firstListItemContent).toHaveLength(1);
       
       const firstParagraph = dataStore.getNode(firstListItemContent?.[0] as string);
-      expect(firstParagraph?.type).toBe('paragraph');
+      expect(firstParagraph?.stype).toBe('paragraph');
       const firstParagraphContent = firstParagraph?.content?.filter((item: any) => item !== undefined);
       expect(firstParagraphContent).toHaveLength(1);
       
       const firstInlineText = dataStore.getNode(firstParagraphContent?.[0] as string);
-      expect(firstInlineText?.type).toBe('inline-text');
+      expect(firstInlineText?.stype).toBe('inline-text');
       expect(firstInlineText?.text).toBe('First item');
     });
 
@@ -257,7 +259,7 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('blockquote');
+      expect(result.operations?.[0].result.data.stype).toBe('blockquote');
       
       // Filter out undefined values from content array
       const validContent = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -265,17 +267,17 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const paragraphNode = dataStore.getNode(validContent[0]);
-      expect(paragraphNode?.type).toBe('paragraph');
+      expect(paragraphNode?.stype).toBe('paragraph');
       
       const paragraphContent = paragraphNode?.content?.filter((item: any) => item !== undefined);
       expect(paragraphContent).toHaveLength(2);
       
       const firstInlineText = dataStore.getNode(paragraphContent?.[0] as string);
-      expect(firstInlineText?.type).toBe('inline-text');
+      expect(firstInlineText?.stype).toBe('inline-text');
       expect(firstInlineText?.text).toBe('Quote text with ');
       
       const secondInlineText = dataStore.getNode(paragraphContent?.[1] as string);
-      expect(secondInlineText?.type).toBe('inline-text');
+      expect(secondInlineText?.stype).toBe('inline-text');
       expect(secondInlineText?.text).toBe('emphasis');
     });
 
@@ -287,7 +289,7 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('codeBlock');
+      expect(result.operations?.[0].result.data.stype).toBe('codeBlock');
       expect(result.operations?.[0].result.data.attributes.language).toBe('typescript');
       expect(result.operations?.[0].result.data.text).toBe('const x = 1;');
     });
@@ -304,7 +306,7 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(3);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('paragraph');
+      expect(result.operations?.[0].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent0 = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -312,10 +314,10 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode0 = dataStore.getNode(validContent0[0]);
-      expect(childNode0?.type).toBe('inline-text');
+      expect(childNode0?.stype).toBe('inline-text');
       expect(childNode0?.text).toBe('First');
       expect(result.operations?.[1].type).toBe('create');
-      expect(result.operations?.[1].result.data.type).toBe('paragraph');
+      expect(result.operations?.[1].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent1 = result.operations?.[1].result.data.content.filter((item: any) => item !== undefined);
@@ -323,10 +325,10 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode1 = dataStore.getNode(validContent1[0]);
-      expect(childNode1?.type).toBe('inline-text');
+      expect(childNode1?.stype).toBe('inline-text');
       expect(childNode1?.text).toBe('Second');
       expect(result.operations?.[2].type).toBe('create');
-      expect(result.operations?.[2].result.data.type).toBe('paragraph');
+      expect(result.operations?.[2].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent2 = result.operations?.[2].result.data.content.filter((item: any) => item !== undefined);
@@ -334,7 +336,7 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode2 = dataStore.getNode(validContent2[0]);
-      expect(childNode2?.type).toBe('inline-text');
+      expect(childNode2?.stype).toBe('inline-text');
       expect(childNode2?.text).toBe('Third');
     });
 
@@ -358,7 +360,7 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(2);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('paragraph');
+      expect(result.operations?.[0].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -366,7 +368,7 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
-      expect(childNode?.type).toBe('inline-text');
+      expect(childNode?.stype).toBe('inline-text');
       expect(childNode?.text).toBe('New paragraph');
       
       expect(result.operations?.[1].type).toBe('setText');
@@ -389,7 +391,7 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('paragraph');
+      expect(result.operations?.[0].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -397,11 +399,11 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
-      expect(childNode?.type).toBe('inline-text');
+      expect(childNode?.stype).toBe('inline-text');
       expect(childNode?.text).toBe('Bold and italic text');
       expect(childNode?.marks).toHaveLength(2);
-      expect(childNode?.marks?.[0].type).toBe('bold');
-      expect(childNode?.marks?.[1].type).toBe('italic');
+      expect(childNode?.marks?.[0].stype).toBe('bold');
+      expect(childNode?.marks?.[1].stype).toBe('italic');
     });
 
     it('should create link with href attribute', async () => {
@@ -416,17 +418,17 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('paragraph');
+      expect(result.operations?.[0].result.data.stype).toBe('paragraph');
       // Filter out undefined values from content array
       const validContent = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
       expect(validContent).toHaveLength(1);
       
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
-      expect(childNode?.type).toBe('inline-text');
+      expect(childNode?.stype).toBe('inline-text');
       expect(childNode?.text).toBe('Click here');
       expect(childNode?.marks).toHaveLength(1);
-      expect(childNode?.marks?.[0].type).toBe('link');
+      expect(childNode?.marks?.[0].stype).toBe('link');
       expect(childNode?.marks?.[0]?.attrs?.href).toBe('https://example.com');
       expect(childNode?.marks?.[0]?.attrs?.title).toBe('Example');
     });
@@ -443,7 +445,7 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(1);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('paragraph');
+      expect(result.operations?.[0].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -451,10 +453,10 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode = dataStore.getNode(validContent[0]);
-      expect(childNode?.type).toBe('inline-text');
+      expect(childNode?.stype).toBe('inline-text');
       expect(childNode?.text).toBe('This is bold text');
       expect(childNode?.marks).toHaveLength(1);
-      expect(childNode?.marks?.[0].type).toBe('bold');
+      expect(childNode?.marks?.[0].stype).toBe('bold');
       expect(childNode?.marks?.[0].range).toEqual([8, 12]);
     });
   });
@@ -476,7 +478,7 @@ describe('DSL Scenarios', () => {
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(2);
       expect(result.operations?.[0].type).toBe('create');
-      expect(result.operations?.[0].result.data.type).toBe('paragraph');
+      expect(result.operations?.[0].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent0 = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -484,10 +486,10 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode0 = dataStore.getNode(validContent0[0]);
-      expect(childNode0?.type).toBe('inline-text');
+      expect(childNode0?.stype).toBe('inline-text');
       expect(childNode0?.text).toBe('First');
       expect(result.operations?.[1].type).toBe('create');
-      expect(result.operations?.[1].result.data.type).toBe('paragraph');
+      expect(result.operations?.[1].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent1 = result.operations?.[1].result.data.content.filter((item: any) => item !== undefined);
@@ -495,7 +497,7 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode1 = dataStore.getNode(validContent1[0]);
-      expect(childNode1?.type).toBe('inline-text');
+      expect(childNode1?.stype).toBe('inline-text');
       expect(childNode1?.text).toBe('Second');
     });
   });
@@ -533,7 +535,7 @@ describe('DSL Scenarios', () => {
 
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(3);
-      expect(result.operations?.[0].result.data.type).toBe('heading');
+      expect(result.operations?.[0].result.data.stype).toBe('heading');
       
       // Filter out undefined values from content array
       const validContent0 = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -541,9 +543,9 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode0 = dataStore.getNode(validContent0[0]);
-      expect(childNode0?.type).toBe('inline-text');
+      expect(childNode0?.stype).toBe('inline-text');
       expect(childNode0?.text).toBe('Article Title');
-      expect(result.operations?.[1].result.data.type).toBe('paragraph');
+      expect(result.operations?.[1].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent1 = result.operations?.[1].result.data.content.filter((item: any) => item !== undefined);
@@ -551,24 +553,24 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child nodes from DataStore
       const childNode1_0 = dataStore.getNode(validContent1[0]);
-      expect(childNode1_0?.type).toBe('inline-text');
+      expect(childNode1_0?.stype).toBe('inline-text');
       expect(childNode1_0?.text).toBe('This is an ');
       const childNode1_1 = dataStore.getNode(validContent1[1]);
-      expect(childNode1_1?.type).toBe('inline-text');
+      expect(childNode1_1?.stype).toBe('inline-text');
       expect(childNode1_1?.text).toBe('important');
       
       const childNode1_2 = dataStore.getNode(validContent1[2]);
-      expect(childNode1_2?.type).toBe('inline-text');
+      expect(childNode1_2?.stype).toBe('inline-text');
       expect(childNode1_2?.text).toBe(' paragraph with a ');
       
       const childNode1_3 = dataStore.getNode(validContent1[3]);
-      expect(childNode1_3?.type).toBe('inline-text');
+      expect(childNode1_3?.stype).toBe('inline-text');
       expect(childNode1_3?.text).toBe('link');
       
       const childNode1_4 = dataStore.getNode(validContent1[4]);
-      expect(childNode1_4?.type).toBe('inline-text');
+      expect(childNode1_4?.stype).toBe('inline-text');
       expect(childNode1_4?.text).toBe('.');
-      expect(result.operations?.[2].result.data.type).toBe('list');
+      expect(result.operations?.[2].result.data.stype).toBe('list');
       expect(result.operations?.[2].result.data.attributes.type).toBe('bullet');
       
       // Filter out undefined values from content array
@@ -576,19 +578,19 @@ describe('DSL Scenarios', () => {
       expect(validContent2).toHaveLength(2);
       // Get the actual child nodes from DataStore
       const firstListItem = dataStore.getNode(validContent2[0]);
-      expect(firstListItem?.type).toBe('listItem');
+      expect(firstListItem?.stype).toBe('listItem');
       
       const firstListItemContent = firstListItem?.content?.filter((item: any) => item !== undefined);
       expect(firstListItemContent).toHaveLength(1);
       
       const firstParagraph = dataStore.getNode(firstListItemContent?.[0] as string);
-      expect(firstParagraph?.type).toBe('paragraph');
+      expect(firstParagraph?.stype).toBe('paragraph');
       
       const firstParagraphContent = firstParagraph?.content?.filter((item: any) => item !== undefined);
       expect(firstParagraphContent).toHaveLength(1);
       
       const firstInlineText = dataStore.getNode(firstParagraphContent?.[0] as string  );
-      expect(firstInlineText?.type).toBe('inline-text');
+      expect(firstInlineText?.stype).toBe('inline-text');
     });
 
     it('should create a code tutorial structure', async () => {
@@ -611,7 +613,7 @@ describe('DSL Scenarios', () => {
 
       expect(result.success).toBe(true);
       expect(result.operations).toHaveLength(4);
-      expect(result.operations?.[0].result.data.type).toBe('heading');
+      expect(result.operations?.[0].result.data.stype).toBe('heading');
       
       // Filter out undefined values from content array
       const validContent0 = result.operations?.[0].result.data.content.filter((item: any) => item !== undefined);
@@ -619,9 +621,9 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode0 = dataStore.getNode(validContent0[0]);
-      expect(childNode0?.type).toBe('inline-text');
+      expect(childNode0?.stype).toBe('inline-text');
       expect(childNode0?.text).toBe('JavaScript Tutorial');
-      expect(result.operations?.[1].result.data.type).toBe('paragraph');
+      expect(result.operations?.[1].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent1 = result.operations?.[1].result.data.content.filter((item: any) => item !== undefined);
@@ -629,11 +631,11 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child node from DataStore
       const childNode1 = dataStore.getNode(validContent1[0]);
-      expect(childNode1?.type).toBe('inline-text');
+      expect(childNode1?.stype).toBe('inline-text');
       expect(childNode1?.text).toBe('Here is a simple function:');
-      expect(result.operations?.[2].result.data.type).toBe('codeBlock');
+      expect(result.operations?.[2].result.data.stype).toBe('codeBlock');
       expect(result.operations?.[2].result.data.text).toBe('function hello() {\n  console.log("Hello World");\n}');
-      expect(result.operations?.[3].result.data.type).toBe('paragraph');
+      expect(result.operations?.[3].result.data.stype).toBe('paragraph');
       
       // Filter out undefined values from content array
       const validContent3 = result.operations?.[3].result.data.content.filter((item: any) => item !== undefined);
@@ -641,14 +643,14 @@ describe('DSL Scenarios', () => {
       
       // Get the actual child nodes from DataStore
       const childNode3_0 = dataStore.getNode(validContent3[0]);
-      expect(childNode3_0?.type).toBe('inline-text');
+      expect(childNode3_0?.stype).toBe('inline-text');
       expect(childNode3_0?.text).toBe('This function will output ');
       const childNode3_1 = dataStore.getNode(validContent3[1]);
-      expect(childNode3_1?.type).toBe('inline-text');
+      expect(childNode3_1?.stype).toBe('inline-text');
       expect(childNode3_1?.text).toBe('Hello World');
       
       const childNode3_2 = dataStore.getNode(validContent3[2]);
-      expect(childNode3_2?.type).toBe('inline-text');
+      expect(childNode3_2?.stype).toBe('inline-text');
       expect(childNode3_2?.text).toBe(' to the console.');
     });
   });


### PR DESCRIPTION
Resolves #16 (transaction commit and DSL scenario tests).

- Mock editor: add getCurrentSelection on selectionManager, historyManager.push, emit
- DSL node shape: expect stype (not type) for INode/IMark in assertions and payloads
- dsl-basic-syntax, dsl-create, dsl-control, dsl-scenarios: all 89 tests in these files pass
- Other model test files (transaction-commit, create.test, selection-manager, etc.) still fail and are out of scope for this PR

Made with [Cursor](https://cursor.com)