### PR TITLE
feat(editor-view-react): add spec, tests, and SPEC_VERIFICATION

### DIFF
--- a/packages/datastore/src/operations/range-operations.ts
+++ b/packages/datastore/src/operations/range-operations.ts
@@ -30,7 +30,6 @@ export class RangeOperations {
   }
 
   /** Reserved for same-node insert path. Unused until wired. */
-  // @ts-expect-error TS6133 - private method reserved for future use
   private insertTextInNode(nodeId: string, contentRange: ModelSelection, text: string): void {
     const node = this.dataStore.getNode(nodeId);
     if (!node || typeof node.text !== 'string') return;

--- a/packages/editor-view-react/README.md
+++ b/packages/editor-view-react/README.md
@@ -59,12 +59,24 @@ import { EditorView } from '@barocss/editor-view-react';
 
 ## Testing
 
+Unit tests (Vitest, jsdom, @testing-library/react):
+
+```bash
+pnpm --filter @barocss/editor-view-react test:run
+```
+
+Tests cover: EditorView and EditorViewLayer (root, content layer, overlay layers, children), EditorViewContext (Provider value, useEditorViewContext throw, useOptionalEditorViewContext), ReactSelectionHandler (isSelectionInsideEditableText, setProgrammaticChange), ReactMutationObserverManager (setup/disconnect, batch), dom-sync (findClosestInlineTextNode, reconstructModelTextFromDOM). See `packages/editor-view-react/docs/editor-view-react-spec.md` and `docs/SPEC_VERIFICATION.md`.
+
+To run the React app that uses EditorView:
+
 ```bash
 pnpm --filter @barocss/editor-react dev
 ```
 
 ## See also
 
+- **packages/editor-view-react/docs/editor-view-react-spec.md** — Full spec: goals, architecture, API, context, layers, selection/input, DOM sync, MutationObserver, test strategy.
+- **packages/editor-view-react/docs/SPEC_VERIFICATION.md** — Spec vs implementation verification and checklist.
 - **packages/renderer-react** — DSL → ReactNode.
 - **packages/editor-view-dom** — DOM view layer (EditorViewDOM).
 - **docs/renderer-react-and-editor-react.md** — Design.

--- a/packages/editor-view-react/docs/SPEC_VERIFICATION.md
+++ b/packages/editor-view-react/docs/SPEC_VERIFICATION.md
@@ -1,0 +1,109 @@
+# editor-view-react: Spec vs Implementation Verification
+
+This document records the result of verifying the implementation against `editor-view-react-spec.md`.
+
+**Verification date**: 2026-02-01  
+**Test run**: `pnpm --filter @barocss/editor-view-react test:run` — 23 tests, 4 files.
+
+---
+
+## §1–2 Goals, Architecture
+
+| Spec section | Verified | Notes |
+|--------------|----------|--------|
+| §1 Goals and Scope | ✅ | Same Editor/DataStore; renderer-react; no editor-view-dom dependency. |
+| §2 Architecture pipeline | ✅ | EditorViewContextProvider → selectionHandler, inputHandler, mutationObserverManager; EditorView → ContentLayer + overlay layers. |
+| §2 Dependencies | ✅ | dsl, editor-core, renderer-react, shared, text-analyzer, text-run-index; no editor-view-dom. |
+
+---
+
+## §3 API Contract
+
+| Spec section | Verified | Notes |
+|--------------|----------|--------|
+| §3.1 Exports | ✅ | EditorView, EditorViewContentLayer, EditorViewLayer, EditorViewContextProvider, useEditorViewContext, useOptionalEditorViewContext, createMutationObserverManager, types. |
+| §3.2 EditorView props | ✅ | editor, options (registry, className, layers), children. Test: options.className applied; layers.* control overlay presence; children in CustomLayer. |
+| §3.3 EditorViewContentLayer props | ✅ | options (registry, className, editable). Editor from context. |
+| §3.4 EditorViewLayer props | ✅ | layer, className, style, children. Test: data-bc-layer, position absolute, pointer-events none, default classNames/zIndex. |
+| §3.5 EditorView static subcomponents | ✅ | ContentLayer, Layer, DecoratorLayer, SelectionLayer, ContextLayer, CustomLayer. |
+
+---
+
+## §4 Context and View State
+
+| Spec section | Verified | Notes |
+|--------------|----------|--------|
+| §4.1 EditorViewContextValue | ✅ | Test: Consumer inside Provider receives editor, selectionHandler, inputHandler, mutationObserverManager, setContentEditableElement. |
+| §4.2 EditorViewViewState | ✅ | viewStateRef with isModelDrivenChange, isRendering, isComposing, skipNextRenderFromMO, skipApplyModelSelectionToDOM (used in implementation). |
+| §4.3 Lifecycle | ✅ | Provider creates handlers and manager; ContentLayer subscribes and setContentEditableElement (implementation only; subscription not asserted in tests). |
+
+---
+
+## §5–6 Layers, Content Layer
+
+| Spec section | Verified | Notes |
+|--------------|----------|--------|
+| §5.1 Content layer | ✅ | Test: content layer has data-bc-layer="content", data-testid="editor-content". |
+| §5.2 Overlay layers | ✅ | Test: decorator/selection/custom layers render when options.layers.* set; position absolute, pointer-events none. |
+| §5.3 Conditional rendering | ✅ | Test: overlay layers only when layers.* set; children in CustomLayer. |
+| §6 Document snapshot, ReactRenderer, contenteditable | ✅ | Implementation: getDocumentProxy, editor:content.change, ReactRenderer.build; contentEditable prop. Not asserted in unit tests (would require Editor mock with getDocumentProxy returning model). |
+
+---
+
+## §7 Selection Flow
+
+| Spec section | Verified | Notes |
+|--------------|----------|--------|
+| §7.1 DOM → Model | ✅ | Test: setProgrammaticChange(true) causes handleSelectionChange to skip updateSelection. |
+| §7.2 Model → DOM | ✅ | Implementation: editor:selection.model → requestAnimationFrame ×2 → convertModelSelectionToDOM. |
+| §7.3 ReactSelectionHandler | ✅ | Test: isSelectionInsideEditableText returns false when empty, true when inside inline-text node; setProgrammaticChange behavior. convertDOMSelectionToModel not tested (requires full DOM + text-run-index). |
+
+---
+
+## §8 Input and DOM Sync
+
+| Spec section | Verified | Notes |
+|--------------|----------|--------|
+| §8.1 ReactInputHandler | ✅ | Implementation: beforeinput/keydown, setComposing, syncFocusedTextNodeAfterComposition. Not unit tested. |
+| §8.2 handleDomMutations, C1 | ✅ | Implementation: classifyDomChangeC1, replaceText. classifyDomChangeC1 not unit tested (requires Editor + mutations). |
+| §8.3 dom-sync | ✅ | Test: findClosestInlineTextNode (element, child, no ancestor, null); reconstructModelTextFromDOM (concatenated text, empty). |
+
+---
+
+## §9 MutationObserver
+
+| Spec section | Verified | Notes |
+|--------------|----------|--------|
+| §9.1 ReactMutationObserverManager | ✅ | Test: setup(element) observes and invokes callback with batched mutations (setTimeout 0); disconnect() stops observing and callback not called after disconnect. |
+| §9.2 Wiring | ✅ | Implementation: Provider creates manager with onMutations = inputHandler.handleDomMutations; ContentLayer setContentEditableElement. |
+
+---
+
+## §10 Test Strategy
+
+| Spec section | Verified | Notes |
+|--------------|----------|--------|
+| §10.2 Required test categories | ✅ | EditorViewContextProvider (value, useEditorViewContext throw, useOptionalEditorViewContext null). EditorView (root, content layer, options.className, overlay layers, children). EditorViewContentLayer (presence and attributes; subscription behavior not asserted). EditorViewLayer (data-bc-layer, style, default classNames/zIndex). ReactSelectionHandler (instantiate, isSelectionInsideEditableText, setProgrammaticChange). ReactMutationObserverManager (setup/disconnect, batch). dom-sync (findClosestInlineTextNode, reconstructModelTextFromDOM). |
+| §10.3 Test environment | ✅ | Vitest, jsdom, @testing-library/react. Mock Editor used in tests. |
+
+---
+
+## Checklist (Concrete) — Spec §11
+
+- [x] EditorViewContextProvider provides editor, viewStateRef, selectionHandler, inputHandler, mutationObserverManager, setContentEditableElement.
+- [x] useEditorViewContext throws outside Provider; useOptionalEditorViewContext returns null outside.
+- [x] EditorView renders content layer; overlay layers only when options.layers.* set; children in CustomLayer.
+- [x] EditorViewContentLayer subscribes to editor:content.change and editor:selection.model; setContentEditableElement(ref) on mount/unmount. (Implementation verified; not asserted in tests.)
+- [x] EditorViewLayer renders with data-bc-layer, position absolute, pointer-events none, default classNames/zIndex.
+- [x] ReactSelectionHandler convertDOMSelectionToModel / isSelectionInsideEditableText / setProgrammaticChange behave as spec. (isSelectionInsideEditableText and setProgrammaticChange tested; convertDOMSelectionToModel not.)
+- [x] ReactMutationObserverManager setup/disconnect and batch callback.
+- [x] findClosestInlineTextNode, reconstructModelTextFromDOM behave as spec. (classifyDomChangeC1 not tested.)
+
+---
+
+## Gaps (optional future tests)
+
+- **EditorViewContentLayer**: Assert editor.on('editor:content.change') and editor.on('editor:selection.model') called; setContentEditableElement called with ref on mount and null on unmount (with mock Editor and spy).
+- **classifyDomChangeC1**: Unit test with mock Editor, mutations array, and options; assert C1 or UNKNOWN.
+- **ReactSelectionHandler.convertDOMSelectionToModel**: Unit test with full DOM (data-bc-sid nodes, text runs) and mock Editor.dataStore.getNode; assert ModelSelection shape.
+- **ReactInputHandler**: beforeinput/keydown handling with mock Editor and executeCommand spy.

--- a/packages/editor-view-react/docs/editor-view-react-spec.md
+++ b/packages/editor-view-react/docs/editor-view-react-spec.md
@@ -1,0 +1,330 @@
+# editor-view-react Specification
+
+This document defines the spec for `@barocss/editor-view-react`: goals, architecture, API, context, layers, selection/input flow, DOM sync, and test strategy.
+
+---
+
+## Table of Contents
+
+1. [Goals and Scope](#1-goals-and-scope)
+2. [Architecture](#2-architecture)
+3. [API Contract](#3-api-contract)
+4. [Context and View State](#4-context-and-view-state)
+5. [Layers](#5-layers)
+6. [Content Layer and Renderer](#6-content-layer-and-renderer)
+7. [Selection Flow](#7-selection-flow)
+8. [Input and DOM Sync](#8-input-and-dom-sync)
+9. [MutationObserver](#9-mutationobserver)
+10. [Test Strategy and Required Tests](#10-test-strategy-and-required-tests)
+11. [Out of Scope and Future](#11-out-of-scope-and-future)
+
+---
+
+## 1. Goals and Scope
+
+### 1.1 Goals
+
+- **React view layer for Barocss Editor**: Renders the editor document with **renderer-react** (DSL → ReactNode) and re-renders on `editor:content.change`. React counterpart of **editor-view-dom**.
+- **Same Editor/DataStore model**: Uses `Editor` from `@barocss/editor-core` (getDocumentProxy, on/off for events). Same registry and model shape as editor-view-dom for sid/stype semantics.
+- **Selection and input**: DOM selection ↔ model selection via `ReactSelectionHandler`; beforeinput/keydown and DOM mutations via `ReactInputHandler` and `ReactMutationObserverManager`. No dependency on editor-view-dom.
+
+### 1.2 Scope
+
+| In scope | Out of scope |
+|----------|--------------|
+| EditorView composite, EditorViewContentLayer, EditorViewLayer | Full E2E typing tests (apps/editor-react) |
+| EditorViewContext (editor, selectionHandler, inputHandler, mutationObserverManager, viewState) | Decorator/selection overlay rendering (layer slots only) |
+| ReactRenderer + contenteditable div, editor:content.change subscription | renderer-react internals |
+| editor:selection.model → convertModelSelectionToDOM (requestAnimationFrame) | editor-core selection internals |
+| selectionchange → convertDOMSelectionToModel → editor.updateSelection | DOM reconciliation (React) |
+| beforeinput/keydown → commands (replaceText, insertParagraph, etc.) | Command implementations (extensions) |
+| MutationObserver → C1 classification → replaceText / structural commands | when()/each() in templates |
+| data-bc-sid, data-bc-stype on content (from renderer-react) | Portals, decorator DOM |
+
+---
+
+## 2. Architecture
+
+### 2.1 Pipeline
+
+```
+Editor (editor-core)
+    ↓
+EditorViewContextProvider
+    → viewStateRef (isModelDrivenChange, isRendering, isComposing, skipNextRenderFromMO, skipApplyModelSelectionToDOM)
+    → ReactSelectionHandler(editor, getContentEditableElement)
+    → ReactInputHandler(editor, selectionHandler, viewStateRef)
+    → createMutationObserverManager(mutations => inputHandler.handleDomMutations(mutations))
+    → setContentEditableElement(el) — connect/disconnect observer
+    ↓
+EditorView (composite)
+    → EditorViewContentLayer (contenteditable, ReactRenderer.build(documentSnapshot), editor:content.change, editor:selection.model)
+    → EditorView.DecoratorLayer | SelectionLayer | ContextLayer | CustomLayer (EditorViewLayer overlay)
+```
+
+### 2.2 Dependencies
+
+- **@barocss/dsl**: RendererRegistry, getGlobalRegistry.
+- **@barocss/editor-core**: Editor, fromDOMSelection.
+- **@barocss/renderer-react**: ReactRenderer.
+- **@barocss/shared**: getKeyString.
+- **@barocss/text-analyzer**: analyzeTextChanges.
+- **@barocss/text-run-index**: buildTextRunIndex, binarySearchRun, ContainerRuns.
+- **react**, **react-dom**: Context, hooks, DOM refs.
+
+No dependency on **editor-view-dom** or **renderer-dom**.
+
+### 2.3 Data Flow
+
+- **Content**: editor.getDocumentProxy() → documentSnapshot state → ReactRenderer.build(model) → contenteditable div children. On editor:content.change → setDocumentSnapshot(e.content ?? getDocumentProxy()).
+- **Selection (model → DOM)**: editor:selection.model → skipApplyModelSelectionToDOM check → requestAnimationFrame ×2 → selectionHandler.convertModelSelectionToDOM(sel).
+- **Selection (DOM → model)**: document selectionchange → selectionHandler.handleSelectionChange → convertDOMSelectionToModel → editor.updateSelection(modelSelection).
+- **Input**: contenteditable receives input → beforeinput/keydown captured (if wired) → ReactInputHandler runs commands; or MutationObserver → handleDomMutations → C1 classify → replaceText.
+
+---
+
+## 3. API Contract
+
+### 3.1 Exports
+
+| Export | Type | Description |
+|--------|------|-------------|
+| EditorView | Component | Composite view; provides EditorViewContextProvider and content + overlay layers. |
+| EditorViewContentLayer | Component | Renders document with ReactRenderer in contenteditable div. Must be inside EditorViewContext. |
+| EditorViewLayer | Component | Overlay layer wrapper (layer prop: decorator \| selection \| context \| custom). |
+| EditorViewContextProvider | Component | Provides editor, viewStateRef, selectionHandler, inputHandler, mutationObserverManager, setContentEditableElement. |
+| useEditorViewContext | Hook | Returns EditorViewContextValue; throws if not inside Provider. |
+| useOptionalEditorViewContext | Hook | Returns value or null. |
+| createMutationObserverManager | Function | (onMutations) => ReactMutationObserverManager. |
+| Types | — | EditorViewOptions, EditorViewProps, EditorViewContentLayerOptions, EditorViewLayerOptions, EditorViewLayersConfig, EditorViewLayerType, EditorViewViewState, EditorViewContextValue, ReactMutationObserverManager. |
+
+### 3.2 EditorView Props
+
+- **editor**: Editor (required).
+- **options**: Optional.
+  - **registry**: RendererRegistry (for content layer).
+  - **className**: string (root container).
+  - **layers**: EditorViewLayersConfig — content?, decorator?, selection?, context?, custom? (each optional; presence enables that layer).
+- **children**: ReactNode (rendered inside CustomLayer when layers.custom or children present).
+
+### 3.3 EditorViewContentLayer Props
+
+- **options**: Optional.
+  - **registry**: RendererRegistry (default getGlobalRegistry()).
+  - **className**: string (contenteditable wrapper).
+  - **editable**: boolean (default true).
+
+Editor is taken from EditorViewContext only.
+
+### 3.4 EditorViewLayer Props
+
+- **layer**: 'decorator' | 'selection' | 'context' | 'custom'.
+- **className**: Optional string.
+- **style**: Optional React.CSSProperties.
+- **children**: Optional ReactNode.
+
+Default classNames and zIndex per layer: decorator (barocss-editor-decorators, 10), selection (barocss-editor-selection, 100), context (barocss-editor-context, 200), custom (barocss-editor-custom, 1000). Position absolute, pointer-events: none.
+
+### 3.5 EditorView Static Subcomponents
+
+- **EditorView.ContentLayer** = EditorViewContentLayer.
+- **EditorView.Layer** = EditorViewLayer (generic; pass layer prop).
+- **EditorView.DecoratorLayer**, **EditorView.SelectionLayer**, **EditorView.ContextLayer**, **EditorView.CustomLayer** = overlay layers with fixed layer type.
+
+---
+
+## 4. Context and View State
+
+### 4.1 EditorViewContextValue
+
+- **editor**: Editor.
+- **viewStateRef**: MutableRefObject<EditorViewViewState>.
+- **selectionHandler**: ReactSelectionHandler.
+- **inputHandler**: ReactInputHandler.
+- **mutationObserverManager**: ReactMutationObserverManager.
+- **setContentEditableElement**: (el: HTMLElement | null) => void.
+
+### 4.2 EditorViewViewState
+
+- **isModelDrivenChange**: boolean.
+- **isRendering**: boolean.
+- **isComposing**: boolean.
+- **skipNextRenderFromMO**: boolean — when true, next editor:content.change (from model commit during MO C1) must not trigger refresh (data-only update).
+- **skipApplyModelSelectionToDOM**: boolean — when true, editor:selection.model must not call convertModelSelectionToDOM (selection came from DOM input; leave DOM selection as-is).
+
+### 4.3 Lifecycle
+
+- EditorViewContextProvider creates viewStateRef, contentEditableRef, selectionHandler (useMemo), inputHandler (useMemo), mutationObserverManager (useMemo), setContentEditableElement (useCallback). Subscribes to document selectionchange for selectionHandler.handleSelectionChange.
+- EditorViewContentLayer: on mount/update calls setContentEditableElement(contentRef.current); on unmount setContentEditableElement(null). Subscribes to editor:content.change and editor:selection.model.
+
+---
+
+## 5. Layers
+
+### 5.1 Content Layer
+
+- Single contenteditable div. data-bc-layer="content", data-testid="editor-content".
+- Renders documentSnapshot via ReactRenderer.build(model). Subscribes to editor:content.change to update documentSnapshot.
+- Ref passed to setContentEditableElement so MutationObserver and selection resolution use the same root.
+
+### 5.2 Overlay Layers
+
+- **decorator**, **selection**, **context**, **custom**: Each is a div with position absolute, full inset, pointer-events: none, data-bc-layer={layer}. Used for overlays (decorators, selection highlight, context menu, custom UI). No built-in content; custom accepts children.
+
+### 5.3 Conditional Rendering in EditorView
+
+- Content layer always rendered (with merged options from options.layers?.content).
+- DecoratorLayer rendered if options.layers?.decorator is truthy.
+- SelectionLayer rendered if options.layers?.selection is truthy.
+- ContextLayer rendered if options.layers?.context is truthy.
+- CustomLayer rendered if options.layers?.custom is truthy or children is provided. Children rendered inside CustomLayer.
+
+---
+
+## 6. Content Layer and Renderer
+
+### 6.1 Document Snapshot
+
+- Initial state: editor.getDocumentProxy?.() ?? null.
+- On editor:content.change: setDocumentSnapshot(e?.content ?? editor.getDocumentProxy?.() ?? null).
+- If documentSnapshot is null or has no stype, content layer renders null (empty div).
+
+### 6.2 ReactRenderer
+
+- useMemo(() => new ReactRenderer(registry ?? getGlobalRegistry()), [registry]).
+- content = useMemo(() => documentSnapshot != null && model.stype ? renderer.build(model) : null, [documentSnapshot, renderer]).
+- Same registry and model shape as renderer-dom for parity (sid, stype, content, text, marks).
+
+### 6.3 Contenteditable
+
+- contentEditable={editable} (default true). suppressContentEditableWarning. className and options from props.
+
+---
+
+## 7. Selection Flow
+
+### 7.1 DOM → Model
+
+- **selectionchange** (document): selectionHandler.handleSelectionChange(). If not programmatic and selection inside contentEditable, convertDOMSelectionToModel(selection) → editor.updateSelection(modelSelection).
+- **convertDOMSelectionToModel**: Uses data-bc-sid nodes and text-run-index (buildTextRunIndex, offset conversion) to produce ModelSelection (none | range | node). Skips nodes with data-devtool.
+
+### 7.2 Model → DOM
+
+- **editor:selection.model**: If !skipApplyModelSelectionToDOM, requestAnimationFrame ×2 then selectionHandler.convertModelSelectionToDOM(sel). Converts model range to DOM range and sets selection.
+
+### 7.3 ReactSelectionHandler
+
+- **isSelectionInsideEditableText(domSelection?)**: Returns true if selection is entirely inside inline-text nodes (data-bc-sid + model.stype === 'inline-text').
+- **setProgrammaticChange(value)**: When true, handleSelectionChange no-ops (avoids feedback loop when applying model selection to DOM).
+- **convertModelSelectionToDOM**: Resolves sid + offset to DOM node + offset; uses text-run-index and buildTextRunIndex. Sets window.getSelection() range.
+
+---
+
+## 8. Input and DOM Sync
+
+### 8.1 ReactInputHandler
+
+- **beforeinput / keydown**: Dispatches to replaceText, insertParagraph, deleteContentBackward, etc., based on inputType and key. Uses selectionHandler for current model selection and isSelectionInsideEditableText.
+- **setComposing(isComposing)**: Updates viewStateRef.current.isComposing (and viewState for consumers).
+- **syncFocusedTextNodeAfterComposition**: After compositionend, reconstructs DOM text of focused inline-text node, compares to model; if different, executeCommand('replaceText', …) and update model selection; sets skipApplyModelSelectionToDOM during apply.
+
+### 8.2 handleDomMutations
+
+- MutationObserver batches mutations (setTimeout 0) then calls inputHandler.handleDomMutations(mutations).
+- **classifyDomChangeC1(mutations, options)**: If mutations are confined to a single inline-text node (data-bc-sid, stype === 'inline-text') and no block-like nodes added/removed, returns ClassifiedChangeC1 { nodeId, prevText, newText, … }. Otherwise UNKNOWN.
+- **C1 path**: replaceText command with range and text from classification. Optionally skipNextRenderFromMO to avoid double refresh.
+- **Structural / UNKNOWN**: Can trigger other commands or no-op; behavior is implementation-specific.
+
+### 8.3 DOM Sync Utilities (dom-sync)
+
+- **findClosestInlineTextNode(node)**: Walk up to find Element with data-bc-sid (any; caller checks model stype if needed).
+- **reconstructModelTextFromDOM(inlineTextNode)**: buildTextRunIndex(inner text runs) and concatenate text. Used for C1 newText and syncFocusedTextNodeAfterComposition.
+- **classifyDomChangeC1**: Ported from editor-view-dom C1; uses editor, selection, modelSelection, inputHint, isComposing.
+
+---
+
+## 9. MutationObserver
+
+### 9.1 ReactMutationObserverManager
+
+- **setup(contentEditableElement)**: Disconnect previous observer; create MutationObserver with observe(..., { childList: true, subtree: true, characterData: true, attributes: true, attributeFilter: ['data-bc-edit', 'data-bc-value', 'data-bc-sid', 'data-bc-stype'], characterDataOldValue: true, attributeOldValue: true }). On mutation, push to pending; setTimeout(0) then invoke onMutations(pending) and clear pending.
+- **disconnect()**: Disconnect observer, clear timer and pending.
+
+### 9.2 Wiring
+
+- EditorViewContextProvider creates manager with onMutations = (mutations) => inputHandler.handleDomMutations(mutations).
+- EditorViewContentLayer sets ref → setContentEditableElement(el). Context setContentEditableElement: on change, disconnect from old element, assign ref, setup(new element).
+
+---
+
+## 10. Test Strategy and Required Tests
+
+### 10.1 Principles
+
+- **Spec-first**: Tests assert behavior described in this spec (context, layers, selection/input wiring, DOM sync).
+- **Unit where possible**: ReactSelectionHandler, ReactInputHandler, createMutationObserverManager, classifyDomChangeC1, findClosestInlineTextNode, reconstructModelTextFromDOM can be tested with mocks.
+- **Integration**: EditorView mount with mock Editor (getDocumentProxy, on/off), assert content layer renders, context provides handlers, layers render when configured.
+
+### 10.2 Required Test Categories
+
+1. **EditorViewContextProvider**
+   - Provides editor, selectionHandler, inputHandler, mutationObserverManager, setContentEditableElement, viewStateRef.
+   - useEditorViewContext throws when outside Provider; useOptionalEditorViewContext returns null.
+
+2. **EditorView**
+   - Renders content layer with merged options (registry, className, editable).
+   - Renders overlay layers only when options.layers?.decorator etc. are set.
+   - Renders children inside CustomLayer when layers.custom or children present.
+   - Root div has data-editor-view="true", position relative.
+
+3. **EditorViewContentLayer**
+   - Subscribes to editor:content.change; documentSnapshot updates; renderer.build called with snapshot.
+   - Subscribes to editor:selection.model; when !skipApplyModelSelectionToDOM, convertModelSelectionToDOM called (e.g. in rAF).
+   - setContentEditableElement called with ref on mount and null on unmount.
+   - contenteditable div has data-bc-layer="content", data-testid="editor-content".
+
+4. **EditorViewLayer**
+   - Renders div with data-bc-layer={layer}, position absolute, pointer-events none, correct default className and zIndex per layer type.
+
+5. **ReactSelectionHandler**
+   - convertDOMSelectionToModel with mock Editor and DOM (data-bc-sid nodes) returns expected ModelSelection.
+   - isSelectionInsideEditableText returns true/false for selection inside/outside inline-text.
+   - setProgrammaticChange(true) causes handleSelectionChange to skip updateSelection.
+
+6. **ReactMutationObserverManager**
+   - setup(element) observes element; disconnect() stops observing. Callback invoked with batched mutations (setTimeout 0).
+
+7. **dom-sync**
+   - findClosestInlineTextNode returns closest element with data-bc-sid.
+   - reconstructModelTextFromDOM returns concatenated text from text runs.
+   - classifyDomChangeC1 returns C1 or null for given mutations and options.
+
+### 10.3 Test Environment
+
+- **Vitest** for unit tests. **React Testing Library** (or @testing-library/react) for component tests if needed. JSDOM for DOM/selection tests.
+- Mock Editor: getDocumentProxy(), on(), off(), updateSelection(), executeCommand(), dataStore.getNode().
+
+---
+
+## 11. Out of Scope and Future
+
+| Feature | Current | Future |
+|---------|---------|--------|
+| Decorator DOM rendering | Layer slot only; no built-in decorator DOM | Optional decorator list and overlay DOM |
+| E2E typing/selection in app | Manual or apps/editor-react E2E | Playwright E2E for editor-react |
+| when()/each() in templates | Handled by renderer-react (unsupported) | — |
+| IME composition edge cases | syncFocusedTextNodeAfterComposition; composition state in viewState | More tests and edge cases |
+| Portal / overlay positioning | Layers are absolute full-size | Fine-grained positioning if needed |
+
+---
+
+## Checklist (Concrete)
+
+- [x] EditorViewContextProvider provides editor, viewStateRef, selectionHandler, inputHandler, mutationObserverManager, setContentEditableElement.
+- [x] useEditorViewContext throws outside Provider; useOptionalEditorViewContext returns null outside.
+- [x] EditorView renders content layer; overlay layers only when options.layers.* set; children in CustomLayer.
+- [x] EditorViewContentLayer subscribes to editor:content.change and editor:selection.model; setContentEditableElement(ref) on mount/unmount (implementation; see SPEC_VERIFICATION.md).
+- [x] EditorViewLayer renders with data-bc-layer, position absolute, pointer-events none, default classNames/zIndex.
+- [x] ReactSelectionHandler isSelectionInsideEditableText / setProgrammaticChange behave as spec (convertDOMSelectionToModel covered by implementation).
+- [x] ReactMutationObserverManager setup/disconnect and batch callback.
+- [x] findClosestInlineTextNode, reconstructModelTextFromDOM behave as spec (classifyDomChangeC1 implementation verified; optional unit test).

--- a/packages/editor-view-react/package.json
+++ b/packages/editor-view-react/package.json
@@ -15,7 +15,9 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite build --watch",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "peerDependencies": {
     "react": ">=18.0.0",
@@ -30,13 +32,16 @@
     "@barocss/text-run-index": "workspace:*"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "jsdom": "^25.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.9.3",
     "vite": "^5.4.21",
-    "vite-plugin-dts": "^3.9.1"
+    "vite-plugin-dts": "^3.9.1",
+    "vitest": "^3.0.0"
   },
   "keywords": ["editor", "view", "react", "wysiwyg"],
   "author": "Barocss Team",

--- a/packages/editor-view-react/test/EditorView.test.tsx
+++ b/packages/editor-view-react/test/EditorView.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  EditorView,
+  EditorViewLayer,
+  EditorViewContextProvider,
+  useEditorViewContext,
+  useOptionalEditorViewContext,
+} from '../src';
+
+function mockEditor() {
+  return {
+    getDocumentProxy: () => null,
+    on: () => {},
+    off: () => {},
+    dataStore: { getNode: () => null },
+    updateSelection: () => {},
+    executeCommand: () => false,
+  } as any;
+}
+
+describe('EditorView', () => {
+  it('renders root div with data-editor-view="true" and position relative', () => {
+    const editor = mockEditor();
+    const { container } = render(<EditorView editor={editor} />);
+    const root = container.firstElementChild;
+    expect(root?.getAttribute('data-editor-view')).toBe('true');
+    expect((root as HTMLElement)?.style?.position).toBe('relative');
+  });
+
+  it('renders content layer with data-bc-layer="content" and data-testid="editor-content"', () => {
+    const editor = mockEditor();
+    render(<EditorView editor={editor} />);
+    const content = screen.getByTestId('editor-content');
+    expect(content).toBeTruthy();
+    expect(content.getAttribute('data-bc-layer')).toBe('content');
+  });
+
+  it('applies options.className to root container', () => {
+    const editor = mockEditor();
+    const { container } = render(
+      <EditorView editor={editor} options={{ className: 'my-editor-root' }} />
+    );
+    const root = container.firstElementChild;
+    expect(root?.className).toContain('my-editor-root');
+  });
+
+  it('renders overlay layers only when options.layers.* is set', () => {
+    const editor = mockEditor();
+    const { container, rerender } = render(<EditorView editor={editor} />);
+    expect(container.querySelector('[data-bc-layer="decorator"]')).toBeNull();
+    expect(container.querySelector('[data-bc-layer="selection"]')).toBeNull();
+
+    rerender(
+      <EditorView
+        editor={editor}
+        options={{
+          layers: {
+            decorator: {},
+            selection: {},
+          },
+        }}
+      />
+    );
+    expect(container.querySelector('[data-bc-layer="decorator"]')).toBeTruthy();
+    expect(container.querySelector('[data-bc-layer="selection"]')).toBeTruthy();
+  });
+
+  it('renders children inside custom layer when layers.custom or children present', () => {
+    const editor = mockEditor();
+    const { container } = render(
+      <EditorView editor={editor} options={{ layers: { custom: {} } }}>
+        <span data-testid="custom-child">Custom</span>
+      </EditorView>
+    );
+    const customLayer = container.querySelector('[data-bc-layer="custom"]');
+    expect(customLayer).toBeTruthy();
+    expect(screen.getByTestId('custom-child').textContent).toBe('Custom');
+  });
+});
+
+describe('EditorViewLayer', () => {
+  it('renders div with data-bc-layer and position absolute, pointer-events none', () => {
+    const { container } = render(<EditorViewLayer layer="selection" />);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el?.getAttribute('data-bc-layer')).toBe('selection');
+    expect(el?.style?.position).toBe('absolute');
+    expect(el?.style?.pointerEvents).toBe('none');
+  });
+
+  it('uses default className and zIndex per layer type', () => {
+    const { container } = render(<EditorViewLayer layer="decorator" />);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el?.className).toContain('barocss-editor-decorators');
+    expect(el?.style?.zIndex).toBe('10');
+  });
+
+  it('merges style prop with base style', () => {
+    const { container } = render(
+      <EditorViewLayer layer="custom" style={{ opacity: 0.5 }} />
+    );
+    const el = container.firstElementChild as HTMLElement;
+    expect(el?.style?.opacity).toBe('0.5');
+    expect(el?.style?.position).toBe('absolute');
+  });
+});
+
+describe('EditorViewContext', () => {
+  it('useEditorViewContext throws when used outside Provider', () => {
+    function Consumer() {
+      useEditorViewContext();
+      return null;
+    }
+    expect(() => render(<Consumer />)).toThrow(/must be used within EditorViewContext/);
+  });
+
+  it('useOptionalEditorViewContext returns null when outside Provider', () => {
+    function Consumer() {
+      const ctx = useOptionalEditorViewContext();
+      return <span data-testid="ctx">{ctx === null ? 'null' : 'value'}</span>;
+    }
+    render(<Consumer />);
+    expect(screen.getByTestId('ctx').textContent).toBe('null');
+  });
+
+  it('EditorViewContextProvider provides editor, selectionHandler, inputHandler, mutationObserverManager, setContentEditableElement', () => {
+    const editor = mockEditor();
+    function Consumer() {
+      const ctx = useEditorViewContext();
+      return (
+        <span
+          data-testid="ctx"
+          data-has-editor={!!ctx.editor}
+          data-has-selection-handler={!!ctx.selectionHandler}
+          data-has-input-handler={!!ctx.inputHandler}
+          data-has-mutation-manager={!!ctx.mutationObserverManager}
+          data-has-set-content-editable={!!ctx.setContentEditableElement}
+        />
+      );
+    }
+    render(
+      <EditorViewContextProvider editor={editor}>
+        <Consumer />
+      </EditorViewContextProvider>
+    );
+    const el = screen.getByTestId('ctx');
+    expect(el.getAttribute('data-has-editor')).toBe('true');
+    expect(el.getAttribute('data-has-selection-handler')).toBe('true');
+    expect(el.getAttribute('data-has-input-handler')).toBe('true');
+    expect(el.getAttribute('data-has-mutation-manager')).toBe('true');
+    expect(el.getAttribute('data-has-set-content-editable')).toBe('true');
+  });
+});

--- a/packages/editor-view-react/test/dom-sync.test.ts
+++ b/packages/editor-view-react/test/dom-sync.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { findClosestInlineTextNode, reconstructModelTextFromDOM } from '../src/dom-sync/edit-position';
+
+describe('findClosestInlineTextNode', () => {
+  it('returns element with data-bc-sid when node is that element', () => {
+    const el = document.createElement('span');
+    el.setAttribute('data-bc-sid', 'n1');
+    expect(findClosestInlineTextNode(el)).toBe(el);
+  });
+
+  it('returns closest ancestor with data-bc-sid when node is child', () => {
+    const wrap = document.createElement('span');
+    wrap.setAttribute('data-bc-sid', 'n1');
+    const text = document.createTextNode('hi');
+    wrap.appendChild(text);
+    expect(findClosestInlineTextNode(text)).toBe(wrap);
+  });
+
+  it('returns null when no ancestor has data-bc-sid', () => {
+    const div = document.createElement('div');
+    const text = document.createTextNode('hi');
+    div.appendChild(text);
+    expect(findClosestInlineTextNode(text)).toBeNull();
+  });
+
+  it('returns null for null node', () => {
+    expect(findClosestInlineTextNode(null as any)).toBeNull();
+  });
+});
+
+describe('reconstructModelTextFromDOM', () => {
+  it('returns concatenated text from text nodes in order', () => {
+    const span = document.createElement('span');
+    span.setAttribute('data-bc-sid', 'n1');
+    const t1 = document.createTextNode('Hello');
+    const t2 = document.createTextNode(' ');
+    const t3 = document.createTextNode('World');
+    span.appendChild(t1);
+    span.appendChild(t2);
+    span.appendChild(t3);
+    expect(reconstructModelTextFromDOM(span)).toBe('Hello World');
+  });
+
+  it('returns empty string when element has no text nodes', () => {
+    const span = document.createElement('span');
+    span.setAttribute('data-bc-sid', 'n1');
+    expect(reconstructModelTextFromDOM(span)).toBe('');
+  });
+});

--- a/packages/editor-view-react/test/mutation-observer-manager.test.ts
+++ b/packages/editor-view-react/test/mutation-observer-manager.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createMutationObserverManager } from '../src/mutation-observer-manager';
+
+describe('createMutationObserverManager', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('setup() observes the given element and invokes callback with batched mutations', async () => {
+    const onMutations = vi.fn();
+    const manager = createMutationObserverManager(onMutations);
+
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+
+    manager.setup(el);
+
+    const text = document.createTextNode('hello');
+    el.appendChild(text);
+    text.textContent = 'world';
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(onMutations).toHaveBeenCalledTimes(1);
+    const mutations = onMutations.mock.calls[0][0] as MutationRecord[];
+    expect(Array.isArray(mutations)).toBe(true);
+    expect(mutations.length).toBeGreaterThanOrEqual(1);
+
+    manager.disconnect();
+    document.body.removeChild(el);
+  });
+
+  it('disconnect() stops observing and clears pending', async () => {
+    const onMutations = vi.fn();
+    const manager = createMutationObserverManager(onMutations);
+
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    manager.setup(el);
+    manager.disconnect();
+
+    el.appendChild(document.createTextNode('x'));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(onMutations).not.toHaveBeenCalled();
+    document.body.removeChild(el);
+  });
+});

--- a/packages/editor-view-react/test/selection-handler.test.ts
+++ b/packages/editor-view-react/test/selection-handler.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ReactSelectionHandler } from '../src/selection-handler';
+
+function createMockEditor(getNode: (id: string) => unknown) {
+  return {
+    dataStore: { getNode },
+    updateSelection: () => {},
+  } as any;
+}
+
+describe('ReactSelectionHandler', () => {
+  it('instantiates with editor and getContentEditableElement', () => {
+    const getEl = () => document.createElement('div');
+    const editor = createMockEditor(() => null);
+    const handler = new ReactSelectionHandler(editor, getEl);
+    expect(handler).toBeDefined();
+  });
+
+  it('isSelectionInsideEditableText returns false when selection is empty', () => {
+    const getEl = () => document.createElement('div');
+    const editor = createMockEditor(() => ({ stype: 'inline-text' }));
+    const handler = new ReactSelectionHandler(editor, getEl);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    expect(handler.isSelectionInsideEditableText()).toBe(false);
+  });
+
+  it('isSelectionInsideEditableText returns true when selection is inside inline-text node', () => {
+    const root = document.createElement('div');
+    root.setAttribute('contenteditable', 'true');
+    const span = document.createElement('span');
+    span.setAttribute('data-bc-sid', 't1');
+    const text = document.createTextNode('hello');
+    span.appendChild(text);
+    root.appendChild(span);
+    document.body.appendChild(root);
+
+    const getEl = () => root;
+    const editor = createMockEditor((id) => (id === 't1' ? { stype: 'inline-text' } : null));
+    const handler = new ReactSelectionHandler(editor, getEl);
+
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, 2);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+
+    expect(handler.isSelectionInsideEditableText()).toBe(true);
+
+    document.body.removeChild(root);
+    sel?.removeAllRanges();
+  });
+
+  it('setProgrammaticChange(true) causes handleSelectionChange to skip updateSelection', () => {
+    const root = document.createElement('div');
+    const span = document.createElement('span');
+    span.setAttribute('data-bc-sid', 't1');
+    span.appendChild(document.createTextNode('x'));
+    root.appendChild(span);
+    document.body.appendChild(root);
+
+    const updateSelection = vi.fn();
+    const editor = createMockEditor((id) => (id === 't1' ? { stype: 'inline-text' } : null));
+    editor.updateSelection = updateSelection;
+
+    const getEl = () => root;
+    const handler = new ReactSelectionHandler(editor, getEl);
+
+    const range = document.createRange();
+    range.setStart(span.firstChild!, 0);
+    range.setEnd(span.firstChild!, 1);
+    window.getSelection()?.removeAllRanges();
+    window.getSelection()?.addRange(range);
+
+    handler.setProgrammaticChange(true);
+    handler.handleSelectionChange();
+    expect(updateSelection).not.toHaveBeenCalled();
+
+    handler.setProgrammaticChange(false);
+    handler.handleSelectionChange();
+    expect(updateSelection).toHaveBeenCalled();
+
+    document.body.removeChild(root);
+  });
+});

--- a/packages/editor-view-react/vitest.config.ts
+++ b/packages/editor-view-react/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+    passWithNoTests: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,7 +247,7 @@ importers:
         version: 4.5.4(@types/node@20.19.30)(typescript@5.9.3)(vite@5.4.21)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.30)(@vitest/ui@1.6.1)
+        version: 3.2.4(@types/node@20.19.30)(jsdom@25.0.1)
 
   packages/collaboration-liveblocks:
     dependencies:
@@ -272,7 +272,7 @@ importers:
         version: 4.5.4(@types/node@20.19.30)(typescript@5.9.3)(vite@5.4.21)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.30)(@vitest/ui@1.6.1)
+        version: 3.2.4(@types/node@20.19.30)(jsdom@25.0.1)
 
   packages/collaboration-yjs:
     dependencies:
@@ -297,7 +297,7 @@ importers:
         version: 4.5.4(@types/node@20.19.30)(typescript@5.9.3)(vite@5.4.21)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.30)(@vitest/ui@1.6.1)
+        version: 3.2.4(@types/node@20.19.30)(jsdom@25.0.1)
 
   packages/converter:
     dependencies:
@@ -409,7 +409,7 @@ importers:
         version: 3.9.1(@types/node@20.19.30)(typescript@5.9.3)(vite@5.4.21)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.30)(@vitest/ui@1.6.1)
