### PR TITLE
fix(renderer-dom): fiber-create-fiber-tree.test.ts

### DIFF
--- a/packages/renderer-dom/src/reconcile/fiber/fiber-tree.ts
+++ b/packages/renderer-dom/src/reconcile/fiber/fiber-tree.ts
@@ -189,12 +189,24 @@ export function createFiberTree(
           }
         }
         
-        // Get prevChildVNode from alternate, or from prevVNode.children by index when no alternate
+        // Get prevChildVNode from alternate, or from prevVNode.children (by sid then by index) when no alternate
         let prevChildVNode: VNode | undefined = prevChildAlternate?.vnode;
-        if (!prevChildVNode && actualPrevVNode?.children && i < actualPrevVNode.children.length) {
-          const prevChild = actualPrevVNode.children[i];
-          if (typeof prevChild === 'object' && prevChild !== null && 'tag' in prevChild) {
-            prevChildVNode = prevChild as VNode;
+        if (!prevChildVNode && actualPrevVNode?.children) {
+          if (effectiveChildId) {
+            for (const prevChild of actualPrevVNode.children) {
+              if (typeof prevChild !== 'object' || prevChild === null || !('tag' in prevChild)) continue;
+              const prevId = getVNodeId(prevChild as VNode);
+              if (prevId === effectiveChildId && !matchedPrevChildVNodes.has(prevChild as VNode)) {
+                prevChildVNode = prevChild as VNode;
+                break;
+              }
+            }
+          }
+          if (!prevChildVNode && i < actualPrevVNode.children.length) {
+            const prevChild = actualPrevVNode.children[i];
+            if (typeof prevChild === 'object' && prevChild !== null && 'tag' in prevChild && !matchedPrevChildVNodes.has(prevChild as VNode)) {
+              prevChildVNode = prevChild as VNode;
+            }
           }
         }
 


### PR DESCRIPTION
Closes #34

When matching prevChildVNode from prevVNode.children (no alternate), match by sid/decoratorSid first, then by index. Prevents wrong prevVNode when child order changes.

Made with [Cursor](https://cursor.com)