### PR TITLE
fix(collaboration): vitest passWithNoTests when no test files

### DIFF
--- a/packages/collaboration/vitest.config.ts
+++ b/packages/collaboration/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['**/*.test.ts'],
+    passWithNoTests: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html']


### PR DESCRIPTION
## Summary
- `packages/collaboration/vitest.config.ts`: add `passWithNoTests: true` so `pnpm --filter @barocss/collaboration test -- --run` exits 0 when no test files exist.

Closes #133

Made with [Cursor](https://cursor.com)