### PR TITLE
fix(test): model — selection-manager-advanced, transaction-commit (#122)

### DIFF
--- a/packages/model/test/operations/selection-manager-advanced.test.ts
+++ b/packages/model/test/operations/selection-manager-advanced.test.ts
@@ -37,15 +37,15 @@ describe('SelectionManager Advanced Features', () => {
       }
     });
 
-    dataStore = new DataStore();
+    dataStore = new DataStore(undefined, schema);
     selectionManager = new SelectionManager({ dataStore });
 
-    // Set up test nodes
-    dataStore.setNode({ id: 'doc-1', type: 'document', content: ['para-1', 'para-2'] });
-    dataStore.setNode({ id: 'para-1', type: 'paragraph', content: ['text-1'] });
-    dataStore.setNode({ id: 'text-1', type: 'inline-text', text: 'Hello World', parentId: 'para-1' });
-    dataStore.setNode({ id: 'para-2', type: 'paragraph', content: ['text-2'] });
-    dataStore.setNode({ id: 'text-2', type: 'inline-text', text: 'Goodbye Universe', parentId: 'para-2' });
+    // Set up test nodes (DataStore uses sid/stype)
+    dataStore.setNode({ sid: 'doc-1', stype: 'document', content: ['para-1', 'para-2'] });
+    dataStore.setNode({ sid: 'para-1', stype: 'paragraph', content: ['text-1'] });
+    dataStore.setNode({ sid: 'text-1', stype: 'inline-text', text: 'Hello World', parentId: 'para-1' });
+    dataStore.setNode({ sid: 'para-2', stype: 'paragraph', content: ['text-2'] });
+    dataStore.setNode({ sid: 'text-2', stype: 'inline-text', text: 'Goodbye Universe', parentId: 'para-2' });
     
     // Clear selection before each test
     selectionManager.clearSelection();
@@ -57,6 +57,7 @@ describe('SelectionManager Advanced Features', () => {
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 0,
         endNodeId: 'text-1',
@@ -75,12 +76,12 @@ describe('SelectionManager Advanced Features', () => {
     it('should select all text from first to last node', () => {
       selectionManager.selectAll();
       const selection = selectionManager.getCurrentSelection();
-      // selectAll behavior: select from first to last node
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 0,
         endNodeId: 'text-2',
-        endOffset: 16 // "Another text".length
+        endOffset: 16 // "Goodbye Universe".length
       });
     });
   });
