### PR TITLE
fix(test): add minimal test files to collaboration packages per internal-logic-validation §3.2

### DIFF
--- a/packages/collaboration-liveblocks/test/liveblocks-adapter.test.ts
+++ b/packages/collaboration-liveblocks/test/liveblocks-adapter.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { LiveblocksAdapter } from '../src/liveblocks-adapter';
+
+describe('LiveblocksAdapter', () => {
+  it('can be constructed with room', () => {
+    const room = {};
+    const adapter = new LiveblocksAdapter({ room });
+    expect(adapter).toBeDefined();
+    expect(adapter.isConnected()).toBe(false);
+  });
+
+  it('accepts config with clientId', () => {
+    const room = {};
+    const adapter = new LiveblocksAdapter({
+      room,
+      config: { clientId: 'test-client' }
+    });
+    expect(adapter.isConnected()).toBe(false);
+  });
+});

--- a/packages/collaboration-yjs/test/yjs-adapter.test.ts
+++ b/packages/collaboration-yjs/test/yjs-adapter.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { YjsAdapter } from '../src/yjs-adapter';
+
+describe('YjsAdapter', () => {
+  it('can be constructed with ydoc and optional ymap', () => {
+    const ydoc = { getMap: (name: string) => ({ _name: name }) };
+    const adapter = new YjsAdapter({ ydoc });
+    expect(adapter).toBeDefined();
+    expect(adapter.isConnected()).toBe(false);
+  });
+
+  it('accepts config with clientId', () => {
+    const ydoc = { getMap: () => ({}) };
+    const adapter = new YjsAdapter({
+      ydoc,
+      config: { clientId: 'test-client' }
+    });
+    expect(adapter.isConnected()).toBe(false);
+  });
+});

--- a/packages/collaboration/test/base-adapter.test.ts
+++ b/packages/collaboration/test/base-adapter.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { BaseAdapter } from '../src/base-adapter';
+import type { DataStore, AtomicOperation } from '@barocss/datastore';
+import type { INode } from '@barocss/datastore';
+
+/** Minimal concrete adapter for testing BaseAdapter behavior */
+class TestAdapter extends BaseAdapter {
+  protected async doConnect(): Promise<void> {}
+  protected async doDisconnect(): Promise<void> {}
+  protected async doSendOperation(_operation: AtomicOperation): Promise<void> {}
+  protected async doReceiveOperation(_operation: AtomicOperation): Promise<void> {}
+  protected async doGetDocumentState(): Promise<INode | null> {
+    return null;
+  }
+  protected async doSetDocumentState(_rootNode: INode): Promise<void> {}
+}
+
+describe('BaseAdapter', () => {
+  it('is not connected after construction', () => {
+    const adapter = new TestAdapter();
+    expect(adapter.isConnected()).toBe(false);
+  });
+
+  it('accepts config and preserves debug default', () => {
+    const adapter = new TestAdapter({ debug: true });
+    expect(adapter.isConnected()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `packages/collaboration/test/base-adapter.test.ts`: TestAdapter (concrete BaseAdapter), isConnected, config
- `packages/collaboration-yjs/test/yjs-adapter.test.ts`: YjsAdapter constructor, isConnected
- `packages/collaboration-liveblocks/test/liveblocks-adapter.test.ts`: LiveblocksAdapter constructor, isConnected

Per `docs/internal-logic-validation.md` §3.2 when a package has test:run but no test files.

Closes #165

Made with [Cursor](https://cursor.com)