### PR TITLE
feat(renderer-react): spec, tests, README, and docs

### DIFF
--- a/.cursor/skills/README.md
+++ b/.cursor/skills/README.md
@@ -17,6 +17,7 @@ Skills in this directory are **per-package**. The agent uses them when working o
 | `package-extensions` | @barocss/extensions | Extension interface, command registration |
 | `package-model` | @barocss/model | Transaction DSL, document operations |
 | `package-renderer-dom` | @barocss/renderer-dom | DSL → DOM rendering |
+| `package-renderer-react` | @barocss/renderer-react | DSL → React (ModelData + Registry → ReactNode); spec in package docs |
 | `package-schema` | @barocss/schema | Document schema definition |
 | `package-shared` | @barocss/shared | Platform, key string, i18n |
 | `package-text-analyzer` | @barocss/text-analyzer | Text change analysis (LCP/LCS) |

--- a/.cursor/skills/package-renderer-react/SKILL.md
+++ b/.cursor/skills/package-renderer-react/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: package-renderer-react
+description: React renderer for Barocss DSL (ModelData + Registry → ReactNode). Use when changing renderer-react, adding tests, or integrating with editor-view-react.
+---
+
+# @barocss/renderer-react
+
+## Scope
+
+- **Rendering**: Same input as renderer-dom (`RendererRegistry` + `ModelData`). Output is **ReactNode** only (no VNode, no DOM reconciliation in this package).
+- **Pipeline**: `buildToReact(registry, model.stype, model)` → `React.createElement`; element/slot/data and marks resolved from DSL.
+- **Dependency**: `@barocss/dsl` only; React is peer. **No** dependency on `@barocss/renderer-dom`.
+- **Consumers**: `@barocss/editor-view-react` (EditorViewContentLayer uses ReactRenderer.build).
+
+## Spec and rules
+
+1. **Spec**: All behavior and test strategy are in **`packages/renderer-react/docs/renderer-react-spec.md`**. Read it before implementing or changing behavior; update it when contract or behavior changes.
+2. **Identity**: Every node must have `key={model.sid}` and `data-bc-sid` / `data-bc-stype` on the root element so React and the view layer can reconcile and apply selection.
+3. **Selection**: This package does **not** preserve or apply selection. The view layer (editor-view-react) applies ModelSelection to DOM after render (e.g. after `editor:content.change`).
+4. **Marks**: Use `splitTextByMarks(text, model.marks)` and `registry.getMarkRenderer(markType)`; wrap runs with the resolved element (e.g. strong, em). Same semantics as renderer-dom; see spec §5.
+5. **Do not** depend on renderer-dom or VNode types. **Do not** use array index as key when `model.sid` is available.
+
+## Quick reference
+
+- Package: `packages/renderer-react/`
+- Entry: `ReactRenderer`, `buildToReact`; utils: `splitTextByMarks` (utils/marks.ts)
+- Spec: `packages/renderer-react/docs/renderer-react-spec.md`
+- Tests: Add under `packages/renderer-react/test/`; run with `pnpm --filter @barocss/renderer-react test:run` (add `test:run` script and vitest config if missing).
+- Integration: `packages/editor-view-react` (EditorViewContentLayer), `apps/editor-react` (React app using EditorView).
+
+## When to use this skill
+
+- Adding or changing `buildToReact`, `ReactRenderer`, or mark rendering.
+- Adding unit tests for renderer-react (splitTextByMarks, buildToReact output shape).
+- Aligning renderer-react behavior with the spec (selection stability, keys, marks).
+- Integrating or fixing editor-view-react content layer (selection after render, registry/model shape).

--- a/docs/renderer-react-and-editor-react.md
+++ b/docs/renderer-react-and-editor-react.md
@@ -1,14 +1,14 @@
-# renderer-react 및 editor-react 설계
+# renderer-react and editor-react Design
 
-## 목표
+## Goals
 
-- **renderer-react**: DSL(define/element/slot/data 등)로 정의한 템플릿을 **React만** 사용해 렌더링. 입력은 renderer-dom과 동일하게 `RendererRegistry` + `ModelData`.
-- **editor-react**: renderer-react로 에디터 컨텐츠를 렌더링하고, 편집 동작은 renderer-dom과 비슷한 형태로 동작하도록 할 앱(테스트/검증용).
+- **renderer-react**: Render templates defined with the DSL (`define`, `element`, `slot`, `data`, etc.) using **React only**. Input is the same as renderer-dom: `RendererRegistry` + `ModelData`.
+- **editor-react**: An app (for testing/validation) that renders editor content with renderer-react and behaves like renderer-dom for editing (contenteditable, selection, input).
 
-## 아키텍처
+## Architecture
 
-- **renderer-dom**: DOM 기반. VNode는 “DOM 위에 React처럼 쓰기 위한” 중간 표현. `DSL → VNodeBuilder → VNode → Reconciler → DOM`.
-- **renderer-react**: React 기반. React가 이미 가상 트리를 갖고 있으므로 VNode를 둘 필요 없음. **DSL → ReactBuilder → ReactNode** 로 직접 연결.
+- **renderer-dom**: DOM-based. VNode is an intermediate representation for “writing on top of DOM in a React-like way.” Pipeline: `DSL → VNodeBuilder → VNode → Reconciler → DOM`.
+- **renderer-react**: React-based. React already has a virtual tree, so VNode is unnecessary. **DSL → ReactBuilder → ReactNode** directly.
 
 ```
 DSL (define, element, slot, data, ...)
@@ -16,19 +16,19 @@ DSL (define, element, slot, data, ...)
 RendererRegistry (nodeType → RendererDefinition)
         ↓
 renderer-dom:  ModelData → VNodeBuilder → VNode → Reconciler → DOM
-renderer-react: ModelData → buildToReact(registry, stype, model) → ReactNode  (VNode 없음)
+renderer-react: ModelData → buildToReact(registry, stype, model) → ReactNode  (no VNode)
 ```
 
-- **renderer-react**: `@barocss/renderer-dom`에 의존하지 않음. `@barocss/dsl`만 사용. 레지스트리에서 템플릿을 가져와 element/slot/data를 해석하고 `React.createElement`로 React 트리를 직접 만듦.
-- **편집**: editor-view-dom과 유사하게 contenteditable + selection/input 처리. editor-react 앱에서는 먼저 **읽기 전용** 또는 **단순 contenteditable 래퍼**로 검증 후, 필요 시 editor-view-react(또는 editor-view-dom과 동일한 입력 레이어 재사용)로 확장.
+- **renderer-react**: Does not depend on `@barocss/renderer-dom`. Uses only `@barocss/dsl`. It fetches templates from the registry, interprets element/slot/data, and builds a React tree directly with `React.createElement`.
+- **Editing**: Similar to editor-view-dom—contenteditable plus selection/input handling. The editor-react app is validated first as **read-only** or a **simple contenteditable wrapper**; then, if needed, it can be extended with editor-view-react (or by reusing the same input layer as editor-view-dom).
 
-## 패키지 역할
+## Package Roles
 
-| 패키지 | 역할 |
+| Package | Role |
 |--------|------|
-| **packages/renderer-react** | `ReactRenderer(registry).build(model)` → `ReactNode`. DSL 템플릿을 해석해 React 트리만 생성 (VNode/renderer-dom 미사용). **react/react-dom은 번들에 포함하지 않음** (peerDependencies, build 시 external). |
-| **packages/editor-view-react** | (필요 시) editor-view-dom의 React 대응. React 트리 + contenteditable/selection/input을 React 친화적으로 묶는 뷰 레이어. |
-| **apps/editor-react** | Vite+React 앱. 동일한 schema/define/initialTree로 ReactRenderer로 문서를 그리며, renderer-react 동작을 테스트. |
+| **packages/renderer-react** | `ReactRenderer(registry).build(model)` → `ReactNode`. Interprets DSL templates and produces only a React tree (no VNode, no renderer-dom). **react/react-dom are not bundled** (peerDependencies, external at build time). |
+| **packages/editor-view-react** | (Optional) React counterpart of editor-view-dom. View layer that wraps React tree + contenteditable/selection/input in a React-friendly way. |
+| **apps/editor-react** | Vite + React app. Renders a document with the same schema/define/initialTree using ReactRenderer, and tests renderer-react behavior. |
 
 ## renderer-react API
 
@@ -45,10 +45,10 @@ const renderer = new ReactRenderer(registry);
 const reactNode = renderer.build(model); // ModelData → ReactNode
 ```
 
-- `ReactRenderer` 옵션: `name?` (디버깅용). decorator/context는 추후 확장.
-- 내부: `buildToReact(registry, model.stype, model)` — element/slot/data/attr 해석 후 `React.createElement` 호출.
+- **ReactRenderer options**: `name?` (for debugging). Decorator/context can be extended later.
+- **Internals**: `buildToReact(registry, model.stype, model)` — resolves element/slot/data/attr and calls `React.createElement`.
 
-## 파일 구조
+## File Structure
 
 ```
 packages/renderer-react/
@@ -57,7 +57,7 @@ packages/renderer-react/
   src/
     index.ts
     react-renderer.ts   # ReactRenderer class
-    build-to-react.ts   # DSL → ReactNode (element/slot/data 해석)
+    build-to-react.ts  # DSL → ReactNode (element/slot/data resolution)
 
 apps/editor-react/
   package.json
@@ -66,18 +66,18 @@ apps/editor-react/
   tsconfig.json
   src/
     main.tsx
