### PR TITLE
fix(editor-view-dom): validate tree and throw on invalid — unskip error-handling test

### DIFF
--- a/packages/editor-view-dom/src/editor-view-dom.ts
+++ b/packages/editor-view-dom/src/editor-view-dom.ts
@@ -954,12 +954,14 @@ export class EditorViewDOM implements IEditorViewDOM {
     if (tree) {
       // Model passed from outside - already in ModelData format (uses sid, stype)
       if (!tree.stype) {
-        console.error('[EditorViewDOM] Invalid tree format: missing stype (required)');
-        return;
+        const msg = '[EditorViewDOM] Invalid tree format: missing stype (required)';
+        console.error(msg);
+        throw new Error(msg);
       }
       if (!tree.sid) {
-        console.error('[EditorViewDOM] Invalid tree format: missing sid (required)');
-        return;
+        const msg = '[EditorViewDOM] Invalid tree format: missing sid (required)';
+        console.error(msg);
+        throw new Error(msg);
       }
       // Use directly without conversion
       modelData = tree as ModelData;

--- a/packages/editor-view-dom/test/integration/error-handling-integration.test.ts
+++ b/packages/editor-view-dom/test/integration/error-handling-integration.test.ts
@@ -43,7 +43,7 @@ describe('EditorViewDOM + renderer-dom Error Handling Integration', () => {
   });
 
   describe('Invalid stype Handling', () => {
-    it.skip('handles missing stype gracefully', () => {
+    it('handles missing stype gracefully', () => {
       const tree: any = {
         sid: 'doc1',
         // No stype
@@ -57,6 +57,7 @@ describe('EditorViewDOM + renderer-dom Error Handling Integration', () => {
     });
 
     it.skip('handles unregistered stype gracefully', () => {
+      // Renderer does not throw for unregistered node type; validation not implemented
       const tree: TreeDocument = {
         sid: 'doc1',
         stype: 'document',
@@ -69,7 +70,6 @@ describe('EditorViewDOM + renderer-dom Error Handling Integration', () => {
         ]
       };
       
-      // Error occurs in VNodeBuilder if stype is missing
       expect(() => {
         view.render(tree);
       }).toThrow('Renderer for node type \'unknown-type\' not found');

--- a/packages/editor-view-dom/test/integration/renderer-dom-detailed-integration.test.ts
+++ b/packages/editor-view-dom/test/integration/renderer-dom-detailed-integration.test.ts
@@ -422,11 +422,10 @@ describe('EditorViewDOM + renderer-dom Detailed Integration', () => {
         // No stype
         content: []
       };
-      
-      // Should throw error or show warning
+
       expect(() => {
         view.render(tree);
-      }).not.toThrow(); // Or appropriate error handling
+      }).toThrow('[EditorViewDOM] Invalid tree format: missing stype (required)');
     });
 
     it('handles invalid tree structure', () => {


### PR DESCRIPTION
Throw when tree has missing stype/sid; unskip 'handles missing stype gracefully'; align renderer-dom-detailed-integration expectation. Closes #155.

Made with [Cursor](https://cursor.com)