### PR TITLE
fix(renderer-dom): VNode sid for Context components, vnode-full-document block decorator

### DIFF
--- a/packages/renderer-dom/src/vnode/factory.ts
+++ b/packages/renderer-dom/src/vnode/factory.ts
@@ -2022,7 +2022,9 @@ export class VNodeBuilder {
       // elementTemplate.attributes are props
       // _buildElement: template.attributes are props, model is runtime data
       const vnode = this._buildElement(elementTemplate, model, options);
-      // After attachComponentInfo, set sid and marks at top level
+      // Set stype so _applySidToVNode can set sid (attachComponentInfo sets stype later; we need it here for sid)
+      vnode.stype = nodeType;
+      // After stype is set, set sid and marks at top level
       this._applySidToVNode(vnode, model, options);
       // Element-based: no wrapper, do not assign component marker
       // Filter decorators for this specific node before attaching

--- a/packages/renderer-dom/test/core/vnode-full-document.test.ts
+++ b/packages/renderer-dom/test/core/vnode-full-document.test.ts
@@ -281,13 +281,13 @@ describe('Full Document VNode Verification', () => {
     
     expect(vnode).toBeTruthy();
     expect(vnode.children).toBeTruthy();
-    
-    // Current builder does not materialize block decorators as children nodes, but stores them in top-level decorators metadata
-    expect(Array.isArray((vnode as any).decorators)).toBe(true);
-    const hasBlockDecorator = ((vnode as any).decorators as any[]).some((d: any) =>
-      d && d.category === 'block' && d.position === 'after' && d.sid === 'd2' && d.target?.sid === 'p-1'
+
+    // Builder materializes block decorators as sibling VNodes (after the paragraph)
+    const children = vnode.children as any[];
+    const hasBlockDecoratorNode = children.some(
+      (c: any) => c && typeof c === 'object' && c.attrs?.['data-decorator-sid'] === 'd2'
     );
-    expect(hasBlockDecorator).toBe(true);
+    expect(hasBlockDecoratorNode).toBe(true);
   });
 
   it('should build VNode for complex nested structure with overlapping marks', () => {


### PR DESCRIPTION
## Summary
- **factory.ts**: Set `vnode.stype = nodeType` before `_applySidToVNode` so Context component root VNode gets `sid` (fixes decorator-structure and related tests).
- **vnode-full-document.test.ts**: Expect block decorator as sibling VNode with `data-decorator-sid` instead of `vnode.decorators` array.

Made with [Cursor](https://cursor.com)