### PR TITLE
feat(schema): Barocss Standard Schema spec and presets

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -21,6 +21,7 @@ This directory and the linked package specs define **what the editor and each pa
 ### Editor-wide
 
 - **`docs/specs/editor.md`** — Document model (tree, block, text, marks), selection (resolution, `selectionAfter`), operation semantics (e.g. insertParagraph, insertText guarantees), and references to architecture/flow docs.
+- **`docs/specs/standard-schema.md`** — Barocss standard schema: canonical node types, marks, content rules; minimal vs full tier; presets `getMinimalSchemaDefinition()` and `getStandardSchemaDefinition()` from `@barocss/schema`.
 
 ### Package specs
 

--- a/docs/specs/standard-schema.md
+++ b/docs/specs/standard-schema.md
@@ -1,0 +1,241 @@
+# Barocss Standard Schema
+
+This document defines the **standard document schema** for the Barocss editor: the canonical set of node types, marks, content rules, and attributes that the editor supports. It is the single source of truth for "what document structure does Barocss use?"
+
+---
+
+## 1. Purpose
+
+- **Single source of truth**: All apps (editor-react, editor-test, docs-site demo) and packages (model, datastore, extensions) that depend on document structure refer to this schema or to presets derived from it.
+- **Two tiers**: **Minimal** (smallest set required for a working editor) and **Full** (all node types and marks for rich editing). Apps choose a tier or extend from it.
+- **Consistency**: Same node names (`stype`), content expressions, and attribute shapes across DataStore, Model, renderer (DSL templates), and extensions. Schema validation and operations (insertParagraph, wrapInList, etc.) assume these types exist when used.
+
+---
+
+## 2. Top Node
+
+- **topNode**: `"document"`
+- **Document node** (`stype: "document"`): Root of the tree. **group**: `"document"`. **content**: `"block+"` (one or more block nodes). Not selectable; not droppable by user (structural root).
+
+---
+
+## 3. Tiers
+
+### 3.1 Minimal schema
+
+Required for any Barocss editor that supports typing and basic blocks. Used by quick-start demos and minimal apps.
+
+| Node type    | group    | content   | Description |
+|-------------|----------|-----------|-------------|
+| document    | document | block+    | Root. |
+| paragraph   | block    | inline*   | Text block. |
+| inline-text | inline   | —         | Text leaf; has `text` and optional `marks`. |
+
+| Mark type | group       | Description |
+|-----------|-------------|-------------|
+| bold      | text-style  | Strong. |
+| italic    | text-style  | Emphasis. |
+
+- **Content rules**: Document contains one or more blocks; paragraph contains zero or more inlines; inline-text is leaf (no content in schema; model stores `text` and `marks`).
+- **Optional in minimal**: `heading` (block, inline*, attrs: level) — useful for titles; can be added without going full.
+
+### 3.2 Full schema
+
+All node types and marks used by editor-test and editor-react: blocks (paragraph, heading, blockQuote, list, listItem, codeBlock, tables, figures, media, etc.), inlines (inline-text, inline-image, hardBreak, mathInline, fields, etc.), and all marks (bold, italic, link, fontColor, code, mention, etc.). See §4 and §5 for the full list.
+
+- **Use case**: Full-featured editor (lists, tables, media, comments, footnotes, etc.).
+- **Preset**: `getStandardSchemaDefinition()` from `@barocss/schema` returns the full standard as `SchemaDefinition`. Apps use `createSchema('app', getStandardSchemaDefinition())` or extend from it.
+
+---
+
+## 4. Node Types (Full Schema)
+
+### 4.1 Document and structure
+
+| name      | group    | content | attrs | Notes |
+|-----------|----------|---------|-------|--------|
+| document  | document | block+  | —     | Top node. |
+| docSection| block    | block+  | —     | Section container. |
+| columns   | block    | column+ | —     | Multi-column. |
+| column    | block    | block+  | width?| Column; optional width. |
+
+### 4.2 Block text and headings
+
+| name     | group | content  | attrs    | Notes |
+|----------|-------|----------|----------|--------|
+| paragraph| block | inline*  | placeholder? | Default text block; optional placeholder when empty. |
+| heading  | block | inline*  | level (required) | h1–h6. |
+| blockQuote | block | block+ | —      | Quote container. |
+| pullQuote| block | inline*  | —        | Pull quote. |
+| codeBlock| block | text*    | language?| Pre/code; editable text. |
+| horizontalRule | block | — | —     | atom. |
+| pageBreak| block | —        | —        | atom. |
+
+### 4.3 Lists and tasks
+
+| name    | group | content   | attrs        | Notes |
+|---------|-------|-----------|--------------|--------|
+| list    | block | listItem+ | type? (bullet)| bullet \| ordered. |
+| listItem| block | block+    | —            | Item container. |
+| taskItem| block | inline*   | checked?     | Checkbox. |
+
+### 4.4 Callouts, details, description list
+
+| name    | group | content      | attrs           | Notes |
+|---------|-------|--------------|-----------------|--------|
+| callout | block | block+       | type?, title?   | info \| warning etc. |
+| bDetails| block | bSummary block+ | —             | Collapsible. |
+| bSummary| block | inline*      | —               | Summary line. |
+| descList| block | (descTerm descDef)+ | —         | DL. |
+| descTerm| block | inline+     | —               | DT. |
+| descDef | block | block+      | —               | DD. |
+
+### 4.5 Figures, tables, media
+
+| name         | group | content                    | attrs     | Notes |
+|--------------|-------|----------------------------|-----------|--------|
+| bFigure      | block | (inline-image \| bTable \| codeBlock \| media*)+ bFigcaption? | — | Figure. |
+| bFigcaption  | block | inline*                    | —         | Caption. |
+| bTable       | block | (bTableHeader)? bTableBody+ (bTableFooter)? | caption? | Table. |
+| bTableHeader | block | bTableHeaderCell+          | —         | thead. |
+| bTableBody   | block | bTableRow+                 | —         | tbody. |
+| bTableFooter | block | bTableRow+                 | —         | tfoot. |
+| bTableRow    | block | bTableCell+                | —         | tr. |
+| bTableHeaderCell | block | inline* | colspan?, rowspan? | th. |
+| bTableCell  | block | inline*                    | colspan?, rowspan? | td. |
+| mediaVideo   | block | —                          | src, poster?, controls? | atom. |
+| mediaAudio   | block | —                          | src, controls? | atom. |
+| mediaEmbed   | block | —                          | provider, id, title? | atom. |
+
+### 4.6 Inline nodes
+
+| name          | group  | content | attrs   | Notes |
+|---------------|--------|---------|---------|--------|
+| inline-text   | inline | —       | —       | Text + marks. |
+| inline-image  | inline | —       | src, alt?| atom. |
+| emoji         | inline | —       | shortcode?, unicode? | atom; explicit emoji (TipTap-style). |
+| hardBreak     | inline | —       | —       | atom. br. |
+| mathInline    | inline | —       | tex, engine?| atom. |
+| mathBlock     | block  | —       | tex, engine?| atom. |
+| fieldPageNumber | inline | —     | —       | atom. |
+| fieldPageCount | inline | —     | —       | atom. |
+| fieldDateTime | inline | —     | format? | atom. |
+| fieldDocTitle | inline | —     | —       | atom. |
+| fieldAuthor   | inline | —     | —       | atom. |
+| bookmarkAnchor| inline | —       | id      | atom. |
+
+### 4.7 Doc-level and special
+
+| name         | group | content | attrs | Notes |
+|--------------|-------|---------|-------|--------|
+| docHeader    | block | inline* | —     | Header. |
+| docFooter    | block | inline* | —     | Footer. |
+| toc          | block | —       | —     | atom. TOC. |
+| footnoteDef  | block | inline* | id    | Footnote. |
+| endnoteDef   | block | inline* | id    | Endnote. |
+| bibliography | block | block*  | —     | Refs. |
+| commentThread| block | inline* | id    | Comment. |
+| indexBlock   | block | block*  | —     | Index. |
+| chart        | block | —       | title?, values | atom; external. |
+
+---
+
+## 5. Marks (Full Schema)
+
+All marks have **group**: `"text-style"` unless noted. Common attrs are omitted below; see preset for full attrs.
+
+| name         | Typical attrs | Notes |
+|--------------|----------------|--------|
+| bold         | weight?        | Strong. |
+| italic       | style?         | Emphasis. |
+| underline    | style?         | Underline. |
+| strikethrough| style?         | Strikethrough. |
+| fontColor    | color?         | Text color. |
+| bgColor      | bgColor?       | Highlight. |
+| code         | language?      | Inline code. |
+| link         | href (required), title? | Link. |
+| highlight    | color?         | Highlight. |
+| fontSize     | size?          | Font size. |
+| fontFamily   | family?        | Font family. |
+| subscript    | position?      | Sub. |
+| superscript  | position?      | Super. |
+| smallCaps    | variant?       | Small caps. |
+| letterSpacing| spacing?       | Letter spacing. |
+| wordSpacing  | spacing?       | Word spacing. |
+| lineHeight   | height?        | Line height. |
+| textShadow   | shadow?        | Text shadow. |
+| border       | style?, width?, color? | Text border. |
+| spanLang     | lang (required), dir? | Language span. |
+| kbd          | —              | Keyboard key. |
+| mention      | id (required)  | Mention. |
+| spoiler      | revealed?      | Spoiler. |
+| footnoteRef  | id (required)  | Footnote ref. |
+
+---
+
+## 6. Content Expressions
+
+- **block+**: One or more block nodes.
+- **block***: Zero or more block nodes.
+- **inline***: Zero or more inline nodes.
+- **inline+**: One or more inline nodes.
+- **text***: Zero or more text (inline-text) nodes; used in codeBlock.
+- **listItem+**: One or more listItem.
+- **column+**: One or more column.
+- **(A | B)+**: One or more of A or B.
+- **(A)?**: Optional A.
+- **A+ B?**: One or more A, optionally followed by B.
+
+Group names **block** and **inline** are used in content expressions; node types declare their group so that validators can resolve expressions. The schema package's content model validation uses these rules; see `@barocss/schema` and `packages/schema/README.md`.
+
+---
+
+## 7. Relationship to Packages and Apps
+
+- **Schema package** (`@barocss/schema`): Exports `createSchema`, `SchemaDefinition`, `NodeTypeDefinition`, `MarkDefinition`. Presets: `getMinimalSchemaDefinition()`, `getStandardSchemaDefinition()` (see §8).
+- **DataStore**: Accepts a Schema instance; uses it for validation and structure (e.g. content rules). Node `stype` must match a schema node name.
+- **Model / extensions**: Operations (insertParagraph, wrapInList, etc.) assume the corresponding node types exist in the schema. If an app uses minimal schema, list operations are not applicable unless the app extends the schema with list/listItem.
+- **DSL / renderer**: Templates are registered with `define(stype, template)` for each node type the app uses. The **standard schema** does not define templates; it defines structure. Apps or a shared "standard templates" module register DSL templates for standard node types.
+- **Apps**: editor-react and editor-test use the full standard schema (or a copy); docs-site demo uses minimal. All can call `createSchema('app', getStandardSchemaDefinition())` or `createSchema('app', getMinimalSchemaDefinition())` and optionally extend.
+
+---
+
+## 8. Presets (Machine-Readable)
+
+- **getMinimalSchemaDefinition()**: Returns a `SchemaDefinition` with topNode `"document"`, nodes (document, paragraph, inline-text), marks (bold, italic). Use for demos and minimal editors.
+- **getStandardSchemaDefinition()**: Returns the full standard schema (all nodes and marks in §4 and §5) as `SchemaDefinition`. Use for full-featured editors. Single source of truth for the full preset; editor-react and editor-test can import from `@barocss/schema` instead of defining their own copy.
+
+Location: `packages/schema/src/standard-schema.ts` (or `presets/standard-schema.ts`). Export from `packages/schema/src/index.ts`.
+
+---
+
+## 9. Extending the Standard
+
+- **Extend from full**: `createSchema(getStandardSchema(), { nodes: { ... }, marks: { ... } })` to add or override node/mark types.
+- **Extend from minimal**: `createSchema(getMinimalSchema(), { nodes: { heading: { ... } }, marks: { link: { ... } } })` to add a few types without pulling the full set.
+- **Custom app schema**: Define a full `SchemaDefinition` and pass to `createSchema('app', definition)`. Document the delta from standard in app docs if relevant.
+
+---
+
+## 10. Comparison with other editors
+
+Barocss standard schema is aligned with concepts from ProseMirror, TipTap, and Lexical where applicable.
+
+- **ProseMirror** (schema-basic, schema-list): `doc` → document; `paragraph`, `blockquote`, `heading`, `horizontal_rule`, `text` → paragraph, blockQuote, heading, horizontalRule, inline-text; list nodes → list, listItem. Content expressions and group-based content (block+, inline*) match. Marks (strong, em, link, code) → bold, italic, link, code.
+- **TipTap**: Document, Paragraph, Blockquote, Heading, CodeBlock, HorizontalRule, HardBreak, BulletList/OrderedList, ListItem, TaskList, TaskItem, Details/DetailsSummary/DetailsContent, Table (with header/row/cell), Image, Audio, Mention, Emoji, Youtube/Twitch embeds. Barocss covers these via document, paragraph, blockQuote, heading, codeBlock, horizontalRule, hardBreak, list/listItem, taskItem, bDetails/bSummary, bTable family, inline-image/mediaVideo/mediaAudio, mediaEmbed (provider/id), mention mark, and (in full schema) emoji node.
+- **Lexical**: RootNode → document; ElementNode (block/inline) → block vs inline group; TextNode (format: bold, italic, underline, strikethrough, code, highlight, subscript, superscript) → corresponding marks; LineBreakNode → hardBreak; DecoratorNode → custom block/inline is handled by Barocss decorators and atom nodes (e.g. mediaEmbed, chart).
+
+Additions adopted from other editors in the full schema:
+
+- **placeholder** (paragraph, optional attr): Hint text when the block is empty (e.g. "Write something…"). Common in ProseMirror/Lexical as a view or node attribute; storing it in the schema allows round-trip and consistent behavior.
+- **emoji** (inline atom): Explicit emoji node with optional shortcode/unicode (TipTap-style). Apps can use Unicode in inline-text instead; the node supports fallback rendering and consistent handling.
+
+Not added (covered by existing types or view layer): block-level "Image" only (bFigure + inline-image or bFigure with single child suffices), separate Youtube/Twitch node types (mediaEmbed with provider covers them), placeholder implemented only in view (we add optional attr for schema round-trip).
+
+---
+
+## 11. References
+
+- **Schema package**: `packages/schema/README.md`, `packages/schema/src/types.ts`, `packages/schema/src/schema.ts`
+- **Editor-wide spec**: `docs/specs/editor.md` (document model, selection, operations)
+- **Model operations**: `packages/model/SPEC.md` (operation semantics; many assume standard node types)

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -39,3 +39,6 @@ export {
   createEditorManager,
   editorManager
 } from './editor-manager';