@@ -92,6 +93,7 @@ describe('SelectionManager Advanced Features', () => {
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 0,
         endNodeId: 'text-1',
@@ -105,6 +107,7 @@ describe('SelectionManager Advanced Features', () => {
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 5,
         endNodeId: 'text-1',
@@ -120,6 +123,7 @@ describe('SelectionManager Advanced Features', () => {
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 0,
         endNodeId: 'text-1',
@@ -133,6 +137,7 @@ describe('SelectionManager Advanced Features', () => {
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 11, // "Hello World".length
         endNodeId: 'text-1',
@@ -148,6 +153,7 @@ describe('SelectionManager Advanced Features', () => {
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 8,
         endNodeId: 'text-1',
@@ -161,6 +167,7 @@ describe('SelectionManager Advanced Features', () => {
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 5,
         endNodeId: 'text-1',
@@ -175,6 +182,7 @@ describe('SelectionManager Advanced Features', () => {
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 0,
         endNodeId: 'text-1',
@@ -187,6 +195,7 @@ describe('SelectionManager Advanced Features', () => {
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 0,
         endNodeId: 'text-1',
@@ -201,6 +210,7 @@ describe('SelectionManager Advanced Features', () => {
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 5,
         endNodeId: 'text-1',
@@ -212,12 +222,13 @@ describe('SelectionManager Advanced Features', () => {
   describe('selectLine', () => {
     it('should select line containing position', () => {
       // Add line breaks to text
-      dataStore.setNode({ id: 'text-3', type: 'inline-text', text: 'Line 1\nLine 2\nLine 3', parentId: 'para-1' });
+      dataStore.setNode({ sid: 'text-3', stype: 'inline-text', text: 'Line 1\nLine 2\nLine 3', parentId: 'para-1' });
       
       selectionManager.selectLine('text-3', 8); // Inside "Line 2"
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-3',
         startOffset: 7, // Start of "Line 2"
         endNodeId: 'text-3',
@@ -275,6 +286,7 @@ describe('SelectionManager Advanced Features', () => {
       
       const selection = selectionManager.getCurrentSelection();
       expect(selection).toEqual({
+        type: 'range',
         startNodeId: 'text-1',
         startOffset: 2,
         endNodeId: 'text-1',

--- a/packages/model/test/transaction/transaction-commit.test.ts
+++ b/packages/model/test/transaction/transaction-commit.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { DataStore } from '@barocss/datastore';
 import { Schema } from '@barocss/schema';
-import { transaction, node } from '../../src/transaction-dsl';
+import { transaction, node, textNode } from '../../src/transaction-dsl';
 import { create } from '../../src/operations-dsl/create';
 import { SelectionManager } from '@barocss/editor-core';
 import { TransactionManager } from '../../src/transaction';
@@ -32,7 +32,6 @@ describe('Transaction Commit', () => {
     dataStore = new DataStore(undefined, schema);
     const selectionManager = new SelectionManager({ dataStore });
 
-    // Mock DataStore methods to track calls
     originalAcquireLock = dataStore.acquireLock;
     originalReleaseLock = dataStore.releaseLock;
     originalBegin = dataStore.begin;
@@ -40,22 +39,24 @@ describe('Transaction Commit', () => {
     originalCommit = dataStore.commit;
     originalRollback = dataStore.rollback;
 
-    dataStore.acquireLock = vi.fn().mockResolvedValue('lock-sid-123');
-    dataStore.releaseLock = vi.fn().mockResolvedValue(undefined);
-    dataStore.begin = vi.fn().mockReturnValue(undefined);
-    dataStore.end = vi.fn().mockReturnValue(undefined);
-    dataStore.commit = vi.fn().mockReturnValue(undefined);
-    dataStore.rollback = vi.fn().mockReturnValue(undefined);
+    dataStore.acquireLock = vi.fn().mockImplementation(() => Promise.resolve('lock-sid-123'));
+    dataStore.releaseLock = vi.fn().mockImplementation(() => Promise.resolve(undefined));
+    dataStore.begin = vi.fn().mockImplementation(originalBegin);
+    dataStore.end = vi.fn().mockImplementation(originalEnd);
+    dataStore.commit = vi.fn().mockImplementation(originalCommit);
+    dataStore.rollback = vi.fn().mockImplementation(originalRollback);
 
     mockEditor = {
       dataStore,
       _dataStore: dataStore,
-      selectionManager
+      selectionManager,
+      emit: vi.fn(),
+      updateSelection: vi.fn(),
+      historyManager: { push: vi.fn() }
     };
   });
 
   afterEach(() => {
-    // Restore original methods
     dataStore.acquireLock = originalAcquireLock;
     dataStore.releaseLock = originalReleaseLock;
     dataStore.begin = originalBegin;
@@ -67,7 +68,7 @@ describe('Transaction Commit', () => {
   describe('TransactionManager Integration', () => {
     it('should use TransactionManager for commit', async () => {
       const builder = transaction(mockEditor, [
-        create(node('inline-text', 'Hello World'))
+        create(textNode('inline-text', 'Hello World'))
       ]);
 
       const result = await builder.commit();
@@ -81,23 +82,23 @@ describe('Transaction Commit', () => {
 
     it('should pass operations to TransactionManager', async () => {
       const operations = [
-        create(node('inline-text', 'Hello')),
-        create(node('inline-text', 'World'))
+        create(textNode('inline-text', 'Hello')),
+        create(textNode('inline-text', 'World'))
       ];
 
       const builder = transaction(mockEditor, operations);
       const result = await builder.commit();
 
-      // operations now include result field; compare types and payload.node
-      expect(result.operations?.map(o => ({ type: o.type, nodeType: o.payload.node.type })))
-        .toEqual(operations.map(o => ({ type: o.type, nodeType: (o as any).payload.node.type })));
+      // operations now include result field; compare types and payload.node.stype
+      expect(result.operations?.map(o => ({ type: o.type, nodeType: o.payload.node.stype })))
+        .toEqual(operations.map(o => ({ type: o.type, nodeType: (o as any).payload.node.stype })));
     });
   });
 
   describe('Lock Management', () => {
     it('should acquire lock before transaction', async () => {
       const builder = transaction(mockEditor, [
-        create(node('inline-text', 'Test'))
+        create(textNode('inline-text', 'Test'))
       ]);
 
       await builder.commit();
@@ -107,7 +108,7 @@ describe('Transaction Commit', () => {
 
     it('should release lock after transaction', async () => {
       const builder = transaction(mockEditor, [
-        create(node('inline-text', 'Test'))
+        create(textNode('inline-text', 'Test'))
       ]);
 
       await builder.commit();
@@ -123,7 +124,7 @@ describe('Transaction Commit', () => {
       });
 
       const builder = transaction(mockEditor, [
-        create(node('inline-text', 'Test'))
+        create(textNode('inline-text', 'Test'))
       ]);
 
       const result = await builder.commit();
@@ -139,7 +140,7 @@ describe('Transaction Commit', () => {
   describe('DataStore Transaction Lifecycle', () => {
     it('should call begin() before operations', async () => {
       const builder = transaction(mockEditor, [
-        create(node('inline-text', 'Test'))
+        create(textNode('inline-text', 'Test'))
       ]);
 
       await builder.commit();
@@ -149,7 +150,7 @@ describe('Transaction Commit', () => {
 
     it('should call end() and commit() after successful operations', async () => {
       const builder = transaction(mockEditor, [
-        create(node('inline-text', 'Test'))
+        create(textNode('inline-text', 'Test'))
       ]);
 
       await builder.commit();
@@ -166,7 +167,7 @@ describe('Transaction Commit', () => {
       });
 
       const builder = transaction(mockEditor, [
-        create(node('inline-text', 'Test'))
+        create(textNode('inline-text', 'Test'))
       ]);
 
       await builder.commit();
@@ -181,7 +182,7 @@ describe('Transaction Commit', () => {
   describe('Schema Propagation', () => {
     it('should set schema on TransactionManager', async () => {
       const builder = transaction(mockEditor, [
-        create(node('inline-text', 'Test'))
+        create(textNode('inline-text', 'Test'))
       ]);
 
       const result = await builder.commit();
@@ -201,7 +202,7 @@ describe('Transaction Commit', () => {
       });
 
       const builder = transaction(mockEditor, [
-        create(node('inline-text', 'Test'))
+        create(textNode('inline-text', 'Test'))
       ]);
 
       const result = await builder.commit();
@@ -217,7 +218,7 @@ describe('Transaction Commit', () => {
       dataStore.acquireLock = vi.fn().mockRejectedValue(new Error('Lock acquisition failed'));
 
       const builder = transaction(mockEditor, [
-        create(node('inline-text', 'Test'))
+        create(textNode('inline-text', 'Test'))
       ]);
 
       const result = await builder.commit();
@@ -230,7 +231,7 @@ describe('Transaction Commit', () => {
   describe('Transaction Result', () => {
     it('should return success result for valid operations', async () => {
       const builder = transaction(mockEditor, [
-        create(node('inline-text', 'Hello World'))
+        create(textNode('inline-text', 'Hello World'))
       ]);
 
       const result = await builder.commit();


### PR DESCRIPTION
Fixes #122

- selection-manager-advanced.test.ts: DataStore sid/stype, schema; getCurrentSelection() expects type: 'range'
- transaction-commit.test.ts: textNode for inline-text; payload.node.stype; real begin/end/commit; mockEditor.emit, updateSelection, historyManager.push

selection-manager-advanced: 20 tests pass. transaction-commit: 13 tests pass.

Made with [Cursor](https://cursor.com)