### PR TITLE
docs: spec verification first + package-scoped tests + documentation guidance

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -65,7 +65,7 @@ Full role list and invocation: see "Agent roles (sub-agents)" below and **`docs/
 
 ## Single command: "What needs to be done? Proceed."
 
-When the user says **"What needs to be done? Proceed."** (or equivalent), do the following in order.
+When the user says **"What needs to be done? Proceed."** or **"Proceed with the next task."** or **"다음 할일 진행해줘"** (or equivalent), do the following in order. **Always run spec verification first** (step 3 below) before the full flow.
 
 ### 1. Determine "what needs to be done"
 
@@ -83,6 +83,14 @@ When the user says **"What needs to be done? Proceed."** (or equivalent), do the
 Reply with one short line: **"Current task: [issue title] (issue #N)"** (e.g. "Current task: Add insertList (issue #5)"). Then continue to step 3.
 
 ### 3. Proceed
+
+**Spec verification first**: Before (or as part of) the full flow, run **spec verification** so that the next task starts from a known-good state and failures are interpreted against the spec.
+
+1. **Run tests for the scope of the current task**:
+   - **If the current issue targets a specific package** (e.g. issue title contains "renderer-dom", "fix(test): renderer-dom", or a package name), run **that package's tests only**: `pnpm --filter @barocss/<package> test -- --run` (e.g. `pnpm --filter @barocss/renderer-dom test -- --run`). This focuses spec verification on the package in scope.
+   - **Otherwise**: Run tests for the repo (`pnpm test`) or per-package in order per **`docs/internal-logic-validation.md`**.
+2. **If any test fails**: Follow **§7.1 Spec verification when tests fail** — locate the spec for the failing behavior (`docs/specs/`, `packages/<name>/SPEC.md`), compare spec vs test expectation, treat spec as source of truth, then fix the test or the implementation. Do not change code or test without consulting the spec first.
+3. **Then** run the full flow for the current task (issue) in role order.
 
 Run the **full flow** for that task, in role order:
 

--- a/docs/agent-roles-and-orchestration.md
+++ b/docs/agent-roles-and-orchestration.md
@@ -6,11 +6,12 @@ This doc defines **role-based sub-agents** so that work can be split and run in 
 
 ## 0. Single entry: "What needs to be done? Proceed."
 
-When the user says **"What needs to be done? Proceed."** (or equivalent), the agent should:
+When the user says **"What needs to be done? Proceed."** or **"Proceed with the next task."** or **"다음 할일 진행해줘"** (or equivalent), the agent should:
 
 1. **Determine next task**: **Backlog = GitHub issues.** List open issues (`gh issue list --state open`). Pick the first open issue (or one labeled `next`). **If none (no open issues)**: do **not** stop. Run **Research Agent** (research other editors and materials, suggest what we need, output draft issues) → **Backlog Agent** (create GitHub issues from draft) → pick the **first new issue**, then continue to step 2. If `gh` is not available, run Research Agent only and show draft issue bodies so the user can create issues manually.
 2. **Report**: "Current task: [issue title] (issue #N)".
-3. **Proceed**: Run the full flow for that task (Spec → Implementation → Test → E2E → GitHub, or Implementation → Test → E2E → GitHub if the issue already has a checklist). Use the role definitions in this doc (§2). Do not stop between roles unless a handback is needed (e.g. tests fail). When the PR is merged with "Closes #N", the issue is closed automatically.
+3. **Spec verification first**: Before the full flow, run **spec verification**: run tests for the scope of the current task. If the issue targets a specific package (e.g. "fix(test): renderer-dom — foo.test.ts"), run **that package's tests only**: `pnpm --filter @barocss/<package> test -- --run` (e.g. `pnpm --filter @barocss/renderer-dom test -- --run`). Otherwise run full repo tests (`pnpm test`) or per-package in order per `docs/internal-logic-validation.md`. If any test fails, consult the spec for the failing behavior (`docs/specs/`, `packages/<name>/SPEC.md`) and follow the spec-first rule (fix test if test is wrong, fix code if spec is correct and code is wrong). See **AGENTS.md** §7.1.
+4. **Proceed**: Run the full flow for that task (Spec → Implementation → Test → E2E → GitHub, or Implementation → Test → E2E → GitHub if the issue already has a checklist). Use the role definitions in this doc (§2). Do not stop between roles unless a handback is needed (e.g. tests fail). When the PR is merged with "Closes #N", the issue is closed automatically.
 
 Full procedure is in **`.cursor/AGENTS.md`** § "Single command: What needs to be done? Proceed.".
 

--- a/docs/internal-logic-validation.md
+++ b/docs/internal-logic-validation.md
@@ -157,6 +157,16 @@ When doing internal logic validation, **always** create GitHub issues for failur
 
 Validation flow: **run tests in order → report pass/fail → create issues for every failure (mandatory) → fix per issue (branch, fix, verify, commit, PR, merge)**.
 
+### 3.4 Spec verification documentation
+
+How to record spec verification so agents and humans stay aligned:
+
+- **Docs (recommended for process)**: Write **when** to run verification, **order** (e.g. per-package or full), and **how** to interpret failures (spec-first rule). Keep in AGENTS.md, agent-roles-and-orchestration.md, and this doc. Docs are the single place for workflow and handoffs.
+- **Don'ts (recommended for mistakes to avoid)**: Record **do-not** rules (e.g. "do not change code without consulting spec first", "do not merge locally"). Short, scannable lists in AGENTS.md or a dedicated "Don'ts" section reduce repeated mistakes.
+- **Comments (use sparingly in code)**: Use comments only for **non-obvious "why"** (e.g. why this assertion matches the spec, why this shape). Avoid long or obvious comments; they go stale. Prefer updating the spec or test description over commenting around the code.
+
+Prefer **docs + don'ts** for spec verification; use **comments** only where the code would be misleading without them.
+
 ---
 
 ## 4. Summary


### PR DESCRIPTION
Agent and spec verification docs:

- AGENTS.md: run spec verification first on 'Proceed with next task'; when issue targets a package (e.g. fix(test): renderer-dom), run that package's tests only.
- agent-roles-and-orchestration.md: same rules.
- internal-logic-validation.md: add §3.4 Spec verification documentation — recommend docs for process, don'ts for mistakes to avoid, comments sparingly for non-obvious why.

Made with [Cursor](https://cursor.com)