### PR TITLE
fix(renderer-dom): fiber-create-fiber-tree-mark-wrapper.test.ts

### DIFF
--- a/packages/renderer-dom/src/reconcile/fiber/fiber-tree.ts
+++ b/packages/renderer-dom/src/reconcile/fiber/fiber-tree.ts
@@ -189,10 +189,15 @@ export function createFiberTree(
           }
         }
         
-        // Get prevChildVNode from alternate (for backward compatibility)
-        const prevChildVNode = prevChildAlternate?.vnode;
-        
-        
+        // Get prevChildVNode from alternate, or from prevVNode.children by index when no alternate
+        let prevChildVNode: VNode | undefined = prevChildAlternate?.vnode;
+        if (!prevChildVNode && actualPrevVNode?.children && i < actualPrevVNode.children.length) {
+          const prevChild = actualPrevVNode.children[i];
+          if (typeof prevChild === 'object' && prevChild !== null && 'tag' in prevChild) {
+            prevChildVNode = prevChild as VNode;
+          }
+        }
+
         // React-style: add matched alternate Fiber to tracking (prevent duplicate matching)
         if (prevChildAlternate) {
           matchedAlternateFibers.add(prevChildAlternate);


### PR DESCRIPTION
Closes #33

When createFiberTree is called with prevVNode but no alternateFiber, child fibers had prevVNode undefined. Fall back to actualPrevVNode.children[i] so mark wrapper (and other) child fibers get prevVNode set.

Made with [Cursor](https://cursor.com)