### PR TITLE
fix(renderer-dom): do not reuse DOM when decorator identity differs

### DIFF
--- a/packages/renderer-dom/src/reconcile/fiber/fiber-reconciler.ts
+++ b/packages/renderer-dom/src/reconcile/fiber/fiber-reconciler.ts
@@ -36,6 +36,16 @@ export interface FiberReconcileDependencies {
 }
 
 /**
+ * Get decorator identity (data-decorator-sid) from VNode (attrs or top-level decoratorSid).
+ */
+function getDecoratorSid(node: VNode | undefined): string | undefined {
+  if (!node || typeof node !== 'object') return undefined;
+  const fromAttrs = (node as VNode & { attrs?: Record<string, unknown> }).attrs?.[DOMAttribute.DECORATOR_SID];
+  if (fromAttrs !== undefined && fromAttrs !== null) return String(fromAttrs);
+  return (node as VNode & { decoratorSid?: string }).decoratorSid;
+}
+
+/**
  * Check Props changes via shallow comparison
  */
 function arePropsEqual(prev: any, next: any): boolean {
@@ -242,11 +252,18 @@ export function renderFiberNode(
     : null;
   const nextType = isTextVNode(vnode) ? 'text' : isHostVNode(vnode) ? 'host' : 'unknown';
   const typeChanged = prevType !== null && prevType !== nextType;
-  
+
+  // Host nodes with different decorator identity must not reuse DOM (create new element)
+  const prevDecoratorSid = getDecoratorSid(prevVNode);
+  const nextDecoratorSid = getDecoratorSid(vnode);
+  const decoratorIdentityChanged =
+    isHostVNode(vnode) &&
+    (prevDecoratorSid !== undefined || nextDecoratorSid !== undefined) &&
+    prevDecoratorSid !== nextDecoratorSid;
   
   // 4. Determine effectTag (calculation only, no DOM manipulation)
   // PLACEMENT if no prevVNode, PLACEMENT if type changed (remove existing DOM then create new), UPDATE otherwise
-  if (!prevVNode || typeChanged) {
+  if (!prevVNode || typeChanged || decoratorIdentityChanged) {
     fiber.effectTag = EffectTag.PLACEMENT;
   } else {
     fiber.effectTag = EffectTag.UPDATE;
@@ -254,11 +271,12 @@ export function renderFiberNode(
   
   // 5. Create or find DOM element (React style: create DOM in Render Phase)
   // In Render Phase, create DOM but do not insert
-  // IMPORTANT: If type changed, do not reuse existing DOM, create new
+  // IMPORTANT: If type changed or decorator identity changed, do not reuse existing DOM, create new
   let domElement: HTMLElement | Text | null = null;
   
-  // Find existing DOM element (from prevVNode, reuse only if type is same)
-  if (prevVNode?.meta?.domElement && !typeChanged) {
+  const cannotReuse = typeChanged || decoratorIdentityChanged;
+  // Find existing DOM element (from prevVNode, reuse only if type and decorator identity are same)
+  if (prevVNode?.meta?.domElement && !cannotReuse) {
     domElement = prevVNode.meta.domElement as HTMLElement | Text;
   } else {
     // Create new DOM element (insertion performed in commit phase)

--- a/packages/renderer-dom/test/core/fiber-reconcile-decorator-reuse.test.ts
+++ b/packages/renderer-dom/test/core/fiber-reconcile-decorator-reuse.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createFiberTree } from '../../src/reconcile/fiber/fiber-tree';
-import { reconcileFiberNode, FiberReconcileDependencies } from '../../src/reconcile/fiber/fiber-reconciler';
+import { renderFiberNode, commitFiberTree, FiberReconcileDependencies } from '../../src/reconcile/fiber/fiber-reconciler';
 import { FiberNode } from '../../src/reconcile/fiber/types';
 import { VNode } from '../../src/vnode/types';
 import { DOMOperations } from '../../src/dom-operations';
@@ -105,26 +105,14 @@ describe('reconcileFiberNode - Decorator 재사용 방지', () => {
       index: 1
     } as FiberNode;
 
-    // Call reconcileFiberNode
-    reconcileFiberNode(chipAfterFiber, deps, {});
+    // Render phase then commit phase (reconcileFiberNode was removed; use renderFiberNode + commitFiberTree)
+    renderFiberNode(chipAfterFiber, deps, {});
+    commitFiberTree(chipAfterFiber, deps, {});
 
     // chip-after VNode should not reuse chip-before DOM element
     // (should create new DOM element or not reuse chip-before)
     const chipBeforeAfter = textEl.querySelector('[data-decorator-sid="chip-before"]');
     const chipAfter = textEl.querySelector('[data-decorator-sid="chip-after"]');
-    
-    // eslint-disable-next-line no-console
-    console.log('After reconcileFiberNode:', {
-      chipBeforeExists: !!chipBeforeAfter,
-      chipAfterExists: !!chipAfter,
-      chipBeforeDecoratorSid: chipBeforeAfter?.getAttribute('data-decorator-sid'),
-      chipAfterDecoratorSid: chipAfter?.getAttribute('data-decorator-sid'),
-      textElChildren: Array.from(textEl.children).map(el => ({
-        tag: el.tagName,
-        decoratorSid: el.getAttribute('data-decorator-sid'),
-        text: el.textContent
-      }))
-    });
 
     // chip-before should not be changed to chip-after
     // (chip-before should remain, chip-after should be newly created)


### PR DESCRIPTION
Decorator identity (data-decorator-sid) differs between prev and next host VNode → treat as non-reusable: PLACEMENT and create new DOM element instead of reusing and updating attributes.

- Add `getDecoratorSid()` and `decoratorIdentityChanged` in renderFiberNode.
- Remove debug console.log from fiber-reconcile-decorator-reuse test.

Closes #38

Made with [Cursor](https://cursor.com)