### PR TITLE
docs(github): require PR flow — push branch, open PR, merge via PR

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -333,6 +333,8 @@ If any of these fail, add or adjust a test (unit or E2E) that reproduces the fai
 
 ## GitHub: issue → PR → merge → deploy
 
+**Rule: do not merge locally.** Flow is: create branch → commit → **push branch** → **open PR** → **merge via PR** (on GitHub or `gh pr merge`). Do not run `git merge <branch> main` and push main; that skips the PR and CI on the PR branch.
+
 To run the same flow with GitHub (issues, PRs, CI, merge, deploy):
 
 - **Issue templates**: `.github/ISSUE_TEMPLATE/` (feature, bug fix, E2E-only). Use when creating an issue so the agent (or you) has a clear scope and verification checklist.

--- a/.cursor/roles/GITHUB_AGENT.md
+++ b/.cursor/roles/GITHUB_AGENT.md
@@ -5,8 +5,10 @@
 **Input**: Branch with passing unit tests (Test Agent) and passing E2E (E2E Agent); optional issue number.
 
 **Output**:
-- Open PR from branch to `main` with `.github/PULL_REQUEST_TEMPLATE.md` filled; link issue (e.g. Closes #123). Merge when CI passes (if allowed). Deploy runs on merge (`.github/workflows/docs.yml`).
+- **Push branch** (`git push origin <branch>`). Do **not** merge the branch into `main` locally.
+- **Open PR** from branch to `main` with `.github/PULL_REQUEST_TEMPLATE.md` filled; link issue (e.g. Closes #123).
+- **Merge via PR** when CI passes (GitHub merge button or `gh pr merge`). Do **not** run `git merge <branch> main` and push `main`. Deploy runs on merge (`.github/workflows/docs.yml`).
 
-**Do not**: Edit spec docs or implementation code.
+**Do not**: Edit spec docs or implementation code; merge branch into main locally and push main.
 
 **Full definition**: `docs/agent-roles-and-orchestration.md` §2.5. See `docs/github-agent-integration.md`.

--- a/docs/agent-roles-and-orchestration.md
+++ b/docs/agent-roles-and-orchestration.md
@@ -124,11 +124,12 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: What needs to b
 - Optionally: issue number to link (e.g. Closes #123).
 
 **Output**:
-- **PR**: Open PR from branch to `main` using `.github/PULL_REQUEST_TEMPLATE.md` (what changed, verification checklist, issue link). Push and `gh pr create` (or equivalent).
-- **Merge**: When CI passes (and optional review), merge PR (human or automation with write access).
+- **Push branch**: Push the branch (`git push origin <branch>`). Do **not** merge the branch into `main` locally and push `main`.
+- **PR**: Open PR from branch to `main` using `.github/PULL_REQUEST_TEMPLATE.md` (what changed, verification checklist, issue link). Use `gh pr create` (or GitHub web UI).
+- **Merge via PR**: When CI passes (and optional review), merge the PR on GitHub (merge button or `gh pr merge`). Do **not** run `git merge <branch> main` locally and push `main`.
 - **Deploy**: Docs deploy via `.github/workflows/docs.yml` on push to `main`. Package release via changesets + `pnpm release` when desired (see `docs/github-agent-integration.md`).
 
-**Handoff**: None. After merge, deploy runs automatically (docs). GitHub Agent does **not** edit specs or implementation.
+**Handoff**: None. After merge, deploy runs automatically (docs). GitHub Agent does **not** edit specs or implementation; does **not** merge locally and push main.
 
 **References**: `docs/github-agent-integration.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/ci.yml`, `.github/workflows/docs.yml`.
 

--- a/docs/github-agent-integration.md
+++ b/docs/github-agent-integration.md
@@ -55,6 +55,8 @@ See `.cursor/AGENTS.md` § Rules and § Single command step 1 "Nothing found".
 
 ## 3. Branch and PR
 
+**Rule: do not merge locally.** Always: create branch → commit → **push branch** → **open PR** → **merge via PR** (on GitHub or `gh pr merge`). Do **not** run `git checkout main && git merge <branch>` and push `main`; that skips the PR and CI on the PR branch.
+
 ### 3.1 Branch naming
 
 - **Feature**: `feat/<short-name>` (e.g. `feat/insert-list`, `feat/wrap-blockquote`).
@@ -80,14 +82,18 @@ git checkout -b feat/insert-list origin/main
 
 After implementing and verifying locally:
 
-```bash
-git add -A
-git commit -m "feat(model,extensions): add insertList operation and E2E"
-git push origin feat/insert-list
-gh pr create --base main --head feat/insert-list --title "Add insertList (model + extension + E2E)" --body "See template checklist."
-```
-
-Or use GitHub web UI: **Compare & pull request** and fill the template.
+1. **Push the branch** (do not merge into main locally):
+   ```bash
+   git add -A
+   git commit -m "feat(model,extensions): add insertList operation and E2E"
+   git push origin feat/insert-list
+   ```
+2. **Open a PR** (do not merge the branch into main and push main):
+   ```bash
+   gh pr create --base main --head feat/insert-list --title "Add insertList (model + extension + E2E)" --body "See template checklist."
+   ```
+   Or use GitHub web UI: **Compare & pull request** and fill the template.
+3. **Merge via PR** when CI passes: use GitHub "Merge" button or `gh pr merge <number>`.
 
 ---
 
@@ -146,10 +152,10 @@ Or use GitHub web UI: **Compare & pull request** and fill the template.
 1. **Input**: User creates an issue (or says "add insertList" → agent creates an issue from the feature template).
 2. **Branch**: Agent creates `feat/insert-list` from `main`.
 3. **Implement**: Agent follows `.cursor/AGENTS.md` (model → extension → E2E) and runs verification (exec test → model test → extensions test → E2E).
-4. **Commit & push**: Agent commits and pushes to `feat/insert-list`.
-5. **PR**: Agent opens a PR with title and body from `.github/PULL_REQUEST_TEMPLATE.md`, referencing the issue.
-6. **CI**: GitHub Actions run lint, type-check, unit tests, E2E. Agent or user fixes any failures and pushes.
-7. **Merge**: Human (or automation) merges the PR to `main`.
+4. **Commit & push branch**: Agent commits and **pushes the branch** (`git push origin feat/insert-list`). Do **not** merge the branch into main locally.
+5. **PR**: Agent opens a PR with title and body from `.github/PULL_REQUEST_TEMPLATE.md`, referencing the issue (e.g. "Closes #123").
+6. **CI**: GitHub Actions run on the PR branch. Agent or user fixes any failures and pushes to the same branch.
+7. **Merge via PR**: Human (or automation) merges the PR to `main` on GitHub (merge button or `gh pr merge`). Do **not** merge locally and push main.
 8. **Deploy**: Docs deploy automatically if docs changed; packages are published when maintainers run the changeset flow and `pnpm release`.
 
 ---


### PR DESCRIPTION
## What changed
- Add rule: do not merge branch into main locally and push main.
- Flow: create branch → commit → **push branch** → **open PR** → **merge via PR** (GitHub or `gh pr merge`).

## Files
- `.cursor/AGENTS.md`: rule under GitHub section
- `docs/github-agent-integration.md`: rule in §3, §3.3 steps (push branch, open PR, merge via PR), §7 summary
- `.cursor/roles/GITHUB_AGENT.md`: Output and Do not updated
- `docs/agent-roles-and-orchestration.md`: §2.5 GitHub Agent Output and Handoff

## Verification
- Docs only; no code or test changes.

Made with [Cursor](https://cursor.com)