### PR TITLE
fix(test): model — range shape (type: range) and DataStore sid/stype (#124)

### DIFF
--- a/packages/model/src/operations-dsl/applyMark.ts
+++ b/packages/model/src/operations-dsl/applyMark.ts
@@ -55,7 +55,7 @@ export const applyMark = defineOperationDSL(
     // cross-node: (startId, startOffset, endId, endOffset, markType, attrs?)
     if (args.length >= 5 && typeof args[0] === 'string' && typeof args[2] === 'string' && typeof args[4] === 'string') {
       const [startId, startOffset, endId, endOffset, markType, attrs] = args as [string, number, string, number, string, (Record<string, any>)?];
-      return { type: 'applyMark', payload: { range: { startNodeId: startId, startOffset, endNodeId: endId, endOffset }, markType, attrs } } as unknown as ApplyMarkOperationPayload;
+      return { type: 'applyMark', payload: { range: { type: 'range' as const, startNodeId: startId, startOffset, endNodeId: endId, endOffset }, markType, attrs } } as unknown as ApplyMarkOperationPayload;
     }
     // direct single-node: (nodeId, start, end, markType, attrs?)
     const [nodeId, start, end, markType, attrs] = args as [string, number, number, string, (Record<string, any>)?];

--- a/packages/model/src/operations-dsl/replaceText.ts
+++ b/packages/model/src/operations-dsl/replaceText.ts
@@ -23,7 +23,7 @@ type ReplaceTextOperationPayload =
     }
   | {
       type: 'replaceText';
-      range: { startNodeId: string; startOffset: number; endNodeId: string; endOffset: number };
+      range: { type: 'range'; startNodeId: string; startOffset: number; endNodeId: string; endOffset: number };
       newText: string;
     }
   | {
@@ -43,7 +43,7 @@ export const replaceText = defineOperationDSL(
     // cross-node: (startId, startOffset, endId, endOffset, newText)
     if (args.length === 5 && typeof args[0] === 'string' && typeof args[2] === 'string') {
       const [startId, startOffset, endId, endOffset, newText] = args as [string, number, string, number, string];
-      return { type: 'replaceText', payload: { range: { startNodeId: startId, startOffset, endNodeId: endId, endOffset }, newText } } as unknown as ReplaceTextOperationPayload;
+      return { type: 'replaceText', payload: { range: { type: 'range' as const, startNodeId: startId, startOffset, endNodeId: endId, endOffset }, newText } } as unknown as ReplaceTextOperationPayload;
     }
     // direct single-node: (nodeId, start, end, newText)
     const [nodeId, start, end, newText] = args as [string, number, number, string];

--- a/packages/model/src/operations/replacePattern.ts
+++ b/packages/model/src/operations/replacePattern.ts
@@ -96,7 +96,7 @@ export const replacePattern = defineOperationDSL(
     // cross-node
     if (args.length === 6 && typeof args[0] === 'string' && typeof args[2] === 'string') {
       const [startId, startOffset, endId, endOffset, pattern, replacement] = args as [string, number, string, number, (string | RegExp), string];
-      return { type: 'replacePattern', payload: { range: { startNodeId: startId, startOffset, endNodeId: endId, endOffset }, pattern, replacement } } as unknown as ReplacePatternOperationPayload;
+      return { type: 'replacePattern', payload: { range: { type: 'range' as const, startNodeId: startId, startOffset, endNodeId: endId, endOffset }, pattern, replacement } } as unknown as ReplacePatternOperationPayload;
     }
     // direct single-node
     const [nodeId, start, end, pattern, replacement] = args as [string, number, number, (string | RegExp), string];

--- a/packages/model/test/operations/replacePattern.exec.test.ts
+++ b/packages/model/test/operations/replacePattern.exec.test.ts
@@ -27,25 +27,25 @@ describe('replacePattern operation (exec)', () => {
   });
 
   it('replaces pattern in single-node range', async () => {
-    dataStore.setNode({ id: 't', type: 'inline-text', text: 'foo bar foo' });
+    dataStore.setNode({ sid: 't', stype: 'inline-text', text: 'foo bar foo' });
     const op = globalOperationRegistry.get('replacePattern');
-    const count = await op!.execute({ type: 'replacePattern', nodeId: 't', start: 0, end: 11, pattern: /foo/g, replacement: 'baz' } as any, context);
-    expect(count).toBeGreaterThan(0);
+    const result = await op!.execute({ type: 'replacePattern', nodeId: 't', start: 0, end: 11, pattern: /foo/g, replacement: 'baz' } as any, context) as { ok?: boolean; data?: number };
+    expect(result?.data).toBeGreaterThan(0);
     expect(dataStore.getNode('t')?.text).toBe('baz bar baz');
   });
 
   it('replaces pattern across nodes via range payload', async () => {
-    dataStore.setNode({ id: 'root', type: 'paragraph', content: ['a', 'b'] } as any);
-    dataStore.setNode({ id: 'a', type: 'inline-text', text: 'hello ', parentId: 'root' });
-    dataStore.setNode({ id: 'b', type: 'inline-text', text: 'world', parentId: 'root' });
+    dataStore.setNode({ sid: 'root', stype: 'paragraph', content: ['a', 'b'] } as any);
+    dataStore.setNode({ sid: 'a', stype: 'inline-text', text: 'hello ', parentId: 'root' });
+    dataStore.setNode({ sid: 'b', stype: 'inline-text', text: 'world', parentId: 'root' });
     // Ensure iterator traverses the tree starting from this parent
     dataStore.setRoot('root');
     const op = globalOperationRegistry.get('replacePattern');
     const rng = { type: 'range' as const, startNodeId: 'a', startOffset: 0, endNodeId: 'b', endOffset: 5 };
     const before = dataStore.range.extractText(rng);
     expect(before).toBe('hello world');
-    const count = await op!.execute({ type: 'replacePattern', range: rng, pattern: /(hello|world)/g, replacement: 'X' } as any, context);
-    expect(count).toBeGreaterThanOrEqual(0);
+    const result = await op!.execute({ type: 'replacePattern', range: rng, pattern: /(hello|world)/g, replacement: 'X' } as any, context) as { ok?: boolean; data?: number };
+    expect(result?.data).toBeGreaterThanOrEqual(0);
     const after = dataStore.range.extractText(rng);
     expect(after).toBe('X X');
   });

--- a/packages/model/test/operations/replaceText.exec.test.ts
+++ b/packages/model/test/operations/replaceText.exec.test.ts
@@ -24,7 +24,7 @@ describe('replaceText operation (exec)', () => {
   });
 
   it('replaces text in single node range and returns deleted segment', async () => {
-    dataStore.setNode({ id: 't1', type: 'inline-text', text: 'Hello World' });
+    dataStore.setNode({ sid: 't1', stype: 'inline-text', text: 'Hello World' });
     const op = globalOperationRegistry.get('replaceText');
     const result = await op!.execute({ type: 'replaceText', payload: { nodeId: 't1', start: 6, end: 11, newText: 'Barocss' } } as any, context);
     expect(result.data).toBe('World');
@@ -38,14 +38,14 @@ describe('replaceText operation (exec)', () => {
   });
 
   it('throws on invalid range', async () => {
-    dataStore.setNode({ id: 't1', type: 'inline-text', text: 'ABC' });
+    dataStore.setNode({ sid: 't1', stype: 'inline-text', text: 'ABC' });
     const op = globalOperationRegistry.get('replaceText');
     await expect(op!.execute({ type: 'replaceText', payload: { nodeId: 't1', start: 3, end: 2, newText: 'X' } } as any, context)).rejects.toThrow('Invalid range');
   });
 
   it('supports cross-node replacement via range payload', async () => {
-    dataStore.setNode({ id: 'a', type: 'inline-text', text: 'Hello ' });
-    dataStore.setNode({ id: 'b', type: 'inline-text', text: 'World' });
+    dataStore.setNode({ sid: 'a', stype: 'inline-text', text: 'Hello ' });
+    dataStore.setNode({ sid: 'b', stype: 'inline-text', text: 'World' });
     // DataStore is prepared to work with delete+insert in branches other than fast-path even without parent content connection
     const op = globalOperationRegistry.get('replaceText');
     const result = await op!.execute({


### PR DESCRIPTION
Fixes #124 (partial)

- DSL: add type: 'range' to cross-node range in replaceText, replacePattern, applyMark
- replaceText.exec.test.ts: sid/stype in setNode, DataStore(undefined, schema)
- replacePattern.exec.test.ts: sid/stype in setNode, assert result.data for count

replaceText.exec + replacePattern.exec: 12 tests pass. Remaining model failures (create, delete, insertText, etc.) use same pattern (sid/stype + schema) and can be fixed in follow-up.

Made with [Cursor](https://cursor.com)