+
+// Standard schema presets (spec: docs/specs/standard-schema.md)
+export { getMinimalSchemaDefinition, getStandardSchemaDefinition } from './standard-schema';

--- a/packages/schema/src/standard-schema.ts
+++ b/packages/schema/src/standard-schema.ts
@@ -1,0 +1,116 @@
+/**
+ * Barocss Standard Schema presets.
+ * Single source of truth for minimal and full document schema.
+ * Spec: docs/specs/standard-schema.md
+ */
+import type { SchemaDefinition } from './types';
+
+/**
+ * Minimal schema: document, paragraph, inline-text, marks bold/italic.
+ * Use for demos and minimal editors.
+ */
+export function getMinimalSchemaDefinition(): SchemaDefinition {
+  return {
+    topNode: 'document',
+    nodes: {
+      document: { name: 'document', group: 'document', content: 'block+' },
+      paragraph: { name: 'paragraph', group: 'block', content: 'inline*' },
+      'inline-text': { name: 'inline-text', group: 'inline' },
+    },
+    marks: {
+      bold: { name: 'bold', group: 'text-style' },
+      italic: { name: 'italic', group: 'text-style' },
+    },
+  };
+}
+
+/**
+ * Full standard schema: all node types and marks used by editor-test and editor-react.
+ * Use for full-featured editors. Single source of truth; apps import from @barocss/schema.
+ */
+export function getStandardSchemaDefinition(): SchemaDefinition {
+  return {
+    topNode: 'document',
+    nodes: {
+      document: { name: 'document', group: 'document', content: 'block+' },
+      heading: { name: 'heading', group: 'block', content: 'inline*', attrs: { level: { type: 'number', required: true } } },
+      paragraph: { name: 'paragraph', group: 'block', content: 'inline*', attrs: { placeholder: { type: 'string', required: false } } },
+      blockQuote: { name: 'blockQuote', group: 'block', content: 'block+' },
+      pullQuote: { name: 'pullQuote', group: 'block', content: 'inline*' },
+      codeBlock: { name: 'codeBlock', group: 'block', content: 'text*', attrs: { language: { type: 'string', required: false } } },
+      horizontalRule: { name: 'horizontalRule', group: 'block', atom: true },
+      pageBreak: { name: 'pageBreak', group: 'block', atom: true },
+      docSection: { name: 'docSection', group: 'block', content: 'block+' },
+      columns: { name: 'columns', group: 'block', content: 'column+' },
+      column: { name: 'column', group: 'block', content: 'block+', attrs: { width: { type: 'string', required: false } } },
+      toc: { name: 'toc', group: 'block', atom: true },
+      footnoteDef: { name: 'footnoteDef', group: 'block', content: 'inline*', attrs: { id: { type: 'string', required: true } } },
+      list: { name: 'list', group: 'block', content: 'listItem+', attrs: { type: { type: 'string', default: 'bullet' } } },
+      listItem: { name: 'listItem', group: 'block', content: 'block+' },
+      taskItem: { name: 'taskItem', group: 'block', content: 'inline*', attrs: { checked: { type: 'boolean', default: false } } },
+      callout: { name: 'callout', group: 'block', content: 'block+', attrs: { type: { type: 'string', default: 'info' }, title: { type: 'string', required: false } } },
+      bFigure: { name: 'bFigure', group: 'block', content: '(inline-image|bTable|codeBlock|mediaEmbed|mediaVideo|mediaAudio)+ bFigcaption?' },
+      bFigcaption: { name: 'bFigcaption', group: 'block', content: 'inline*' },
+      bDetails: { name: 'bDetails', group: 'block', content: 'bSummary block+' },
+      bSummary: { name: 'bSummary', group: 'block', content: 'inline*' },
+      descList: { name: 'descList', group: 'block', content: '(descTerm descDef)+' },
+      descTerm: { name: 'descTerm', group: 'block', content: 'inline+' },
+      descDef: { name: 'descDef', group: 'block', content: 'block+' },
+      mathInline: { name: 'mathInline', group: 'inline', atom: true, attrs: { tex: { type: 'string', required: true }, engine: { type: 'string', default: 'katex' } } },
+      mathBlock: { name: 'mathBlock', group: 'block', atom: true, attrs: { tex: { type: 'string', required: true }, engine: { type: 'string', default: 'katex' } } },
+      mediaVideo: { name: 'mediaVideo', group: 'block', atom: true, attrs: { src: { type: 'string', required: true }, poster: { type: 'string', required: false }, controls: { type: 'boolean', default: true } } },
+      mediaAudio: { name: 'mediaAudio', group: 'block', atom: true, attrs: { src: { type: 'string', required: true }, controls: { type: 'boolean', default: true } } },
+      mediaEmbed: { name: 'mediaEmbed', group: 'block', atom: true, attrs: { provider: { type: 'string', required: true }, id: { type: 'string', required: true }, title: { type: 'string', required: false } } },
+      hardBreak: { name: 'hardBreak', group: 'inline', atom: true },
+      chart: { name: 'chart', group: 'block', atom: true, attrs: { title: { type: 'string', required: false }, values: { type: 'string', required: true } } },
+      docHeader: { name: 'docHeader', group: 'block', content: 'inline*' },
+      docFooter: { name: 'docFooter', group: 'block', content: 'inline*' },
+      bibliography: { name: 'bibliography', group: 'block', content: 'block*' },
+      commentThread: { name: 'commentThread', group: 'block', content: 'inline*', attrs: { id: { type: 'string', required: true } } },
+      endnoteDef: { name: 'endnoteDef', group: 'block', content: 'inline*', attrs: { id: { type: 'string', required: true } } },
+      indexBlock: { name: 'indexBlock', group: 'block', content: 'block*' },
+      fieldPageNumber: { name: 'fieldPageNumber', group: 'inline', atom: true },
+      fieldPageCount: { name: 'fieldPageCount', group: 'inline', atom: true },
+      fieldDateTime: { name: 'fieldDateTime', group: 'inline', atom: true, attrs: { format: { type: 'string', required: false } } },
+      fieldDocTitle: { name: 'fieldDocTitle', group: 'inline', atom: true },
+      fieldAuthor: { name: 'fieldAuthor', group: 'inline', atom: true },
+      bookmarkAnchor: { name: 'bookmarkAnchor', group: 'inline', atom: true, attrs: { id: { type: 'string', required: true } } },
+      bTable: { name: 'bTable', group: 'block', content: '(bTableHeader)? bTableBody+ (bTableFooter)?', attrs: { caption: { type: 'string', required: false } } },
+      bTableHeader: { name: 'bTableHeader', group: 'block', content: 'bTableHeaderCell+' },
+      bTableBody: { name: 'bTableBody', group: 'block', content: 'bTableRow+' },
+      bTableFooter: { name: 'bTableFooter', group: 'block', content: 'bTableRow+' },
+      bTableHeaderCell: { name: 'bTableHeaderCell', group: 'block', content: 'inline*', attrs: { colspan: { type: 'number', default: 1 }, rowspan: { type: 'number', default: 1 } } },
+      bTableRow: { name: 'bTableRow', group: 'block', content: 'bTableCell+' },
+      bTableCell: { name: 'bTableCell', group: 'block', content: 'inline*', attrs: { colspan: { type: 'number', default: 1 }, rowspan: { type: 'number', default: 1 } } },
+      'inline-image': { name: 'inline-image', group: 'inline', atom: true, attrs: { src: { type: 'string', required: true }, alt: { type: 'string', required: false } } },
+      emoji: { name: 'emoji', group: 'inline', atom: true, attrs: { shortcode: { type: 'string', required: false }, unicode: { type: 'string', required: false } } },
+      'inline-text': { name: 'inline-text', group: 'inline' },
+    },
+    marks: {
+      bold: { name: 'bold', group: 'text-style', attrs: { weight: { type: 'string', default: 'bold' } } },
+      italic: { name: 'italic', group: 'text-style', attrs: { style: { type: 'string', default: 'italic' } } },
+      fontColor: { name: 'fontColor', group: 'text-style', attrs: { color: { type: 'string', default: '#000000' } } },
+      bgColor: { name: 'bgColor', group: 'text-style', attrs: { bgColor: { type: 'string', default: '#ffff00' } } },
+      underline: { name: 'underline', group: 'text-style', attrs: { style: { type: 'string', default: 'underline' } } },
+      strikethrough: { name: 'strikethrough', group: 'text-style', attrs: { style: { type: 'string', default: 'line-through' } } },
+      code: { name: 'code', group: 'text-style', attrs: { language: { type: 'string', default: 'text' } } },
+      link: { name: 'link', group: 'text-style', attrs: { href: { type: 'string', required: true }, title: { type: 'string', required: false } } },
+      highlight: { name: 'highlight', group: 'text-style', attrs: { color: { type: 'string', default: '#ffff00' } } },
+      fontSize: { name: 'fontSize', group: 'text-style', attrs: { size: { type: 'string', default: '14px' } } },
+      fontFamily: { name: 'fontFamily', group: 'text-style', attrs: { family: { type: 'string', default: 'Arial' } } },
+      subscript: { name: 'subscript', group: 'text-style', attrs: { position: { type: 'string', default: 'sub' } } },
+      superscript: { name: 'superscript', group: 'text-style', attrs: { position: { type: 'string', default: 'super' } } },
+      smallCaps: { name: 'smallCaps', group: 'text-style', attrs: { variant: { type: 'string', default: 'small-caps' } } },
+      letterSpacing: { name: 'letterSpacing', group: 'text-style', attrs: { spacing: { type: 'string', default: '0.1em' } } },
+      wordSpacing: { name: 'wordSpacing', group: 'text-style', attrs: { spacing: { type: 'string', default: '0.2em' } } },
+      lineHeight: { name: 'lineHeight', group: 'text-style', attrs: { height: { type: 'string', default: '1.5' } } },
+      textShadow: { name: 'textShadow', group: 'text-style', attrs: { shadow: { type: 'string', default: '1px 1px 2px rgba(0,0,0,0.3)' } } },
+      border: { name: 'border', group: 'text-style', attrs: { style: { type: 'string', default: 'solid' }, width: { type: 'string', default: '1px' }, color: { type: 'string', default: '#000000' } } },
+      spanLang: { name: 'spanLang', group: 'text-style', attrs: { lang: { type: 'string', required: true }, dir: { type: 'string', required: false } } },
+      kbd: { name: 'kbd', group: 'text-style' },
+      mention: { name: 'mention', group: 'text-style', attrs: { id: { type: 'string', required: true } } },
+      spoiler: { name: 'spoiler', group: 'text-style', attrs: { revealed: { type: 'boolean', default: false } } },
+      footnoteRef: { name: 'footnoteRef', group: 'text-style', attrs: { id: { type: 'string', required: true } } },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- **Spec**: `docs/specs/standard-schema.md` — tiers (minimal/full), node types, marks, content expressions. §10 Comparison with ProseMirror, TipTap, Lexical.
- **Presets**: `packages/schema/src/standard-schema.ts` — `getMinimalSchemaDefinition()`, `getStandardSchemaDefinition()`.
- **Additions from other editors**: paragraph optional `placeholder` attr; inline `emoji` node (shortcode?, unicode?).
- `docs/specs/README.md`: link to standard-schema. `packages/schema/src/index.ts`: export presets.

Closes #173

Made with [Cursor](https://cursor.com)