### PR TITLE
fix(model): allow empty string in setText; unskip dsl-integration empty/null test

### DIFF
--- a/packages/model/src/operations/setText.ts
+++ b/packages/model/src/operations/setText.ts
@@ -61,7 +61,8 @@ export const setText = defineOperationDSL((...args: [string] | [string, string])
 // Runtime operation implementation
 defineOperation('setText', async (operation: any, context: TransactionContext) => {
   const { nodeId, text } = operation.payload;
-  if (!text) throw new Error('Text is required for setText operation');
+  if (text === undefined || text === null) throw new Error('Text is required for setText operation');
+  if (typeof text !== 'string') throw new Error('Text must be a string');
   const node = context.dataStore.getNode(nodeId);
   if (!node) throw new Error(`Node not found: ${nodeId}`);
   

--- a/packages/model/test/transaction/dsl-integration.test.ts
+++ b/packages/model/test/transaction/dsl-integration.test.ts
@@ -440,7 +440,7 @@ describe('DSL Integration Tests', () => {
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
-    it.skip('should handle empty and null values in operations', async () => {
+    it('should handle empty and null values in operations', async () => {
       const createResult = await transaction(mockEditor, [
         create(node('paragraph', {}, [createTextNode('inline-text', '')]))
       ]).commit();


### PR DESCRIPTION
## Summary
- **setText**: Accept empty string `''` as valid text; reject only `undefined`/`null` and non-string. Added `typeof text !== 'string'` check.
- **dsl-integration**: Removed `it.skip` for `should handle empty and null values in operations`; test now passes.

## Tests
- `pnpm --filter @barocss/model test -- --run`: 61 files, 367 tests passed.

Closes #129

Made with [Cursor](https://cursor.com)