### PR TITLE
fix(extensions): tests — delete mock (deleteTextRange/deleteOp), toggleMark payload, cross-node false

### DIFF
--- a/packages/extensions/src/strikethrough.ts
+++ b/packages/extensions/src/strikethrough.ts
@@ -47,6 +47,9 @@ export class StrikeThroughExtension implements Extension {
     if (!selection || selection.type !== 'range') {
       return false;
     }
+    if (selection.startNodeId !== selection.endNodeId) {
+      return false;
+    }
 
     const op = toggleMark(
       selection.startNodeId,

--- a/packages/extensions/src/underline.ts
+++ b/packages/extensions/src/underline.ts
@@ -47,6 +47,9 @@ export class UnderlineExtension implements Extension {
     if (!selection || selection.type !== 'range') {
       return false;
     }
+    if (selection.startNodeId !== selection.endNodeId) {
+      return false;
+    }
 
     const op = toggleMark(
       selection.startNodeId,

--- a/packages/extensions/test/delete-extension.test.ts
+++ b/packages/extensions/test/delete-extension.test.ts
@@ -12,9 +12,9 @@ vi.mock('@barocss/model', () => {
       recordedTransactions.push(operations);
       return { commit: commitMock };
     },
-    // control is used for wrapping operations in single node text deletion,
-    // so just return the internal operations array as is
-    control: (_nodeId: string, ops: any[]) => ops
+    control: (_nodeId: string, ops: any[]) => ops,
+    deleteTextRange: (start: number, end: number) => ({ type: 'deleteTextRange', payload: { start, end } }),
+    deleteOp: (nodeId: string) => ({ type: 'delete', payload: { nodeId } })
   };
 });
 

--- a/packages/extensions/test/strikethrough-extension.test.ts
+++ b/packages/extensions/test/strikethrough-extension.test.ts
@@ -5,19 +5,14 @@ import { StrikeThroughExtension } from '../src/strikethrough';
 const recordedTransactions: any[][] = [];
 const commitMock = vi.fn();
 
-vi.mock('@barocss/model', () => {
+vi.mock('@barocss/model', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@barocss/model')>();
   return {
+    ...actual,
     transaction: (_editor: Editor, operations: any[]) => {
       recordedTransactions.push(operations);
-      return {
-        commit: commitMock
-      };
-    },
-    control: (_nodeId: string, ops: any[]) => ops,
-    toggleMark: (markType: string, range: [number, number]) => ({
-      type: 'toggleMark',
-      payload: { markType, range }
-    })
+      return { commit: commitMock };
+    }
   };
 });
 
@@ -78,7 +73,10 @@ describe('StrikeThroughExtension - toggleStrikeThrough', () => {
     expect(ops).toEqual([
       {
         type: 'toggleMark',
-        payload: { markType: 'strikethrough', range: [2, 7] }
+        payload: {
+          range: { startNodeId: 'text-1', startOffset: 2, endNodeId: 'text-1', endOffset: 7 },
+          markType: 'strikethrough'
+        }
       }
     ]);
   });

--- a/packages/extensions/test/underline-extension.test.ts
+++ b/packages/extensions/test/underline-extension.test.ts
@@ -5,19 +5,14 @@ import { UnderlineExtension } from '../src/underline';
 const recordedTransactions: any[][] = [];
 const commitMock = vi.fn();
 
-vi.mock('@barocss/model', () => {
+vi.mock('@barocss/model', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@barocss/model')>();
   return {
+    ...actual,
     transaction: (_editor: Editor, operations: any[]) => {
       recordedTransactions.push(operations);
-      return {
-        commit: commitMock
-      };
-    },
-    control: (_nodeId: string, ops: any[]) => ops,
-    toggleMark: (markType: string, range: [number, number]) => ({
-      type: 'toggleMark',
-      payload: { markType, range }
-    })
+      return { commit: commitMock };
+    }
   };
 });
 
@@ -78,7 +73,10 @@ describe('UnderlineExtension - toggleUnderline', () => {
     expect(ops).toEqual([
       {
         type: 'toggleMark',
-        payload: { markType: 'underline', range: [2, 7] }
+        payload: {
+          range: { startNodeId: 'text-1', startOffset: 2, endNodeId: 'text-1', endOffset: 7 },
+          markType: 'underline'
+        }
       }
     ]);
   });


### PR DESCRIPTION
Closes #19

## Summary
- **delete-extension.test**: Add `deleteTextRange` and `deleteOp` to `@barocss/model` mock so extension code using these DSLs does not fail under vitest.
- **underline / strikethrough**: Return `false` when selection spans multiple nodes (`startNodeId !== endNodeId`) so tests expecting "cross-node not supported yet" pass.
- **underline / strikethrough tests**: Use `importOriginal` for `@barocss/model` and expect real `toggleMark` payload shape (`range: { startNodeId, startOffset, endNodeId, endOffset }, markType`).

Made with [Cursor](https://cursor.com)