-    App.tsx             # registry + initialTree + ReactRenderer.build
+    App.tsx            # registry + initialTree + ReactRenderer.build
 ```
 
-## editor-view-react (필요 시)
+## editor-view-react (Optional)
 
-- **editor-view-dom**: DOM 레이어. DOMRenderer + contenteditable + selection/input 이벤트.
-- **editor-view-react**: 필요하면 editor-view-dom과 비슷한 형태로, React 쪽 대응 패키지를 둘 수 있음.
-  - 역할: React 트리(renderer-react) + contenteditable/selection/input을 React 컴포넌트/훅으로 제공.
-  - 의존: `@barocss/editor-core`, `@barocss/renderer-react`, `react`, `react-dom` 등. editor-view-dom과 동일한 Editor/DataStore/Registry 모델을 공유.
-  - 구현 시점: editor-react 앱에서 읽기 전용이 아닌 편집이 필요해지거나, React 앱에서 에디터를 컴포넌트로 써야 할 때.
+- **editor-view-dom**: DOM layer. DOMRenderer + contenteditable + selection/input events.
+- **editor-view-react**: If needed, a React counterpart package similar to editor-view-dom.
+  - **Role**: Expose React tree (renderer-react) + contenteditable/selection/input as React components/hooks.
+  - **Dependencies**: `@barocss/editor-core`, `@barocss/renderer-react`, `react`, `react-dom`, etc. Shares the same Editor/DataStore/Registry model as editor-view-dom.
+  - **When to implement**: When the editor-react app needs editing (not just read-only), or when the editor must be used as a component in a React app.
 
-## 편집과의 관계
+## Relation to Editing
 
-- renderer-dom: contenteditable DOM 위에 Reconciler가 패치. selection/input은 editor-view-dom에서 DOM 이벤트로 처리.
-- renderer-react: React가 트리를 그리므로, 편집 시에는 (1) React 트리를 contenteditable 컨테이너 안에 두고 DOM selection/input을 그대로 쓰거나, (2) **editor-view-react**에서 React 친화적인 입력 레이어를 두는 방식이 가능. 1차는 (1)로 동일한 입력 모델을 재사용하는 방향을 전제로 함.
+- **renderer-dom**: The Reconciler patches the contenteditable DOM. Selection/input are handled by editor-view-dom via DOM events.
+- **renderer-react**: React renders the tree, so for editing either (1) put the React tree inside a contenteditable container and use DOM selection/input as-is, or (2) add a React-friendly input layer in **editor-view-react**. The first approach assumes reusing the same input model (1) as the baseline.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -27,6 +27,11 @@ This directory and the linked package specs define **what the editor and each pa
 - **`packages/model/SPEC.md`** — Model: transaction, operations (inputs/outputs, invariants), selection resolution. Exec tests in `packages/model/test/operations/*.exec.test.ts` are the concrete spec for each operation.
 - Other packages: add `packages/<name>/SPEC.md` when the package has a clear contract (API, invariants, or behavior that other packages or tests rely on). List new specs here and in `.cursor/AGENTS.md`.
 
+### Package specs (in package directories)
+
+- **`packages/renderer-dom/docs/renderer-dom-spec.md`** — renderer-dom: VNode, reconciliation, marks, decorators.
+- **`packages/renderer-react/docs/renderer-react-spec.md`** — renderer-react: DSL→React, selection considerations, marks, tests, implementation plan.
+
 ### Existing docs that act as specs
 
 - **`docs/dom/portal-system-spec.md`** — Portal system (renderer-dom): goals, API, behavior.

--- a/packages/renderer-react/README.md
+++ b/packages/renderer-react/README.md
@@ -19,27 +19,59 @@ const reactNode = renderer.build(model); // ModelData → ReactNode
 
 ## How it works
 
-- **Input**: Same as renderer-dom — `RendererRegistry` (from `define(...)`) and `ModelData` (document tree with `sid`, `stype`, `content`, etc.).
-- **Pipeline**: **DSL only**. `buildToReact(registry, model.stype, model)` reads the template from the registry, walks element/slot/data (and attr/data bindings), and calls `React.createElement` to build the tree. No VNode, no dependency on renderer-dom.
+- **Input**: Same as renderer-dom — `RendererRegistry` (from `define(...)`) and `ModelData` (document tree with `sid`, `stype`, `content`, `text`, `marks`, etc.).
+- **Pipeline**: **DSL only**. `buildToReact(registry, model.stype, model)` reads the template via `registry.get(nodeType)`, walks element/slot/data (and attr/data bindings, function children), and calls `React.createElement` to build the tree. No VNode, no dependency on renderer-dom.
 - **Output**: `ReactNode` (usable with JSX or `createRoot().render()`).
 - **Bundle**: `react` and `react-dom` are **not** included in the build output; they are peer dependencies. The host app must provide them.
 
+## Supported DSL
+
+| Feature | Supported |
+|--------|-----------|
+| `element(tag, attrs, children)` | Yes; dynamic tag `(d) => string`, `data(path)`, `attr(key)`, `className`/`style` from model. |
+| `slot('content')` | Yes; expands to `model.content` children. |
+| `data('text')`, `data(path, defaultValue)`, `data(getter)` | Yes; marks applied only for `data('text')` (or getter yielding string) when `model.marks` exists. |
+| `attr(key)`, `attr(key, defaultValue)` | Yes; resolves to `model.attributes[key]`. |
+| Child as function `(d) => element(...)` | Yes; flattened and built. |
+| `defineMark(type, template)` | Yes; template can be ElementTemplate or ComponentTemplate (component returns element). |
+| Contextual component (template as function) | Yes; minimal context stub; override via `options.contextStub`. |
+| External component (`managesDOM`) | Yes; placeholder div with `data-bc-sid`, `data-bc-stype`. |
+| `when()` / `each()` | **No**; build does not throw but conditional/iterated content is not rendered. |
+
 ## API
 
-- **`ReactRenderer(registry?, options?)`**  
-  - `registry`: Optional; if omitted, uses `getGlobalRegistry()` from `@barocss/dsl`.  
+- **`ReactRenderer(registry?, options?)`**
+  - `registry`: Optional; if omitted, uses `getGlobalRegistry()` from `@barocss/dsl`.
   - `options.name`: Debug name.
 
+- **`renderer.getRegistry()`**  
+  Returns the `RendererRegistry` passed to the constructor.
+
 - **`renderer.build(model)`**  
-  Returns `ReactNode`.  
-  - `model`: Must have `stype` (and usually `sid`, `content`).
+  Returns `ReactNode` (or `null` if template resolves to non-element).
+  - `model`: Must have `stype`; typically `sid`, `content`, `text`, `marks`, `attributes` as needed by templates.
 
 - **`buildToReact(registry, nodeType, model, options?)`**  
   Exported for advanced use: builds a single node (and its children) to `ReactNode`.
+  - `options.contextStub`: Optional partial `ComponentContext` for contextual components.
+
+**Exports**: `ReactRenderer`, `buildToReact`, `ReactRendererOptions`.
+
+## Identity and selection
+
+Every node is rendered with `key={model.sid}` and `data-bc-sid`, `data-bc-stype` on its root element so that React reconciles by identity and the view layer (e.g. editor-view-react) can map model selection (sid + offset) to DOM. Selection preservation is **not** implemented in this package; it is the view layer’s responsibility.
 
 ## Testing
 
-Use **apps/editor-react** to run a small React app that renders a document with `ReactRenderer` (read-only). From repo root:
+Unit tests (Vitest) are in `packages/renderer-react/test/`:
+
+```bash
+pnpm --filter @barocss/renderer-react test:run
+```
+
+Tests cover: buildToReact / ReactRenderer.build, slot expansion, data/text and marks (including overlapping, unregistered mark), attributes (including attr, className object, style), contextual component and contextStub, managesDOM placeholder, defineMark with ComponentTemplate, when()/each() unsupported, splitTextByMarks (empty, global, range, overlap, clamp, invalid range), and full document tree with marks.
+
+To run the React app that uses the renderer (read-only document):
 
 ```bash
 pnpm --filter @barocss/editor-react dev
@@ -47,6 +79,7 @@ pnpm --filter @barocss/editor-react dev
 
 ## See also
 
+- **packages/renderer-react/docs/renderer-react-spec.md** — Full spec: concepts, difference from renderer-dom, selection, marks, test checklist, implementation plan.
 - **docs/renderer-react-and-editor-react.md** — Design and editor-react app plan.
 - **packages/renderer-dom** — DOM renderer (VNode + Reconciler); separate pipeline.
 - **packages/dsl** — DSL types and `RendererRegistry`.

--- a/packages/renderer-react/docs/SPEC_VERIFICATION.md
+++ b/packages/renderer-react/docs/SPEC_VERIFICATION.md
@@ -1,0 +1,63 @@
+# renderer-react: Spec vs Implementation Verification
+
+This document records the result of verifying the implementation against `renderer-react-spec.md`.
+
+---
+
+## 1. Verification Summary
+
+| Spec requirement | Status | Notes |
+|-----------------|--------|--------|
+| **§1–2** Same input (Registry + ModelData), React-only output, no renderer-dom dep | ✅ | buildToReact + React.createElement; deps: dsl, react peer. |
+| **§2.2** key = model.sid, data-bc-sid, data-bc-stype on root | ✅ | buildElement sets props.key, data-bc-sid, data-bc-stype. |
+| **§2.3** Lookup: registry.get(nodeType) or equivalent; throw if not found | ✅ **Fixed** | Was using registry.getComponent(nodeType), which does not resolve define() templates (stored in _renderers). Switched to registry.get(nodeType). |
+| **§2.3** Element/slot/data resolution | ✅ | processChildren: slot → model.content + buildToReact; data → text/marks; element → buildElement. |
+| **§2.3** Contextual component: minimal context stub | ✅ | makeMinimalContext provides registry.getComponent, getState/setState no-ops. |
+| **§2.3** External (managesDOM): placeholder | ✅ | createElement('div', { key, data-bc-sid, data-bc-stype }, 'Component'). |
+| **§4** No selection logic in renderer-react | ✅ | No selection context or restore. |
+| **§5** splitTextByMarks: boundaries, global + ranged marks, types per run | ✅ | utils/marks.ts: boundaries from range clamp; types from global + overlapping ranged. |
+| **§5** getMarkRenderer(markType), buildMarkRunToReact, stable keys | ✅ | resolveMarkTemplate; key = `${keyBase}_${markType}_${i}`. |
+| **§5** Unregistered mark: skip wrapper, text still rendered | ✅ | if (!elementTmpl) continue; inner stays. |
+| **§6.1** ReactRenderer.build(model): requires model.stype, calls buildToReact | ✅ | Throws if !model?.stype; returns buildToReact(registry, model.stype, model). |
+| **§6.2** buildToReact(registry, nodeType, model, options?) | ✅ | contextStub optional; minimal context used when resolving contextual. |
+| **§10** No array index as key when sid available | ✅ | key = model.sid; mark run key = sid_r${ri}, mark wrapper key = keyBase_markType_i. |
+| **§10** No renderer-dom dependency | ✅ | Only @barocss/dsl and react. |
+
+---
+
+## 2. Bug Fixed
+
+- **Registry lookup**: Implementation used `registry.getComponent(nodeType)`. In DSL, `define(nodeType, element(...))` stores the definition in `_renderers` via `register()`. `getComponent(nodeType)` only looks at `_components`, so it returned `undefined` for all define()‑registered node types. **Fix**: Use `registry.get(nodeType)` and then `def.template`. `get()` returns a definition from either `_renderers` or (wrapped) `_components`.
+
+---
+
+## 3. Gaps / Not Yet Implemented (per spec)
+
+- **§8 / Phase 1**: Done — `test:run` script, vitest config, and unit tests for splitTextByMarks and buildToReact added.
+- **§7** when() / each(): Not in buildToReact (spec says “not in current buildToReact”).
+- **§7** Decorators, portals, component state: Out of scope (spec).
+
+---
+
+## 4. Checklist (spec §8.4) – Implementation vs Tests
+
+| Item | Implementation | Tests |
+|------|----------------|-------|
+| build(model) returns ReactNode when registered | ✅ | ✅ build-to-react.test.ts |
+| build(model) throws when stype missing / unregistered | ✅ | ✅ build-to-react.test.ts |
+| Root has key, data-bc-sid, data-bc-stype | ✅ | ✅ build-to-react.test.ts |
+| slot('content') expands; children have key/data-bc-* | ✅ | ✅ build-to-react.test.ts |
+| data('text') no marks → text (or span) | ✅ | (covered by slot test) |
+| data('text') with marks → split runs, wrappers | ✅ | (not yet; add when needed) |
+| splitTextByMarks: global, range, overlap, clamp | ✅ | ✅ split-text-by-marks.test.ts |
+| Unregistered mark → skip wrapper, text present | ✅ | (not yet; add when needed) |
+| Contextual component → context stub, correct output | ✅ | (not yet; add when needed) |
+
+---
+
+## 5. Next Steps
+
+1. ~~Add `test:run` and vitest config to renderer-react (Phase 1).~~ Done.
+2. ~~Add unit tests for splitTextByMarks (no React).~~ Done: test/split-text-by-marks.test.ts.
+3. ~~Add unit tests for buildToReact / ReactRenderer.build (prop assertions).~~ Done: test/build-to-react.test.ts.
+4. Optional: add tests for data('text') with marks, unregistered mark skip, contextual component.

--- a/packages/renderer-react/docs/renderer-react-spec.md
+++ b/packages/renderer-react/docs/renderer-react-spec.md
@@ -1,0 +1,308 @@
+# renderer-react Specification
+
+This document defines the spec for `@barocss/renderer-react`: goals, concepts, differences from renderer-dom, selection/mark behavior, test strategy, and implementation plan.
+
+**Status**: Phase 1–3 implemented and covered by tests (Vitest). See §8.4 Checklist and §9 Implementation Plan.
+
+---
+
+## Table of Contents
+
+1. [Goals and Scope](#1-goals-and-scope)
+2. [Concepts](#2-concepts)
+3. [Difference from renderer-dom](#3-difference-from-renderer-dom)
+4. [Selection Considerations](#4-selection-considerations)
+5. [Mark Rendering](#5-mark-rendering)
+6. [API Contract](#6-api-contract)
+7. [Out of Scope (Current vs Future)](#7-out-of-scope-current-vs-future)
+8. [Test Strategy and Required Tests](#8-test-strategy-and-required-tests)
+9. [Implementation Plan](#9-implementation-plan)
+10. [Prohibited / Careful Practices](#10-prohibited--careful-practices)
+
+---
+
+## 1. Goals and Scope
+
+### 1.1 Goals
+
+- **Same input as renderer-dom**: `RendererRegistry` + `ModelData`. Templates are defined with the same DSL (`define`, `element`, `slot`, `data`, `attr`, `defineMark`). Child functions `(d) => element(...)` are supported; `when()` and `each()` are not (see §7).
+- **React-only output**: Produce `ReactNode` directly. No VNode; no DOM reconciliation inside this package.
+- **No dependency on renderer-dom**: Depends only on `@barocss/dsl`. React is a peer dependency.
+- **Parity where meaningful**: Element/slot/data and marks should behave like renderer-dom’s semantics (same template → equivalent structure). Reconciliation and selection are the responsibility of React and the view layer, not renderer-react.
+
+### 1.2 Scope
+
+| In scope | Out of scope (view / other packages) |
+|----------|--------------------------------------|
+| ModelData → ReactNode from registry + stype | DOM reconciliation, fiber, commit phase |
+| element / slot / data resolution | Selection preservation (editor-view-react or app) |
+| Marks: splitTextByMarks + getMarkRenderer → wrapped elements | Decorators (layer/inline/block) — future |
+| data-bc-sid, data-bc-stype on root of each node | Component state (mount/update/unmount) — future |
+| External/contextual component stub (placeholder or thin bridge) | Portals |
+| Key stability (sid as key) for React reconciliation | Actual DOM selection restore |
+
+---
+
+## 2. Concepts
+
+### 2.1 Pipeline
+
+```
+ModelData + RendererRegistry
+    → buildToReact(registry, model.stype, model)
+    → ReactNode tree (React.createElement)
+```
+
+- **No VNode**: React’s own virtual tree is the only intermediate representation.
+- **Same DSL**: `element`, `slot('content')`, `data('text')`, `data('path')`, attribute bindings. Resolved the same way as renderer-dom’s builder for element/slot/data.
+- **Node identity**: Every node that has `model.sid` is rendered with `key={model.sid}` and `data-bc-sid`, `data-bc-stype` so that:
+  - React can reconcile by identity.
+  - The view layer can map ModelSelection (sid + offset) to DOM when applying selection.
+
+### 2.2 Identity and Keys
+
+- **key**: Use `(model as any).sid` for the React `key` of the top-level element for each model node. Required for stable reconciliation and to avoid unnecessary re-mounts that would disturb selection.
+- **data-bc-sid / data-bc-stype**: Attached to the root DOM element of each node so that:
+  - View layer can resolve `sid` → DOM node for selection application.
+  - Debugging and tests can assert on structure.
+
+### 2.3 Template Resolution
+
+- **Lookup**: `registry.get(nodeType)` returns the definition (from `define()` or `registerComponent()`). If not found or no template, throw a clear error.
+- **Element template**: `element(tag, attrs, children)` → `React.createElement(tag, props, ...children)` with children resolved recursively (slot → model.content, data → text/marks, function children flattened).
+- **Contextual component**: If template is a function `(props, model, context)`, call it with a minimal context stub (registry, getState/setState no-ops or minimal impl) and use the returned `ElementTemplate` for building. Custom context can be passed via `options.contextStub`.
+- **External component (managesDOM)**: Renders a placeholder div with `data-bc-sid`, `data-bc-stype`, and `className: 'react-renderer-external-placeholder'`. Full lifecycle is out of scope.
+
+---
+
+## 3. Difference from renderer-dom
+
+| Aspect | renderer-dom | renderer-react |
+|--------|--------------|----------------|
+| **Intermediate representation** | VNode tree | None (direct React tree) |
+| **Reconciliation** | Custom fiber: render phase + commit phase, sid-based matching | React’s own reconciliation (key = sid) |
+| **Selection** | Optional selection context + TextNodePool; restore after commit | No selection logic; view must apply selection after render (e.g. editor-view-react) |
+| **Marks** | VNodeBuilder splits text by marks, builds mark wrappers; reconciler commits | splitTextByMarks + getMarkRenderer; build mark wrappers with React.createElement |
+| **Decorators** | VNode decorator metadata, pattern/custom decorators, layer rendering | Not in initial scope; can be added later |
+| **Component state** | ComponentManager, mount/update/unmount, state registry | Stub or minimal; full state can be added later |
+| **Portals** | Portal handler in reconciler | Out of scope initially |
+| **Dependencies** | dsl, text-run-index, etc. | dsl only (+ React peer) |
+
+**Summary**: renderer-react is “DSL → React” only. No VNode, no DOM reconciliation, no selection preservation inside the package. Parity is in “same model + same registry → same logical structure (elements, slots, data, marks)”. Stability (keys, data-bc-sid) is so that the view layer and React can keep DOM stable and apply selection correctly.
+
+---
+
+## 4. Selection Considerations
+
+### 4.1 Why It Matters
+
+- On every React re-render, the content tree may be replaced or updated. If nodes are re-mounted (e.g. missing or changing keys), DOM selection can be lost or shifted.
+- The view layer (e.g. editor-view-react) is responsible for applying ModelSelection to DOM after content or selection changes. It uses `data-bc-sid` and offset to find the correct text node and offset.
+
+### 4.2 What renderer-react Must Do
+
+1. **Stable keys**: Use `model.sid` as React `key` for the root element of each model node so that React reuses DOM when the same node is still present.
+2. **Stable attributes**: Emit `data-bc-sid` and `data-bc-stype` on the root element of each node so the view layer can resolve selection (sid → element, then offset in text).
+3. **No arbitrary remounts**: Avoid changing keys or structure in a way that would force React to remount nodes that are still the same logical node (same sid). For example, do not use array index as key when sid is available.
+
+### 4.3 What renderer-react Does Not Do
+
+- It does **not** receive or apply selection context.
+- It does **not** preserve or restore DOM selection. That is the responsibility of editor-view-react (or the app) after render: e.g. subscribe to `editor:selection.model` and apply selection after `editor:content.change` and after React has committed (e.g. in requestAnimationFrame or useEffect).
+
+### 4.4 View-Layer Checklist (editor-view-react / app)
+
+- After content change: update document snapshot and let React re-render; then apply current ModelSelection to DOM (e.g. convert model selection to DOM range and set range on selection).
+- Optionally set `skipApplyModelSelectionToDOM` during a render or batch to avoid fighting with React.
+- Use the same registry and model shape as editor-view-dom so that sid/stype semantics are consistent.
+
+---
+
+## 5. Mark Rendering
+
+### 5.1 Semantics (Same as renderer-dom)
+
+- Marks apply to **text** only. Model has `marks: Array<{ stype: string; range?: [number, number]; attrs?: Record<string, unknown> }>`.
+- **range**: `[start, end]` in character offsets. Omitted or global marks apply to the whole text.
+- Multiple marks can overlap; text is split into **runs** at boundaries, and each run gets the set of mark types that cover it.
+
+### 5.2 Algorithm
+
+1. **splitTextByMarks(text, marks)**  
+   - Input: `text: string`, `marks` array.  
+   - Output: `TextRun[]` where each run has `{ start, end, text, types?: string[] }`.  
+   - Boundaries: 0, text.length, and all range start/end clamped to [0, text.length].  
+   - For each run, collect all mark types that overlap that range (global marks + ranged marks overlapping [start, end]).
+
+2. **getMarkRenderer(markType)**  
+   - Registry returns a template for the mark (e.g. from `defineMark('bold', element('strong', {}, ...))`).  
+   - Template can be ElementTemplate or ComponentTemplate; resolve to an element (tag + attrs) for wrapping.
+
+3. **buildMarkRunToReact(registry, run, model, keyBase)**  
+   - Inner content: run.text (string).  
+   - For each type in `run.types` (innermost to outermost), get mark template, resolve to element, wrap: `createElement(tag, { ...attrs, key }, inner)`.  
+   - Result: one React node (possibly nested elements) for that run.
+
+4. **Integration in processChildren**  
+   - When processing `data('text')` (or equivalent data path that yields text):  
+     - If `model.marks` exists and is non-empty, call `splitTextByMarks(text, model.marks)` and then for each run either push `run.text` (no marks) or `buildMarkRunToReact(...)` (with marks).  
+     - Otherwise push the text string.
+
+### 5.3 Rules
+
+- Mark templates are resolved via `registry.getMarkRenderer(markType)`. If a mark type has no registered template, that mark is skipped for wrapping (text still rendered).
+- Keys for mark wrappers must be stable (e.g. `${keyBase}_${markType}_${i}`) so React does not remount unnecessarily.
+- Do not add or assume classes like `mark-{stype}` unless the user’s template includes them; use only the template’s tag and attributes.
+
+---
+
+## 6. API Contract
+
+### 6.1 ReactRenderer
+
+```ts
+class ReactRenderer {
+  constructor(registry?: RendererRegistry, options?: ReactRendererOptions);
+  getRegistry(): RendererRegistry;
+  build(model: ModelData): ReactNode;
+}
+```
+
+- **build(model)**  
+  - Requires `model.stype`.  
+  - Calls `buildToReact(registry, model.stype, model)`.  
+  - Returns a single ReactNode (or null if unsupported template).
+
+### 6.2 buildToReact
+
+```ts
+function buildToReact(
+  registry: RendererRegistry,
+  nodeType: string,
+  model: ModelData,
+  options?: { contextStub?: Partial<ComponentContext> }
+): ReactNode;
+```
+
+- **registry**: Same registry used by renderer-dom (define/element/slot/data/defineMark).
+- **nodeType**: Usually `model.stype`.
+- **model**: Full model node (sid, stype, content, text, marks, attributes, etc.).
+- **contextStub**: Optional; used when resolving contextual components. If not provided, a minimal stub is used (getState/setState no-ops, registry getComponent only).
+
+### 6.3 Exports
+
+- `ReactRenderer`, `buildToReact`, `ReactRendererOptions`.
+- Mark utils (`splitTextByMarks`, `TextRun`, `TextMark`) can be exported for tests or shared use.
+
+---
+
+## 7. Out of Scope (Current vs Future)
+
+| Feature | Current | Future |
+|---------|---------|--------|
+| Decorators (inline/block/layer) | Not implemented | Define API: decorator list passed in? Rendered in same tree or overlay? |
+| Component state (mount/update/unmount) | Stub only | ComponentManager-like state in React (e.g. useRef/useState per sid) |
+| Portals | No | Optional portal(target, node) support |
+| when() / each() | **Not supported**. Templates with `when()` or `each()` do not throw; conditional/iterated content is not rendered (processChildren does not handle `type === 'conditional'` or `type === 'each'`). | Add if parity with renderer-dom is required. |
+| Selection preservation inside renderer | No | Never; stays in view layer |
+
+---
+
+## 8. Test Strategy and Required Tests
+
+### 8.1 Principles
+
+- **Spec-first**: Tests assert behavior described in this spec (identity, keys, marks, slot expansion, data resolution).
+- **No implementation detail**: Prefer asserting on output structure (e.g. React tree shape, presence of key/data-bc-sid) rather than internal functions.
+- **Parity**: Where possible, use the same model + registry as renderer-dom tests and assert equivalent structure (e.g. same nesting, same marks on text).
+
+### 8.2 Required Test Categories
+
+1. **Unit: buildToReact / ReactRenderer.build**
+   - Model with stype only (minimal node): returns one element with correct tag, key, data-bc-sid, data-bc-stype.
+   - Model with content: slot('content') expands to children; each child has correct key and data-bc-*.
+   - Model with text and no marks: data('text') produces text node (or wrapped in span if that’s the template).
+   - Model with text and marks: splitTextByMarks + getMarkRenderer produce correct wrapper elements (strong, em, etc.) and keys.
+   - Missing stype or unregistered stype: throws with clear message.
+   - Contextual component: receives minimal context, returns element template, build produces React node.
+
+2. **Unit: splitTextByMarks (utils/marks)**
+   - Empty text / no marks: returns [] or single run.
+   - Global mark only: single run with that type.
+   - Single range mark: boundaries correct, run.types correct.
+   - Overlapping marks: multiple runs, each run has correct types.
+   - Clamp: range beyond [0, len] clamped.
+
+3. **Integration: React tree shape**
+   - Given a document model (document > paragraph > inline-text with marks), assert root has key and data-bc-sid; children are present; text runs with marks are wrapped (e.g. strong/em).
+
+4. **Integration: editor-view-react (in app or package)**
+   - Document renders without error.
+   - After content change, React updates; selection can be applied by view layer (manual or automated test that applies model selection and reads back DOM selection).
+
+### 8.3 Test Environment
+
+- **React Test Renderer** (or similar) to get a tree from `renderer.build(model)` and assert on node types, props (key, data-bc-sid, data-bc-stype), and children.
+- **Vitest** for unit tests; optional React Testing Library or editor-react E2E for integration.
+
+### 8.4 Checklist (Concrete)
+
+- [x] ReactRenderer(registry).build(model) returns ReactNode when model.stype is defined and registered.
+- [x] build(model) throws when model.stype is missing or not registered.
+- [x] Root element has key = model.sid and data-bc-sid, data-bc-stype.
+- [x] slot('content') expands model.content; each child built with buildToReact(registry, child.stype, child).
+- [x] data('text') with no marks renders text (or single span with text).
+- [x] data('text') with marks renders split runs; runs with types use getMarkRenderer and wrap with correct tag.
+- [x] splitTextByMarks: global mark, single range, overlapping ranges, clamp; range with end ≤ start skipped.
+- [x] Unregistered mark type: that mark is skipped (no wrapper), text still present.
+- [x] Contextual component receives context stub and returns element; build outputs correct React node.
+- [x] options.contextStub passed to buildToReact is used for contextual component.
+- [x] data(path, defaultValue) and attr(key, defaultValue) use defaultValue when value is null/undefined.
+- [x] defineMark with ComponentTemplate (component returns element) wraps text run in that element.
+- [x] managesDOM template renders placeholder div with data-bc-sid, data-bc-stype.
+- [x] buildToReact returns null when ComponentTemplate’s component() returns non-element.
+- [x] when() / each() in template: build does not throw; conditional/iterated content is not rendered.
+
+---
+
+## 9. Implementation Plan
+
+### Phase 1: Spec and test harness — Done
+
+- [x] Write this spec (renderer-react-spec.md).
+- [x] Add `test:run` script and vitest config to renderer-react.
+- [x] Add tests for splitTextByMarks (empty text, no marks, global/single range/overlapping/clamp, invalid range).
+- [x] Add tests for buildToReact and ReactRenderer.build (minimal node, slot, data, marks, stype validation, contextual, attributes, deep tree, integration with marks).
+
+### Phase 2: Parity and stability — Done
+
+- [x] All nodes use `key={model.sid}` and `data-bc-sid` / `data-bc-stype`.
+- [x] Mark rendering aligned with splitTextByMarks + getMarkRenderer (ElementTemplate and ComponentTemplate); mark run keys `${sid}_r${ri}_${markType}_${i}`.
+- [x] Minimal context stub for contextual components; options.contextStub overridable.
+
+### Phase 3: Gaps and edge cases — Done
+
+- [x] ExternalComponent (managesDOM): placeholder div with data-bc-sid, data-bc-stype, className.
+- [x] when() / each(): documented as unsupported; build does not throw; conditional/iterated content not rendered.
+- [x] Error messages: missing stype → ReactRenderer throws "model must have stype property"; unregistered nodeType → buildToReact throws "No renderer for node type '...'. Register with define()."
+
+### Phase 4: Integration and selection — Future
+
+- [ ] editor-view-react: after content change, apply model selection in a stable way (e.g. useEffect + requestAnimationFrame).
+- [ ] Optional E2E in editor-react: type, change selection, assert DOM selection or cursor position.
+
+### Phase 5: Optional extensions — Future
+
+- [ ] Decorators: define API (e.g. decorators array passed to build) and implement inline or layer decorators.
+- [ ] Component state: define API (e.g. state registry per sid) and implement with React state/refs.
+
+---
+
+## 10. Prohibited / Careful Practices
+
+- **Do not** use array index as React key when `model.sid` is available.
+- **Do not** add selection preservation logic inside renderer-react; it belongs in the view layer.
+- **Do not** depend on renderer-dom or VNode types in renderer-react.
+- **Do not** mutate model or registry inside buildToReact.
+- **Be careful** with contextual component context: provide a minimal stub so that templates that call context.getState/setState do not throw; actual state persistence can be added later.
+- **Be careful** with mark keys: ensure keys are unique per run (e.g. sid + run index + mark type) so that React does not reuse the wrong wrapper when content changes.

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -15,7 +15,9 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite build --watch",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "peerDependencies": {
     "react": ">=18.0.0"
@@ -32,7 +34,8 @@
     "react-dom": "^19.0.0",
     "typescript": "^5.9.3",
     "vite": "^5.4.21",
-    "vite-plugin-dts": "^3.9.1"
+    "vite-plugin-dts": "^3.9.1",
+    "vitest": "^4.0.7"
   },
   "keywords": ["renderer", "react", "dsl", "editor"],
   "author": "Barocss Team",

--- a/packages/renderer-react/src/build-to-react.ts
+++ b/packages/renderer-react/src/build-to-react.ts
@@ -118,7 +118,7 @@ function flattenChildren(children: ElementChild[], data: ModelData): ElementChil
 
 /**
  * Build ReactNode from (registry, nodeType, model).
- * Uses registry.getComponent(nodeType) to get template; resolves element/slot/data to React.
+ * Uses registry.get(nodeType) to get definition (define() stores in _renderers); resolves element/slot/data to React.
  */
 export function buildToReact(
   registry: RendererRegistry,
@@ -126,12 +126,13 @@ export function buildToReact(
   model: ModelData,
   options?: { contextStub?: Partial<ComponentContext> }
 ): ReactNode {
-  const component = registry.getComponent?.(nodeType);
-  if (!component) {
+  const def = (registry as any).get?.(nodeType);
+  if (!def || !def.template) {
     throw new Error(`[renderer-react] No renderer for node type '${nodeType}'. Register with define().`);
   }
 
-  if ((component as any).managesDOM === true) {
+  const templateOrComponent = def.template;
+  if ((templateOrComponent as any)?.managesDOM === true) {
     return createElement('div', {
       key: (model as any).sid,
       'data-bc-sid': (model as any).sid,
@@ -140,7 +141,7 @@ export function buildToReact(
     }, 'Component');
   }
 
-  let template = (component as any).template;
+  let template = templateOrComponent;
   if (typeof template === 'function') {
     const ctx = options?.contextStub ?? makeMinimalContext(registry);
     template = (template as ContextualComponent)({}, model, ctx as ComponentContext);

--- a/packages/renderer-react/test/build-to-react-complex.test.ts
+++ b/packages/renderer-react/test/build-to-react-complex.test.ts
@@ -1,0 +1,691 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { define, element, slot, data, attr, when, each, defineMark, getGlobalRegistry } from '@barocss/dsl';
+import { buildToReact } from '../src/build-to-react';
+import { ReactRenderer } from '../src/react-renderer';
+
+/** Get direct children of a React node (single or array) for assertion */
+function directChildren(node: any): any[] {
+  if (node == null) return [];
+  const c = node.props?.children;
+  if (c == null) return [];
+  return Array.isArray(c) ? c : [c];
+}
+
+/** Recursively collect all descendants (for finding nested elements) */
+function flattenChildren(node: any): any[] {
+  if (node == null) return [];
+  if (typeof node === 'string' || typeof node === 'number') return [node];
+  const children = directChildren(node);
+  return children.flatMap((ch: any) =>
+    ch && typeof ch === 'object' && ch.type ? [ch, ...flattenChildren(ch)] : [ch]
+  );
+}
+
+/** Collect direct child keys and types */
+function collectChildKeysAndTypes(node: any): { key: string | null; type: string }[] {
+  const children = directChildren(node);
+  return children.map((ch: any) => ({
+    key: ch?.key ?? null,
+    type: typeof ch?.type === 'string' ? ch.type : ch?.type?.displayName ?? 'component',
+  }));
+}
+
+/** Find first descendant that is an element with the given type (e.g. 'strong', 'em') */
+function findElementByType(node: any, tag: string): any {
+  if (node == null) return null;
+  if (typeof node.type === 'string' && node.type === tag) return node;
+  const children = directChildren(node);
+  for (const ch of children) {
+    const found = findElementByType(ch, tag);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Check if a node tree contains raw string content */
+function hasRawText(node: any, text: string): boolean {
+  if (node == null) return false;
+  if (typeof node === 'string') return node === text;
+  const children = directChildren(node);
+  for (const ch of children) {
+    if (hasRawText(ch, text)) return true;
+  }
+  return false;
+}
+
+describe('buildToReact – data(text) and marks', () => {
+  beforeEach(() => {
+    const registry = getGlobalRegistry();
+    if (!registry.has?.('inline-text')) {
+      define('inline-text', element('span', { className: 'text' }, [data('text')]));
+    }
+    if (!(registry as any).get?.('mark:bold')) {
+      defineMark('bold', element('strong', { className: 'mark-bold' }, []));
+    }
+    if (!(registry as any).get?.('mark:italic')) {
+      defineMark('italic', element('em', { className: 'mark-italic' }, []));
+    }
+  });
+
+  it('data("text") with no marks renders text inside span', () => {
+    const registry = getGlobalRegistry();
+    const model = { sid: 't1', stype: 'inline-text', text: 'Plain text' };
+    const node = buildToReact(registry, 'inline-text', model as any) as any;
+    expect(node.type).toBe('span');
+    expect(node.key).toBe('t1');
+    expect(node.props?.['data-bc-sid']).toBe('t1');
+    const children = directChildren(node);
+    expect(children).toHaveLength(1);
+    expect(children[0]).toBe('Plain text');
+  });
+
+  it('data("text") with global bold mark wraps text in strong', () => {
+    const registry = getGlobalRegistry();
+    const model = {
+      sid: 't1',
+      stype: 'inline-text',
+      text: 'Bold text',
+      marks: [{ stype: 'bold' }],
+    };
+    const node = buildToReact(registry, 'inline-text', model as any) as any;
+    expect(node.type).toBe('span');
+    const strong = findElementByType(node, 'strong');
+    expect(strong).toBeTruthy();
+    expect(strong.props?.className).toContain('mark-bold');
+    const children = directChildren(strong);
+    expect(children).toContain('Bold text');
+  });
+
+  it('data("text") with ranged marks splits into runs and wraps each run', () => {
+    const registry = getGlobalRegistry();
+    const model = {
+      sid: 't1',
+      stype: 'inline-text',
+      text: 'Hello world',
+      marks: [
+        { stype: 'bold', range: [0, 5] },
+        { stype: 'italic', range: [6, 11] },
+      ],
+    };
+    const node = buildToReact(registry, 'inline-text', model as any) as any;
+    expect(node.type).toBe('span');
+    const strong = findElementByType(node, 'strong');
+    const em = findElementByType(node, 'em');
+    expect(strong).toBeTruthy();
+    expect(em).toBeTruthy();
+    expect(hasRawText(node, 'Hello')).toBe(true);
+    expect(hasRawText(node, ' ')).toBe(true);
+    expect(hasRawText(node, 'world')).toBe(true);
+  });
+
+  it('unregistered mark type is skipped; text still rendered', () => {
+    const registry = getGlobalRegistry();
+    const model = {
+      sid: 't1',
+      stype: 'inline-text',
+      text: 'Mixed',
+      marks: [
+        { stype: 'bold', range: [0, 2] },
+        { stype: 'unknown-mark', range: [2, 5] },
+      ],
+    };
+    const node = buildToReact(registry, 'inline-text', model as any) as any;
+    expect(node).toBeTruthy();
+    const strong = findElementByType(node, 'strong');
+    expect(strong).toBeTruthy();
+    expect(hasRawText(node, 'Mi')).toBe(true);
+    expect(hasRawText(node, 'xed')).toBe(true);
+  });
+});
+
+describe('buildToReact – deep tree and multiple children', () => {
+  beforeEach(() => {
+    const registry = getGlobalRegistry();
+    if (!registry.has?.('doc')) {
+      define('doc', element('div', { className: 'document' }, [slot('content')]));
+    }
+    if (!registry.has?.('paragraph')) {
+      define('paragraph', element('p', { className: 'paragraph' }, [slot('content')]));
+    }
+    if (!registry.has?.('inline-text')) {
+      define('inline-text', element('span', {}, [data('text')]));
+    }
+  });
+
+  it('document with two paragraphs renders both with correct keys', () => {
+    const registry = getGlobalRegistry();
+    const model = {
+      sid: 'd1',
+      stype: 'doc',
+      content: [
+        { sid: 'p1', stype: 'paragraph', content: [{ sid: 't1', stype: 'inline-text', text: 'First' }] },
+        { sid: 'p2', stype: 'paragraph', content: [{ sid: 't2', stype: 'inline-text', text: 'Second' }] },
+      ],
+    };
+    const node = buildToReact(registry, 'doc', model as any) as any;
+    const keysAndTypes = collectChildKeysAndTypes(node);
+    expect(keysAndTypes).toHaveLength(2);
+    expect(keysAndTypes[0]).toEqual({ key: 'p1', type: 'p' });
+    expect(keysAndTypes[1]).toEqual({ key: 'p2', type: 'p' });
+  });
+
+  it('document with empty content array renders div with no block children', () => {
+    const registry = getGlobalRegistry();
+    const model = { sid: 'd1', stype: 'doc', content: [] };
+    const node = buildToReact(registry, 'doc', model as any) as any;
+    expect(node.type).toBe('div');
+    expect(node.key).toBe('d1');
+    const children = directChildren(node);
+    expect(children).toHaveLength(0);
+  });
+
+  it('deep tree: doc > paragraph > inline-text preserves key and data-bc-* at each level', () => {
+    const registry = getGlobalRegistry();
+    const model = {
+      sid: 'd1',
+      stype: 'doc',
+      content: [
+        {
+          sid: 'p1',
+          stype: 'paragraph',
+          content: [{ sid: 't1', stype: 'inline-text', text: 'Nested' }],
+        },
+      ],
+    };
+    const node = buildToReact(registry, 'doc', model as any) as any;
+    expect(node.props?.['data-bc-sid']).toBe('d1');
+    expect(node.props?.['data-bc-stype']).toBe('doc');
+    const p = directChildren(node)[0] as any;
+    expect(p?.props?.['data-bc-sid']).toBe('p1');
+    expect(p?.props?.['data-bc-stype']).toBe('paragraph');
+    const span = directChildren(p)[0] as any;
+    expect(span?.props?.['data-bc-sid']).toBe('t1');
+    expect(span?.props?.['data-bc-stype']).toBe('inline-text');
+  });
+});
+
+describe('buildToReact – attributes', () => {
+  beforeEach(() => {
+    const registry = getGlobalRegistry();
+    if (!registry.has?.('styled-block')) {
+      define('styled-block', element('div', { className: 'block', 'data-test': 'value' }, [slot('content')]));
+    }
+  });
+
+  it('element template attributes are applied to root element', () => {
+    const registry = getGlobalRegistry();
+    const model = { sid: 'b1', stype: 'styled-block', content: [] };
+    const node = buildToReact(registry, 'styled-block', model as any) as any;
+    expect(node.type).toBe('div');
+    expect(node.props?.className).toBe('block');
+    expect(node.props?.['data-test']).toBe('value');
+    expect(node.props?.['data-bc-sid']).toBe('b1');
+  });
+});
+
+describe('ReactRenderer – complex document', () => {
+  beforeEach(() => {
+    const registry = getGlobalRegistry();
+    if (!registry.has?.('doc')) {
+      define('doc', element('div', { className: 'document' }, [slot('content')]));
+    }
+    if (!registry.has?.('paragraph')) {
+      define('paragraph', element('p', { className: 'paragraph' }, [slot('content')]));
+    }
+    if (!registry.has?.('inline-text')) {
+      define('inline-text', element('span', {}, [data('text')]));
+    }
+  });
+
+  it('build() produces full document tree with stable keys', () => {
+    const renderer = new ReactRenderer(getGlobalRegistry());
+    const model = {
+      sid: 'root',
+      stype: 'doc',
+      content: [
+        {
+          sid: 'p1',
+          stype: 'paragraph',
+          content: [
+            { sid: 't1', stype: 'inline-text', text: 'One' },
+          ],
+        },
+        {
+          sid: 'p2',
+          stype: 'paragraph',
+          content: [
+            { sid: 't2', stype: 'inline-text', text: 'Two' },
+          ],
+        },
+      ],
+    };
+    const node = renderer.build(model as any) as any;
+    expect(node.type).toBe('div');
+    expect(node.key).toBe('root');
+    const children = directChildren(node);
+    expect(children).toHaveLength(2);
+    expect(children[0].key).toBe('p1');
+    expect(children[1].key).toBe('p2');
+    const p1Children = directChildren(children[0]);
+    const p2Children = directChildren(children[1]);
+    expect(p1Children.some((c: any) => c === 'One' || (c?.props?.children === 'One'))).toBe(true);
+    expect(p2Children.some((c: any) => c === 'Two' || (c?.props?.children === 'Two'))).toBe(true);
+  });
+});
+
+// --- Implementation verification: complex scenarios matching build-to-react.ts and marks.ts ---
+
+describe('buildToReact – implementation: overlapping marks and run keys', () => {
+  beforeEach(() => {
+    const registry = getGlobalRegistry();
+    if (!registry.has?.('inline-text')) {
+      define('inline-text', element('span', { className: 'text' }, [data('text')]));
+    }
+    if (!(registry as any).get?.('mark:bold')) {
+      defineMark('bold', element('strong', { className: 'mark-bold' }, []));
+    }
+    if (!(registry as any).get?.('mark:italic')) {
+      defineMark('italic', element('em', { className: 'mark-italic' }, []));
+    }
+  });
+
+  it('overlapping marks produce 5 runs with correct strong/em and text', () => {
+    const registry = getGlobalRegistry();
+    const model = {
+      sid: 't1',
+      stype: 'inline-text',
+      text: 'abcdef',
+      marks: [
+        { stype: 'bold', range: [1, 4] },
+        { stype: 'italic', range: [2, 5] },
+      ],
+    };
+    const node = buildToReact(registry, 'inline-text', model as any) as any;
+    expect(node.type).toBe('span');
+    const children = directChildren(node);
+    expect(children).toHaveLength(5);
+    expect(children[0]).toBe('a');
+    const run1 = children[1];
+    const run2 = children[2];
+    const run3 = children[3];
+    expect(children[4]).toBe('f');
+    expect(run1?.type).toBe('strong');
+    expect(hasRawText(run1, 'b')).toBe(true);
+    expect(run2?.type).toBe('strong');
+    const run2Inner = directChildren(run2)[0];
+    expect(run2Inner?.type).toBe('em');
+    expect(hasRawText(run2Inner, 'cd')).toBe(true);
+    expect(run3?.type).toBe('em');
+    expect(hasRawText(run3, 'e')).toBe(true);
+  });
+
+  it('mark run elements have keys from keyBase (sid_r0, sid_r1, ...)', () => {
+    const registry = getGlobalRegistry();
+    const model = {
+      sid: 'n1',
+      stype: 'inline-text',
+      text: 'xy',
+      marks: [
+        { stype: 'bold', range: [0, 1] },
+        { stype: 'italic', range: [1, 2] },
+      ],
+    };
+    const node = buildToReact(registry, 'inline-text', model as any) as any;
+    const children = directChildren(node);
+    expect(children).toHaveLength(2);
+    expect(children[0].key).toMatch(/^n1_r0_/);
+    expect(children[1].key).toMatch(/^n1_r1_/);
+  });
+});
+
+describe('buildToReact – implementation: dynamic tag and data path', () => {
+  it('dynamic tag from model resolves to correct element type', () => {
+    const registry = getGlobalRegistry();
+    const tagFn = (d: any) => d.tagName ?? 'div';
+    define('dynamic-block', element(tagFn as any, { className: 'dynamic' }, [slot('content')]));
+    const model = { sid: 'b1', stype: 'dynamic-block', tagName: 'section', content: [] };
+    const node = buildToReact(registry, 'dynamic-block', model as any) as any;
+    expect(node.type).toBe('section');
+    expect(node.props?.className).toBe('dynamic');
+  });
+
+  it('data path with dot resolves nested value', () => {
+    const registry = getGlobalRegistry();
+    define('meta-line', element('span', {}, [data('meta.title')]));
+    const model = { sid: 'm1', stype: 'meta-line', meta: { title: 'Title' } };
+    const node = buildToReact(registry, 'meta-line', model as any) as any;
+    const children = directChildren(node);
+    expect(children).toHaveLength(1);
+    expect(children[0]).toBe('Title');
+  });
+
+  it('data(path) other than "text" does not apply marks even when model.marks exists', () => {
+    const registry = getGlobalRegistry();
+    define('caption-block', element('span', {}, [data('caption')]));
+    const model = {
+      sid: 'c1',
+      stype: 'caption-block',
+      caption: 'Cap',
+      marks: [{ stype: 'bold' }],
+    };
+    const node = buildToReact(registry, 'caption-block', model as any) as any;
+    const children = directChildren(node);
+    expect(children).toHaveLength(1);
+    expect(children[0]).toBe('Cap');
+    expect(findElementByType(node, 'strong')).toBeNull();
+  });
+});
+
+describe('buildToReact – implementation: mixed children and empty text', () => {
+  beforeEach(() => {
+    const registry = getGlobalRegistry();
+    if (!registry.has?.('doc')) {
+      define('doc', element('div', { className: 'document' }, [slot('content')]));
+    }
+    if (!registry.has?.('paragraph')) {
+      define('paragraph', element('p', {}, [slot('content')]));
+    }
+    if (!registry.has?.('inline-text')) {
+      define('inline-text', element('span', {}, [data('text')]));
+    }
+  });
+
+  it('template with slot then data renders slot children then data value', () => {
+    const registry = getGlobalRegistry();
+    define('block-with-caption', element('div', {}, [slot('content'), data('caption')]));
+    const model = {
+      sid: 'b1',
+      stype: 'block-with-caption',
+      content: [{ sid: 'p1', stype: 'paragraph', content: [{ sid: 't1', stype: 'inline-text', text: 'Para' }] }],
+      caption: 'Caption text',
+    };
+    const node = buildToReact(registry, 'block-with-caption', model as any) as any;
+    const children = directChildren(node);
+    expect(children.length).toBeGreaterThanOrEqual(2);
+    expect(hasRawText(node, 'Para')).toBe(true);
+    expect(hasRawText(node, 'Caption text')).toBe(true);
+  });
+
+  it('data("text") with empty string renders without throwing', () => {
+    const registry = getGlobalRegistry();
+    const model = { sid: 't1', stype: 'inline-text', text: '' };
+    const node = buildToReact(registry, 'inline-text', model as any) as any;
+    expect(node).toBeTruthy();
+    const children = directChildren(node);
+    expect(children).toHaveLength(1);
+    expect(children[0]).toBe('');
+  });
+});
+
+describe('buildToReact – implementation: contextual component and managesDOM', () => {
+  it('contextual component (template as function) returns element and is used for build', () => {
+    const registry = getGlobalRegistry();
+    const contextualTemplate = (_props: any, model: any) =>
+      element('div', { className: 'from-contextual', 'data-bc-sid': model?.sid }, [data('text')]);
+    define('contextual-block', contextualTemplate as any);
+    const model = { sid: 'c1', stype: 'contextual-block', text: 'From contextual' };
+    const node = buildToReact(registry, 'contextual-block', model as any) as any;
+    expect(node.type).toBe('div');
+    expect(node.props?.className).toBe('from-contextual');
+    expect(hasRawText(node, 'From contextual')).toBe(true);
+  });
+
+  it('managesDOM template renders placeholder div with data-bc-sid and data-bc-stype', () => {
+    const registry = getGlobalRegistry();
+    (registry as any).registerComponent?.('external-block', {
+      managesDOM: true,
+      mount: () => ({} as any),
+      unmount: () => {},
+    });
+    const model = { sid: 'e1', stype: 'external-block' };
+    const node = buildToReact(registry, 'external-block', model as any) as any;
+    expect(node.type).toBe('div');
+    expect(node.props?.['data-bc-sid']).toBe('e1');
+    expect(node.props?.['data-bc-stype']).toBe('external-block');
+    expect(node.props?.className).toContain('react-renderer-external-placeholder');
+  });
+});
+
+// --- Spec §8.2 Integration + checklist + edge cases ---
+
+describe('buildToReact – spec §3 integration: document > paragraph > inline-text with marks', () => {
+  beforeEach(() => {
+    const registry = getGlobalRegistry();
+    if (!registry.has?.('doc')) {
+      define('doc', element('div', { className: 'document' }, [slot('content')]));
+    }
+    if (!registry.has?.('paragraph')) {
+      define('paragraph', element('p', { className: 'paragraph' }, [slot('content')]));
+    }
+    if (!registry.has?.('inline-text')) {
+      define('inline-text', element('span', { className: 'text' }, [data('text')]));
+    }
+    if (!(registry as any).get?.('mark:bold')) {
+      defineMark('bold', element('strong', { className: 'mark-bold' }, []));
+    }
+    if (!(registry as any).get?.('mark:italic')) {
+      defineMark('italic', element('em', { className: 'mark-italic' }, []));
+    }
+  });
+
+  it('full document tree has root key and data-bc-sid; children present; text runs with marks wrapped (strong/em)', () => {
+    const registry = getGlobalRegistry();
+    const model = {
+      sid: 'doc1',
+      stype: 'doc',
+      content: [
+        {
+          sid: 'p1',
+          stype: 'paragraph',
+          content: [
+            {
+              sid: 't1',
+              stype: 'inline-text',
+              text: 'Bold and italic',
+              marks: [
+                { stype: 'bold', range: [0, 4] },
+                { stype: 'italic', range: [9, 15] },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const node = buildToReact(registry, 'doc', model as any) as any;
+    expect(node.key).toBe('doc1');
+    expect(node.props?.['data-bc-sid']).toBe('doc1');
+    expect(node.props?.['data-bc-stype']).toBe('doc');
+    const p = directChildren(node)[0] as any;
+    expect(p?.key).toBe('p1');
+    const span = directChildren(p)[0] as any;
+    expect(span?.key).toBe('t1');
+    const strong = findElementByType(node, 'strong');
+    const em = findElementByType(node, 'em');
+    expect(strong).toBeTruthy();
+    expect(em).toBeTruthy();
+    expect(hasRawText(node, 'Bold')).toBe(true);
+    expect(hasRawText(node, ' and ')).toBe(true);
+    expect(hasRawText(node, 'italic')).toBe(true);
+  });
+});
+
+describe('buildToReact – data defaultValue and attribute resolution', () => {
+  it('data(path, defaultValue) uses defaultValue when value is null or undefined', () => {
+    const registry = getGlobalRegistry();
+    define('fallback-text', element('span', {}, [data('title', 'Default Title')]));
+    const node1 = buildToReact(registry, 'fallback-text', { sid: 'a1', stype: 'fallback-text' } as any) as any;
+    const node2 = buildToReact(registry, 'fallback-text', { sid: 'a2', stype: 'fallback-text', title: null } as any) as any;
+    expect(directChildren(node1)[0]).toBe('Default Title');
+    expect(directChildren(node2)[0]).toBe('Default Title');
+  });
+
+  it('attribute from model path (e.g. attributes.className) resolves to element prop', () => {
+    const registry = getGlobalRegistry();
+    define('attr-block', element('div', { className: data('attributes.className') }, [slot('content')]));
+    const model = { sid: 'b1', stype: 'attr-block', attributes: { className: 'from-model' }, content: [] };
+    const node = buildToReact(registry, 'attr-block', model as any) as any;
+    expect(node.props?.className).toBe('from-model');
+  });
+
+  it('data(getter) without path uses getter result as text', () => {
+    const registry = getGlobalRegistry();
+    define('getter-text', element('span', {}, [data((d: any) => (d.prefix ?? '') + '-' + (d.suffix ?? ''))]));
+    const model = { sid: 'g1', stype: 'getter-text', prefix: 'Pre', suffix: 'Fix' };
+    const node = buildToReact(registry, 'getter-text', model as any) as any;
+    expect(directChildren(node)[0]).toBe('Pre-Fix');
+  });
+
+  it('attr(key) from DSL resolves to model.attributes[key]', () => {
+    const registry = getGlobalRegistry();
+    define('attr-dsl-block', element('div', { className: attr('className'), id: attr('id', 'default-id') }, []));
+    const model = { sid: 'a1', stype: 'attr-dsl-block', attributes: { className: 'from-attr', id: 'my-id' } };
+    const node = buildToReact(registry, 'attr-dsl-block', model as any) as any;
+    expect(node.props?.className).toBe('from-attr');
+    expect(node.props?.id).toBe('my-id');
+  });
+
+  it('attr(key, defaultValue) uses defaultValue when attribute is missing', () => {
+    const registry = getGlobalRegistry();
+    define('attr-fallback', element('div', { role: attr('role', 'article') }, []));
+    const model = { sid: 'a2', stype: 'attr-fallback', attributes: {} };
+    const node = buildToReact(registry, 'attr-fallback', model as any) as any;
+    expect(node.props?.role).toBe('article');
+  });
+
+  it('className resolved as object (Record<string, boolean>) yields only true keys as class string', () => {
+    const registry = getGlobalRegistry();
+    define('class-map-block', element('div', { className: (d: any) => ({ active: !!d.active, disabled: !!d.disabled }) }, []));
+    const model = { sid: 'b1', stype: 'class-map-block', active: true, disabled: false };
+    const node = buildToReact(registry, 'class-map-block', model as any) as any;
+    expect(node.props?.className).toBe('active');
+  });
+
+  it('style object with values from model resolves to inline style', () => {
+    const registry = getGlobalRegistry();
+    define('styled-block', element('div', { style: (d: any) => ({ color: d.color, fontSize: d.fontSize }) }, []));
+    const model = { sid: 'b1', stype: 'styled-block', color: 'red', fontSize: '14px' };
+    const node = buildToReact(registry, 'styled-block', model as any) as any;
+    expect(node.props?.style?.color).toBe('red');
+    expect(node.props?.style?.fontSize).toBe('14px');
+  });
+});
+
+describe('buildToReact – flattenChildren: function child returning element', () => {
+  beforeEach(() => {
+    const registry = getGlobalRegistry();
+    if (!registry.has?.('inline-text')) {
+      define('inline-text', element('span', {}, [data('text')]));
+    }
+  });
+
+  it('template child as function (d) => element(...) is flattened and built', () => {
+    const registry = getGlobalRegistry();
+    define('fn-child-block', element('div', {}, [(d: any) => element('span', {}, [d.label ?? '']) as any]));
+    const model = { sid: 'b1', stype: 'fn-child-block', label: 'From function' };
+    const node = buildToReact(registry, 'fn-child-block', model as any) as any;
+    expect(node.type).toBe('div');
+    const span = directChildren(node)[0] as any;
+    expect(span?.type).toBe('span');
+    expect(hasRawText(node, 'From function')).toBe(true);
+  });
+});
+
+describe('buildToReact – options.contextStub and component returning non-element', () => {
+  it('options.contextStub is passed to contextual component', () => {
+    const registry = getGlobalRegistry();
+    const contextualTemplate = (_p: any, model: any, ctx: any) =>
+      element('div', { className: ctx?.getState?.('theme') ?? 'none' }, [data('text')]);
+    define('contextual-theme', contextualTemplate as any);
+    const model = { sid: 'c1', stype: 'contextual-theme', text: 'Hi' };
+    const node = buildToReact(registry, 'contextual-theme', model as any, {
+      contextStub: { getState: (key: string) => (key === 'theme' ? 'dark' : undefined) },
+    } as any) as any;
+    expect(node.props?.className).toBe('dark');
+    expect(hasRawText(node, 'Hi')).toBe(true);
+  });
+
+  it('returns null when template is ComponentTemplate and component() returns non-element', () => {
+    const registry = getGlobalRegistry();
+    define('null-component', { type: 'component', component: () => null } as any);
+    const model = { sid: 'n1', stype: 'null-component' };
+    const node = buildToReact(registry, 'null-component', model as any);
+    expect(node).toBeNull();
+  });
+});
+
+describe('buildToReact – defineMark with ComponentTemplate', () => {
+  beforeEach(() => {
+    const registry = getGlobalRegistry();
+    if (!registry.has?.('inline-text')) {
+      define('inline-text', element('span', {}, [data('text')]));
+    }
+  });
+
+  it('mark registered with component that returns element wraps run in that element', () => {
+    const registry = getGlobalRegistry();
+    defineMark(
+      'highlight',
+      { type: 'component', component: () => element('mark', { className: 'hl' }, []) } as any
+    );
+    const model = {
+      sid: 't1',
+      stype: 'inline-text',
+      text: 'One two',
+      marks: [{ stype: 'highlight', range: [0, 3] }],
+    };
+    const node = buildToReact(registry, 'inline-text', model as any) as any;
+    const markEl = findElementByType(node, 'mark');
+    expect(markEl).toBeTruthy();
+    expect(markEl?.props?.className).toBe('hl');
+    expect(hasRawText(node, 'One')).toBe(true);
+    expect(hasRawText(node, ' two')).toBe(true);
+  });
+});
+
+describe('ReactRenderer – options', () => {
+  beforeEach(() => {
+    const registry = getGlobalRegistry();
+    if (!registry.has?.('doc')) {
+      define('doc', element('div', {}, [slot('content')]));
+    }
+  });
+
+  it('constructor accepts options and getRegistry returns same registry', () => {
+    const registry = getGlobalRegistry();
+    const renderer = new ReactRenderer(registry, { name: 'TestRenderer' });
+    expect(renderer.getRegistry()).toBe(registry);
+    const node = renderer.build({ sid: 'd1', stype: 'doc', content: [] } as any) as any;
+    expect(node).toBeTruthy();
+    expect(node.type).toBe('div');
+  });
+});
+
+describe('buildToReact – when() / each() unsupported', () => {
+  it('template with when() does not throw; conditional branch is not rendered', () => {
+    const registry = getGlobalRegistry();
+    define(
+      'conditional-block',
+      element('div', {}, [when((d: any) => !!d.show, element('span', {}, ['visible']))])
+    );
+    const model = { sid: 'c1', stype: 'conditional-block', show: true };
+    const node = buildToReact(registry, 'conditional-block', model as any) as any;
+    expect(node).toBeTruthy();
+    expect(node.type).toBe('div');
+    const children = directChildren(node);
+    expect(children).toHaveLength(0);
+  });
+
+  it('template with each() does not throw; iterated content is not rendered', () => {
+    const registry = getGlobalRegistry();
+    define(
+      'each-block',
+      element('div', {}, [each('items', (item: any) => element('span', {}, [String(item?.name ?? '')]))])
+    );
+    const model = { sid: 'e1', stype: 'each-block', items: [{ name: 'A' }, { name: 'B' }] };
+    const node = buildToReact(registry, 'each-block', model as any) as any;
+    expect(node).toBeTruthy();
+    expect(node.type).toBe('div');
+    const children = directChildren(node);
+    expect(children).toHaveLength(0);
+  });
+});

--- a/packages/renderer-react/test/build-to-react.test.ts
+++ b/packages/renderer-react/test/build-to-react.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { define, element, slot, data, getGlobalRegistry } from '@barocss/dsl';
+import { buildToReact } from '../src/build-to-react';
+import { ReactRenderer } from '../src/react-renderer';
+
+describe('buildToReact / ReactRenderer (spec verification)', () => {
+  beforeEach(() => {
+    const registry = getGlobalRegistry();
+    if (!registry.has?.('doc')) {
+      define('doc', element('div', { className: 'document' }, [slot('content')]));
+    }
+    if (!registry.has?.('paragraph')) {
+      define('paragraph', element('p', { className: 'paragraph' }, [slot('content')]));
+    }
+    if (!registry.has?.('inline-text')) {
+      define('inline-text', element('span', {}, [data('text')]));
+    }
+  });
+
+  it('buildToReact returns element with key, data-bc-sid, data-bc-stype when model.stype is registered via define()', () => {
+    const registry = getGlobalRegistry();
+    const model = { sid: 'd1', stype: 'doc', content: [] };
+    const node = buildToReact(registry, 'doc', model as any);
+    expect(node).toBeTruthy();
+    expect(typeof node).toBe('object');
+    const el = node as any;
+    expect(el.key).toBe('d1');
+    expect(el.props?.['data-bc-sid']).toBe('d1');
+    expect(el.props?.['data-bc-stype']).toBe('doc');
+    expect(el.type).toBe('div');
+  });
+
+  it('ReactRenderer.build(model) returns ReactNode when model.stype is registered', () => {
+    const renderer = new ReactRenderer(getGlobalRegistry());
+    const model = { sid: 'd1', stype: 'doc', content: [] };
+    const node = renderer.build(model as any);
+    expect(node).toBeTruthy();
+    const el = node as any;
+    expect(el.key).toBe('d1');
+    expect(el.props?.['data-bc-sid']).toBe('d1');
+  });
+
+  it('build(model) throws when model.stype is missing', () => {
+    const renderer = new ReactRenderer(getGlobalRegistry());
+    expect(() => renderer.build({ sid: 'd1' } as any)).toThrow(/model must have stype property/);
+  });
+
+  it('buildToReact throws when nodeType is not registered', () => {
+    const registry = getGlobalRegistry();
+    expect(() => buildToReact(registry, 'unknown-type', { sid: 'x', stype: 'unknown-type' } as any)).toThrow(
+      /No renderer for node type 'unknown-type'/
+    );
+  });
+
+  it('slot(content) expands model.content; each child has key and data-bc-*', () => {
+    const registry = getGlobalRegistry();
+    const model = {
+      sid: 'd1',
+      stype: 'doc',
+      content: [
+        { sid: 'p1', stype: 'paragraph', content: [{ sid: 't1', stype: 'inline-text', text: 'Hello' }] },
+      ],
+    };
+    const node = buildToReact(registry, 'doc', model as any) as any;
+    expect(node.type).toBe('div');
+    expect(node.props?.children).toBeDefined();
+    const children = Array.isArray(node.props.children)
+      ? node.props.children
+      : node.props.children != null
+        ? [node.props.children]
+        : [];
+    expect(children.length).toBeGreaterThanOrEqual(1);
+    const p = children[0] as any;
+    expect(p).toBeTruthy();
+    expect(p.key).toBe('p1');
+    expect(p.props?.['data-bc-sid']).toBe('p1');
+    expect(p.type).toBe('p');
+  });
+});

--- a/packages/renderer-react/test/split-text-by-marks.test.ts
+++ b/packages/renderer-react/test/split-text-by-marks.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { splitTextByMarks } from '../src/utils/marks';
+
+describe('splitTextByMarks', () => {
+  it('returns empty array for empty text', () => {
+    expect(splitTextByMarks('', [])).toEqual([]);
+    expect(splitTextByMarks('', [{ stype: 'bold' }])).toEqual([]);
+  });
+
+  it('returns single run when no marks', () => {
+    const runs = splitTextByMarks('hello', []);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toEqual({ start: 0, end: 5, text: 'hello', types: [] });
+  });
+
+  it('applies global mark to entire text', () => {
+    const runs = splitTextByMarks('hello', [{ stype: 'bold' }]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].text).toBe('hello');
+    expect(runs[0].types).toEqual(['bold']);
+  });
+
+  it('splits by single range mark', () => {
+    const runs = splitTextByMarks('hello', [{ stype: 'bold', range: [1, 4] }]);
+    expect(runs).toHaveLength(3);
+    expect(runs[0]).toEqual({ start: 0, end: 1, text: 'h', types: [] });
+    expect(runs[1]).toEqual({ start: 1, end: 4, text: 'ell', types: ['bold'] });
+    expect(runs[2]).toEqual({ start: 4, end: 5, text: 'o', types: [] });
+  });
+
+  it('clamps range beyond text length', () => {
+    const runs = splitTextByMarks('hi', [{ stype: 'bold', range: [0, 100] }]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].text).toBe('hi');
+    expect(runs[0].types).toEqual(['bold']);
+  });
+
+  it('overlapping marks produce correct types per run', () => {
+    const runs = splitTextByMarks('abcdef', [
+      { stype: 'bold', range: [1, 4] },
+      { stype: 'italic', range: [2, 5] },
+    ]);
+    expect(runs).toHaveLength(5);
+    expect(runs[0].text).toBe('a');
+    expect(runs[0].types).toEqual([]);
+    expect(runs[1].text).toBe('b');
+    expect(runs[1].types).toEqual(['bold']);
+    expect(runs[2].text).toBe('cd');
+    expect(runs[2].types).toContain('bold');
+    expect(runs[2].types).toContain('italic');
+    expect(runs[3].text).toBe('e');
+    expect(runs[3].types).toEqual(['italic']);
+    expect(runs[4].text).toBe('f');
+    expect(runs[4].types).toEqual([]);
+  });
+
+  it('range with end <= start is skipped (no extra boundary)', () => {
+    const runs = splitTextByMarks('ab', [{ stype: 'bold', range: [3, 1] }]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].text).toBe('ab');
+    expect(runs[0].types).toEqual([]);
+  });
+});

--- a/packages/renderer-react/vitest.config.ts
+++ b/packages/renderer-react/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+    passWithNoTests: false,
+  },
+});


### PR DESCRIPTION
## Summary

- **packages/renderer-react**: Spec (`docs/renderer-react-spec.md`), Vitest tests (45), README (usage, supported DSL, API, testing), `buildToReact` registry.get fix.
- **docs**: `renderer-react-and-editor-react.md` in English; `docs/specs/README.md` link to renderer-react spec.
- **.cursor/skills**: `package-renderer-react/SKILL.md`, README updated.

Closes #167

## Verification

`pnpm --filter @barocss/renderer-react test:run` — all 45 tests pass.

Made with [Cursor](https://cursor.com)