### PR TITLE
fix(test): mark-range-verification — use stype for splitTextByMarks

### DIFF
--- a/packages/renderer-dom/test/core/mark-range-verification.test.ts
+++ b/packages/renderer-dom/test/core/mark-range-verification.test.ts
@@ -11,7 +11,7 @@ describe('Mark Range Verification', () => {
   it('should correctly split text by mark range [0, 16] for "yellow background" (17 chars)', () => {
     const text = 'yellow background';
     const marks = [{
-      type: 'bgColor',
+      stype: 'bgColor',
       range: [0, 16] as [number, number],
       attrs: { bgColor: '#ffff00' }
     }];
@@ -60,7 +60,7 @@ describe('Mark Range Verification', () => {
   it('should correctly split text by mark range [0, 18] for "yellow bㅁackground" (18 chars)', () => {
     const text = 'yellow bㅁackground';
     const marks = [{
-      type: 'bgColor',
+      stype: 'bgColor',
       range: [0, 18] as [number, number],
       attrs: { bgColor: '#ffff00' }
     }];
@@ -100,7 +100,7 @@ describe('Mark Range Verification', () => {
   it('should handle mark range that covers entire text', () => {
     const text = 'yellow background';
     const marks = [{
-      type: 'bgColor',
+      stype: 'bgColor',
       range: [0, text.length] as [number, number],
       attrs: { bgColor: '#ffff00' }
     }];


### PR DESCRIPTION
Tests in mark-range-verification.test.ts were failing because splitTextByMarks uses `stype` (IMark); tests passed `type`. Align test to pass `stype` so runs.types includes the mark type.

Closes #48

Made with [Cursor](https://cursor.com)