### PR TITLE
fix(renderer-dom): do not remove Text nodes in removeStaleChildren

### DIFF
--- a/packages/renderer-dom/src/reconcile/fiber/fiber-reconciler.ts
+++ b/packages/renderer-dom/src/reconcile/fiber/fiber-reconciler.ts
@@ -767,13 +767,18 @@ export function removeStaleChildren(
   const components = deps.components;
   const context = deps.context || {};
   
-  // Remove unused DOM elements
+  // Remove unused DOM elements only (do not remove Text nodes)
+  // Text nodes are managed by handleVNodeTextProperty and processPrimitiveTextChildren,
+  // and are not in usedDomElements (no Fiber for primitive/vnode.text).
   for (const childNode of childNodes) {
     if (usedDomElements.has(childNode as HTMLElement | Text)) {
       continue; // Keep used elements
     }
-    
-    // Remove unused DOM elements
+    if (childNode.nodeType === Node.TEXT_NODE) {
+      continue; // Keep text nodes (vnode.text or primitive text children)
+    }
+
+    // Remove unused DOM elements (HTMLElement only)
     if (childNode instanceof HTMLElement) {
       // Component unmount (only if sid exists)
       const sid = childNode.getAttribute(DOMAttribute.BC_SID);
@@ -797,13 +802,13 @@ export function removeStaleChildren(
           }
         }
         }
-        }
       }
-    
+
       try {
-      host.removeChild(childNode);
+        host.removeChild(childNode);
       } catch {
         // May have already been removed
+      }
     }
   }
 }

--- a/packages/renderer-dom/test/core/fiber-reconcile-edge-cases.test.ts
+++ b/packages/renderer-dom/test/core/fiber-reconcile-edge-cases.test.ts
@@ -179,16 +179,6 @@ describe('reconcileWithFiber - Edge Cases', () => {
 
       reconcileWithFiber(container, vnode, undefined, {}, deps);
 
-      // eslint-disable-next-line no-console
-      console.log('Container HTML:', container.innerHTML);
-      // eslint-disable-next-line no-console
-      console.log('All decorator elements:', Array.from(container.querySelectorAll('[data-decorator-sid="d-highlight"]')).map(el => ({
-        tag: el.tagName,
-        parent: el.parentElement?.tagName,
-        text: el.textContent,
-        innerHTML: el.innerHTML
-      })));
-
       // Decorator element should exist
       // NOTE: Current reconciler may create separate decorator elements for text nodes in children
       const decoratorElements = container.querySelectorAll('[data-decorator-sid="d-highlight"]');


### PR DESCRIPTION
removeStaleChildren was removing all nodes not in usedDomElements, including Text nodes created by handleVNodeTextProperty (vnode.text) and processPrimitiveTextChildren. Text nodes have no Fiber, so they were incorrectly removed.

- Skip removing childNode when nodeType === Node.TEXT_NODE.
- Fixes fiber-reconcile-edge-cases.test.ts: vnode.text and primitive text (before/after) assertions now pass.
- Remove debug console.log from edge-cases test.

Closes #39

Made with [Cursor](https://cursor.com)