### PR TITLE
docs(docs-site): clarify footer copyright wording

### DIFF
--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -123,7 +123,7 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} Barocss Editor. Built with Docusaurus.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Barocss Editor. Documentation built with Docusaurus.`,
     },
     prism: {
       theme: prismThemes.github,


### PR DESCRIPTION
Change footer copyright from 'Built with Docusaurus' to 'Documentation built with Docusaurus' for Barocss Editor branding.

Made with [Cursor](https://cursor.com)