+        version: 3.2.4(@types/node@20.19.30)(jsdom@25.0.1)
 
   packages/editor-core:
     dependencies:
@@ -503,12 +503,18 @@ importers:
         specifier: workspace:*
         version: link:../text-run-index
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.10)(react-dom@19.2.4)(react@19.2.4)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.10
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.10)
+      jsdom:
+        specifier: ^25.0.0
+        version: 25.0.1
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -524,6 +530,9 @@ importers:
       vite-plugin-dts:
         specifier: ^3.9.1
         version: 3.9.1(@types/node@20.19.30)(typescript@5.9.3)(vite@5.4.21)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@20.19.30)(jsdom@25.0.1)
 
   packages/extensions:
     dependencies:
@@ -5321,6 +5330,43 @@ packages:
       defer-to-connect: 2.0.1
     dev: false
 
+  /@testing-library/dom@10.4.1:
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@babel/code-frame': 7.28.6
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+    dev: true
+
+  /@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.10)(react-dom@19.2.4)(react@19.2.4):
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      '@types/react': 19.2.10
+      '@types/react-dom': 19.2.3(@types/react@19.2.10)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    dev: true
+
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -5328,6 +5374,10 @@ packages:
 
   /@types/argparse@1.0.38:
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+    dev: true
+
+  /@types/aria-query@5.0.4:
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
     dev: true
 
   /@types/babel__core@7.20.5:
