### PR TITLE
docs: enforce PR workflow and Closes #N for auto-closing issues

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -97,9 +97,9 @@ Run the **full flow** for that task, in role order:
 - **Implementation Agent**: Create branch, implement per checklist (model → extension → docs-site). Do not run E2E or open PR.
 - **Test Agent**: Run unit tests for touched packages; fix or hand back to Implementation if fail.
 - **E2E Agent**: Run `pnpm test:e2e:react` (or `pnpm test:e2e`); add/update E2E spec if needed; report pass/fail.
-- **GitHub Agent**: Open PR with template, link issue. Do not edit spec or code.
+- **GitHub Agent**: Open PR with template; **include "Closes #N" in the PR body** so the issue is closed when the PR is merged. Do not edit spec or code.
 
-If the user only said "What needs to be done? Proceed." with no other context, use the **first open issue** and run the full flow. After each role, continue to the next role without asking unless a handback is needed (e.g. tests fail → fix or report). When the PR is merged, the issue is closed (e.g. "Closes #N"); no separate backlog file to update.
+If the user only said "What needs to be done? Proceed." with no other context, use the **first open issue** and run the full flow. After each role, continue to the next role without asking unless a handback is needed (e.g. tests fail → fix or report). **PR body must include "Closes #N" (or "Fixes #N")** so that when the PR is merged, GitHub automatically closes the issue; no separate backlog file to update.
 
 ---
 

--- a/.cursor/roles/GITHUB_AGENT.md
+++ b/.cursor/roles/GITHUB_AGENT.md
@@ -6,7 +6,7 @@
 
 **Output**:
 - **Push branch** (`git push origin <branch>`). Do **not** merge the branch into `main` locally.
-- **Open PR** from branch to `main` with `.github/PULL_REQUEST_TEMPLATE.md` filled; link issue (e.g. Closes #123).
+- **Open PR** from branch to `main` with `.github/PULL_REQUEST_TEMPLATE.md` filled; **include "Closes #N" (or "Fixes #N") in the PR body** so the issue is closed when the PR is merged.
 - **Merge via PR** when CI passes (GitHub merge button or `gh pr merge`). Do **not** run `git merge <branch> main` and push `main`. Deploy runs on merge (`.github/workflows/docs.yml`).
 
 **Do not**: Edit spec docs or implementation code; merge branch into main locally and push main.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@
 
 ## Related
 
-- Issue: (link or "none")
+- Issue: (link or "none"). **If this PR addresses an issue, add "Closes #N" below so the issue is closed when this PR is merged.**
 - Ref: `.cursor/AGENTS.md` (verification by scenario), `docs/testing-verification.md`

--- a/docs/agent-roles-and-orchestration.md
+++ b/docs/agent-roles-and-orchestration.md
@@ -125,7 +125,7 @@ Full procedure is in **`.cursor/AGENTS.md`** § "Single command: What needs to b
 
 **Output**:
 - **Push branch**: Push the branch (`git push origin <branch>`). Do **not** merge the branch into `main` locally and push `main`.
-- **PR**: Open PR from branch to `main` using `.github/PULL_REQUEST_TEMPLATE.md` (what changed, verification checklist, issue link). Use `gh pr create` (or GitHub web UI).
+- **PR**: Open PR from branch to `main` using `.github/PULL_REQUEST_TEMPLATE.md` (what changed, verification checklist). **Include "Closes #N" in the PR body** so the issue is closed when the PR is merged. Use `gh pr create` (or GitHub web UI).
 - **Merge via PR**: When CI passes (and optional review), merge the PR on GitHub (merge button or `gh pr merge`). Do **not** run `git merge <branch> main` locally and push `main`.
 - **Deploy**: Docs deploy via `.github/workflows/docs.yml` on push to `main`. Package release via changesets + `pnpm release` when desired (see `docs/github-agent-integration.md`).
 

--- a/docs/github-agent-integration.md
+++ b/docs/github-agent-integration.md
@@ -39,7 +39,7 @@ Agents can automate up to **PR creation**; **merge** and **release** are typical
 
 - Read the issue (title + body) to know scope: feature / fix / E2E-only.
 - Use the "Verification" section in the template as the checklist to run before opening a PR.
-- Optionally reference the issue in the PR (e.g. "Closes #123").
+- When opening a PR for an issue, **include "Closes #N" (or "Fixes #N") in the PR body** so that when the PR is merged, GitHub automatically closes the issue.
 
 ### 2.4 Rule: no open issues → research and create issues
 
@@ -75,7 +75,7 @@ git checkout -b feat/insert-list origin/main
 ### 3.2 PR template
 
 - **File**: `.github/PULL_REQUEST_TEMPLATE.md`
-- When opening a PR, fill: **What changed**, **Verification** (what was run), **Related** (issue link).
+- When opening a PR, fill: **What changed**, **Verification** (what was run), **Related** (issue link). If the PR addresses an issue, **include "Closes #N" in the PR body** so the issue is closed when the PR is merged.
 - CI runs on every push to the PR branch: lint, type-check, unit tests, E2E (React).
 
 ### 3.3 Opening a PR (agent or human)


### PR DESCRIPTION
## Summary
- Do not merge locally; always push branch → open PR → merge via PR.
- Document steps in `docs/github-agent-integration.md`, `.cursor/AGENTS.md`, `.cursor/roles/GITHUB_AGENT.md`, `docs/agent-roles-and-orchestration.md`.
- `.github/PULL_REQUEST_TEMPLATE.md`: prompt to add `Closes #N` when PR addresses an issue so the issue is closed on merge.

Made with [Cursor](https://cursor.com)