### PR TITLE
fix(datastore,model): paste insertion order — unique ids when parentId set

### DIFF
--- a/packages/datastore/src/operations/core-operations.ts
+++ b/packages/datastore/src/operations/core-operations.ts
@@ -224,8 +224,12 @@ export class CoreOperations {
   createNodeWithChildren(node: INode, schema?: Schema): INode {
     const targetSchema = schema || this.dataStore.getActiveSchema();
     
-    // 1. Initialize globalCounter to current node count
-    (this.dataStore.constructor as any)._globalCounter = this.dataStore.getNodes().size;
+    // 1. Initialize globalCounter to current node count only when creating a root (no parentId).
+    // When parentId is set (e.g. deserializeNodes inserting under existing parent), do not reset
+    // so each call gets a unique id and overlay/main store size does not cause id reuse.
+    if (node.parentId == null) {
+      (this.dataStore.constructor as any)._globalCounter = this.dataStore.getNodes().size;
+    }
     
     // 2. Assign IDs to all nested objects (recursively)
     this._assignIdsRecursively(node);

--- a/packages/datastore/src/operations/serialization-operations.ts
+++ b/packages/datastore/src/operations/serialization-operations.ts
@@ -95,7 +95,7 @@ export class SerializationOperations {
       newIds.push(created.sid!);
     }
 
-    // Insert new ids into parent.content
+    // Insert new ids into parent.content (preserve input order: first node at insertAt, second at insertAt+1, ...)
     content.splice(insertAt, 0, ...newIds);
     this.dataStore.updateNode(targetParentId, { content });
 

--- a/packages/model/test/operations/paste.exec.test.ts
+++ b/packages/model/test/operations/paste.exec.test.ts
@@ -62,6 +62,8 @@ describe('paste operation', () => {
     const ids = root.content as string[];
     expect(ids.length).toBe(4);
     expect(ds.getNode(ids[0])!.text).toBe('A');
+    expect(ds.getNode(ids[1])!.text).toBe('B1');
+    expect(ds.getNode(ids[2])!.text).toBe('B2');
     expect(ds.getNode(ids[3])!.text).toBe('C');
 
     const firstOp = result.operations?.[0] as { result?: { insertedNodeIds?: string[]; newSelection?: unknown } };


### PR DESCRIPTION
## Summary
- **datastore** CoreOperations.createNodeWithChildren: reset `_globalCounter` only when `node.parentId` is null (root creation). When `parentId` is set (e.g. deserializeNodes inserting under existing parent), do not reset so each call gets a unique id; previously overlay/main store size caused id reuse (same 0:4 for B1 and B2).
- **model** paste.exec.test: assert pasted nodes order (`ids[1]=B1`, `ids[2]=B2`).

## Tests
- `pnpm --filter @barocss/model test -- --run`: 61 files, 367 tests (1 skipped).
- `pnpm --filter @barocss/datastore test -- --run`: 58 files, 780 tests (1 skipped).

Closes #131

Made with [Cursor](https://cursor.com)