### PR TITLE
fix(editor-view-dom): validate tree node stype against registry — unskip unregistered stype test

### DIFF
--- a/packages/editor-view-dom/src/editor-view-dom.ts
+++ b/packages/editor-view-dom/src/editor-view-dom.ts
@@ -926,6 +926,27 @@ export class EditorViewDOM implements IEditorViewDOM {
     return this.selectionHandler.convertStaticRangeToModel(staticRange);
   }
 
+  /**
+   * Recursively validate that every node in the tree has a registered renderer for its stype.
+   * Throws if any node's stype is not found in the registry.
+   */
+  private _validateTreeStypes(node: any, registry: RendererRegistry): void {
+    if (!node || typeof node !== 'object') return;
+    const stype = node.stype;
+    if (stype != null && stype !== '') {
+      const def = registry.get(stype);
+      if (!def) {
+        throw new Error(`Renderer for node type '${stype}' not found`);
+      }
+    }
+    const content = node.content;
+    if (Array.isArray(content)) {
+      for (const child of content) {
+        this._validateTreeStypes(child, registry);
+      }
+    }
+  }
+
   // External render API
   render(tree?: ModelData | any, options?: { sync?: boolean }): void {
     if (!this._domRenderer) {
@@ -962,6 +983,9 @@ export class EditorViewDOM implements IEditorViewDOM {
         const msg = '[EditorViewDOM] Invalid tree format: missing sid (required)';
         console.error(msg);
         throw new Error(msg);
+      }
+      if (this._rendererRegistry) {
+        this._validateTreeStypes(tree, this._rendererRegistry);
       }
       // Use directly without conversion
       modelData = tree as ModelData;

--- a/packages/editor-view-dom/test/integration/error-handling-integration.test.ts
+++ b/packages/editor-view-dom/test/integration/error-handling-integration.test.ts
@@ -56,8 +56,7 @@ describe('EditorViewDOM + renderer-dom Error Handling Integration', () => {
       }).toThrow('[EditorViewDOM] Invalid tree format: missing stype (required)');
     });
 
-    it.skip('handles unregistered stype gracefully', () => {
-      // Renderer does not throw for unregistered node type; validation not implemented
+    it('handles unregistered stype gracefully', () => {
       const tree: TreeDocument = {
         sid: 'doc1',
         stype: 'document',


### PR DESCRIPTION
## Summary
- Add `_validateTreeStypes()` to recursively validate every node's `stype` against the renderer registry before rendering.
- Throw `Renderer for node type 'X' not found` when an unregistered `stype` is encountered.
- Unskip `handles unregistered stype gracefully` in `error-handling-integration.test.ts`.

Closes #157

Made with [Cursor](https://cursor.com)