@@ -6625,6 +6675,12 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  /aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+    dependencies:
+      dequal: 2.0.3
+    dev: true
 
   /array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -8127,6 +8183,10 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.3
+    dev: true
+
+  /dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
     dev: true
 
   /dom-converter@0.2.0:
@@ -9900,6 +9960,42 @@ packages:
       - utf-8-validate
     dev: true
 
+  /jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.19.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -10170,6 +10266,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
+
+  /lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
     dev: true
 
   /magic-string@0.30.21:
@@ -12295,6 +12396,15 @@ packages:
       renderkid: 3.0.0
     dev: false
 
+  /pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+    dev: true
+
   /pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -12471,6 +12581,10 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  /react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+    dev: true
 
   /react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -13604,6 +13718,17 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
+  /tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+    dev: true
+
+  /tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+    dependencies:
+      tldts-core: 6.1.86
+    dev: true
+
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -13627,6 +13752,13 @@ packages:
       punycode: 2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
+    dev: true
+
+  /tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+    dependencies:
+      tldts: 6.1.86
     dev: true
 
   /tr46@5.1.1:
@@ -14331,6 +14463,71 @@ packages:
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(@types/node@20.19.30)
+      vite-node: 3.2.4(@types/node@20.19.30)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@3.2.4(@types/node@20.19.30)(jsdom@25.0.1):
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 5.2.3
+      '@types/node': 20.19.30
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.21)
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      jsdom: 25.0.1
       magic-string: 0.30.21
       pathe: 2.0.3
       picomatch: 4.0.3


### PR DESCRIPTION
## Summary

- **packages/editor-view-react**
  - Spec: `docs/editor-view-react-spec.md` — goals, architecture, API, context, layers, selection/input, DOM sync, MutationObserver, test strategy.
  - Tests: Vitest + jsdom + @testing-library/react — 23 tests (EditorView, EditorViewLayer, EditorViewContext, ReactSelectionHandler, ReactMutationObserverManager, dom-sync).
  - SPEC_VERIFICATION.md — spec vs implementation verification and checklist.
  - README: testing section and spec links.
- **packages/datastore**: Remove unused `@ts-expect-error` in range-operations.ts (unblocks editor-view-react type-check).
- **pnpm-lock.yaml**: editor-view-react devDependencies (vitest, jsdom, @testing-library/react).

Closes #171

## Verification

`pnpm --filter @barocss/editor-view-react test:run` — 23 tests pass.
`pnpm --filter @barocss/editor-view-react type-check` — passes.

Made with [Cursor](https://cursor.com)