### PR TITLE
chore(converter): add editor-core dependency and update lockfile

### DIFF
--- a/packages/converter/package.json
+++ b/packages/converter/package.json
@@ -24,7 +24,8 @@
     "test:run": "vitest run"
   },
   "dependencies": {
-    "@barocss/datastore": "workspace:*"
+    "@barocss/datastore": "workspace:*",
+    "@barocss/editor-core": "workspace:*"
   },
   "devDependencies": {
     "jsdom": "^24.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,9 @@ importers:
       '@barocss/datastore':
         specifier: workspace:*
         version: link:../datastore
+      '@barocss/editor-core':
+        specifier: workspace:*
+        version: link:../editor-core
     devDependencies:
       jsdom:
         specifier: ^24.1.3
@@ -630,6 +633,9 @@ importers:
       vite-plugin-dts:
         specifier: ^3.9.1
         version: 3.9.1(@types/node@20.19.30)(typescript@5.9.3)(vite@5.4.21)
+      vitest:
+        specifier: ^4.0.7
+        version: 4.0.18(@types/node@20.19.30)(jsdom@24.1.3)
 
   packages/schema:
     devDependencies:


### PR DESCRIPTION
## Summary

- `packages/converter/package.json`: add `@barocss/editor-core` to dependencies.
- `pnpm-lock.yaml`: update.

Note: converter source does not import editor-core yet; dependency can be removed in a follow-up if unused.

Closes #169

## Verification

`pnpm install` succeeds.

Made with [Cursor](https://cursor.com)