### PR TITLE
feat(extensions,converter): insertEmoji command + emoji/placeholder HTML rules

### DIFF
--- a/packages/converter/docs/standard-schema-html.md
+++ b/packages/converter/docs/standard-schema-html.md
@@ -1,0 +1,30 @@
+# Standard schema HTML conversion
+
+HTML conversion rules for Barocss standard schema node types: **emoji** and **paragraph placeholder**. Registered by `registerDefaultHTMLRules()`.
+
+## Emoji
+
+- **Model**: `stype: 'emoji'`, inline atom; attrs: `shortcode?`, `unicode?`.
+- **HTML → Model (parser)**  
+  - Matches `<span data-emoji>` (optionally with `data-shortcode`, `data-unicode`).  
+  - Attributes: `shortcode` from `data-shortcode`, `unicode` from `data-unicode` or from element text content.
+- **Model → HTML (converter)**  
+  - Output: `<span data-emoji data-shortcode="..." data-unicode="...">…</span>`.  
+  - Inner text is the unicode character or shortcode when present.
+
+Round-trip: paste/export HTML with `<span data-emoji data-shortcode=":smile:" data-unicode="😀">😀</span>` and parse back to an `emoji` node with the same attrs.
+
+## Paragraph placeholder
+
+- **Model**: `paragraph` with optional `attributes.placeholder` (empty-block hint).
+- **HTML → Model (parser)**  
+  - On `<p>`, reads `data-placeholder` and sets `attributes.placeholder`.
+- **Model → HTML (converter)**  
+  - On paragraph, if `node.attributes.placeholder` is set, outputs `<p data-placeholder="...">PLACEHOLDER_CONTENT</p>`.
+
+Round-trip: `<p data-placeholder="Write something…">...</p>` parses to a paragraph with `attributes.placeholder === "Write something…"` and exports back with the same attribute.
+
+## References
+
+- Standard schema: `docs/specs/standard-schema.md` (§4.2 paragraph, §4.6 emoji).
+- Rules: `packages/converter/src/rules/default-html-rules.ts`.

--- a/packages/converter/src/rules/default-html-rules.ts
+++ b/packages/converter/src/rules/default-html-rules.ts
@@ -7,9 +7,26 @@ import { defineParser, defineConverter } from '../api';
 export function registerDefaultHTMLRules(): void {
   // === Parser Rules (HTML → Model) ===
   
-  // Paragraph
+  // Paragraph (including optional data-placeholder for empty-block hint; preserve other data-*)
   defineParser('paragraph', 'html', {
-    parseDOM: [{ tag: 'p' }]
+    parseDOM: [
+      {
+        tag: 'p',
+        getAttrs: (node) => {
+          const el = node as Element;
+          const attrs: Record<string, string> = {};
+          const placeholder = el.getAttribute?.('data-placeholder');
+          if (placeholder != null) attrs.placeholder = placeholder;
+          for (const name of el.getAttributeNames?.() ?? []) {
+            if (name.startsWith('data-')) {
+              const val = el.getAttribute(name);
+              if (val != null) attrs[name] = val;
+            }
+          }
+          return attrs;
+        }
+      }
+    ]
   });
   
   // Heading
@@ -128,6 +145,27 @@ export function registerDefaultHTMLRules(): void {
     ]
   });
 
+  // Emoji (standard schema inline atom: shortcode?, unicode?)
+  defineParser('emoji', 'html', {
+    parseDOM: [
+      {
+        tag: 'span',
+        getAttrs: (node) => {
+          const el = node as Element;
+          if (!el.getAttribute?.('data-emoji')) return null;
+          const shortcode = el.getAttribute('data-shortcode') ?? undefined;
+          const unicode = el.getAttribute('data-unicode') ?? undefined;
+          const textContent = el.textContent?.trim();
+          return {
+            shortcode: shortcode || undefined,
+            unicode: unicode || textContent || undefined
+          };
+        },
+        priority: 110
+      }
+    ]
+  });
+
   // Image
   defineParser('image', 'html', {
     parseDOM: [
@@ -146,12 +184,12 @@ export function registerDefaultHTMLRules(): void {
 
   // === Converter Rules (Model → HTML) ===
   
-  // Paragraph
+  // Paragraph (optional data-placeholder for empty-block hint)
   defineConverter('paragraph', 'html', {
     convert: (node) => {
-      // Content conversion is handled recursively inside HTMLConverter
-      // Here, only return placeholder (actual conversion performed in HTMLConverter._convertContentToHTML)
-      return '<p>PLACEHOLDER_CONTENT</p>';
+      const placeholder = node.attributes?.placeholder;
+      const attr = placeholder != null ? ` data-placeholder="${escapeHTML(String(placeholder))}"` : '';
+      return `<p${attr}>PLACEHOLDER_CONTENT</p>`;
     }
   });
   
@@ -222,6 +260,19 @@ export function registerDefaultHTMLRules(): void {
       const isHeader = node.attributes?.header === true;
       const tag = isHeader ? 'th' : 'td';
       return `<${tag}>PLACEHOLDER_CONTENT</${tag}>`;
+    }
+  });
+
+  // Emoji (standard schema: shortcode?, unicode?)
+  defineConverter('emoji', 'html', {
+    convert: (node) => {
+      const attrs = node.attributes || {};
+      const shortcode = attrs.shortcode != null ? String(attrs.shortcode) : '';
+      const unicode = attrs.unicode != null ? String(attrs.unicode) : '';
+      const dShort = shortcode ? ` data-shortcode="${escapeHTML(shortcode)}"` : '';
+      const dUnicode = unicode ? ` data-unicode="${escapeHTML(unicode)}"` : '';
+      const inner = unicode || shortcode || '';
+      return `<span data-emoji${dShort}${dUnicode}>${escapeHTML(inner)}</span>`;
     }
   });
 

--- a/packages/extensions/src/emoji.ts
+++ b/packages/extensions/src/emoji.ts
@@ -1,0 +1,128 @@
+import { Editor, Extension } from '@barocss/editor-core';
+import type { ModelSelection } from '@barocss/editor-core';
+import { transaction, control, splitTextNode, addChild } from '@barocss/model';
+
+export interface EmojiExtensionOptions {
+  enabled?: boolean;
+}
+
+export interface InsertEmojiPayload {
+  /** Emoji shortcode (e.g. ":smile:") */
+  shortcode?: string;
+  /** Unicode character (e.g. "😀") */
+  unicode?: string;
+  selection?: ModelSelection;
+}
+
+/**
+ * Emoji Extension – inserts the standard `emoji` node (inline atom) at the current selection.
+ * Schema must include node type `emoji` with optional attrs shortcode, unicode.
+ */
+export class EmojiExtension implements Extension {
+  name = 'emoji';
+  priority = 150;
+
+  private _options: EmojiExtensionOptions;
+
+  constructor(options: EmojiExtensionOptions = {}) {
+    this._options = {
+      enabled: true,
+      ...options,
+    };
+  }
+
+  onCreate(editor: Editor): void {
+    if (!this._options.enabled) return;
+
+    editor.registerCommand({
+      name: 'insertEmoji',
+      execute: async (ed: Editor, payload?: InsertEmojiPayload) => {
+        return await this._executeInsertEmoji(ed, payload);
+      },
+      canExecute: (_ed: Editor, payload?: InsertEmojiPayload) => {
+        if (!payload || (payload.shortcode == null && payload.unicode == null)) return false;
+        return true;
+      },
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+
+  private async _executeInsertEmoji(
+    editor: Editor,
+    payload?: InsertEmojiPayload
+  ): Promise<boolean> {
+    if (!payload?.selection || payload.selection.type !== 'range') return false;
+
+    const dataStore = (editor as any).dataStore;
+    if (!dataStore) return false;
+
+    const schema = dataStore.getActiveSchema?.();
+    if (schema && !schema.getNodeType('emoji')) return false;
+
+    const selection = payload.selection;
+    const startNode = dataStore.getNode(selection.startNodeId);
+    if (!startNode) return false;
+
+    const blockId = this._getBlockId(dataStore, schema, startNode);
+    if (!blockId) return false;
+
+    const block = dataStore.getNode(blockId);
+    if (!block || !Array.isArray(block.content)) return false;
+
+    const childIndex = block.content.indexOf(selection.startNodeId);
+    if (childIndex === -1) return false;
+
+    const attrs: Record<string, string> = {};
+    if (payload.shortcode != null) attrs.shortcode = String(payload.shortcode);
+    if (payload.unicode != null) attrs.unicode = String(payload.unicode);
+
+    const emojiNode = {
+      stype: 'emoji',
+      attributes: attrs,
+    };
+
+    const startOffset = selection.startOffset ?? 0;
+    const textLen =
+      typeof startNode.text === 'string' ? startNode.text.length : 0;
+
+    let ops: any[];
+
+    if (startOffset === 0) {
+      ops = [addChild(blockId, emojiNode, childIndex)];
+    } else if (startOffset >= textLen) {
+      ops = [addChild(blockId, emojiNode, childIndex + 1)];
+    } else {
+      ops = [
+        ...control(selection.startNodeId, [splitTextNode(startOffset)]),
+        addChild(blockId, emojiNode, childIndex + 1),
+      ];
+    }
+
+    const result = await transaction(editor, ops, {
+      applySelectionToView: true,
+    }).commit();
+    return result.success;
+  }
+
+  private _getBlockId(dataStore: any, schema: any, startNode: any): string | null {
+    const nodeType = schema?.getNodeType(startNode.stype);
+    if (nodeType?.group === 'block') return startNode.sid ?? null;
+
+    let current: any = startNode;
+    while (current?.parentId) {
+      const parent = dataStore.getNode(current.parentId);
+      if (!parent) break;
+      const parentType = schema?.getNodeType(parent.stype);
+      if (parentType?.group === 'block') return parent.sid ?? null;
+      current = parent;
+    }
+    return null;
+  }
+}
+
+export function createEmojiExtension(
+  options?: EmojiExtensionOptions
+): EmojiExtension {
+  return new EmojiExtension(options);
+}

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -13,6 +13,7 @@ export * from './move-block';
 export * from './escape';
 export * from './list';
 export * from './blockquote';
+export * from './emoji';
 
 // Import classes
 import { TextExtension } from './text';

--- a/packages/extensions/test/emoji-extension.test.ts
+++ b/packages/extensions/test/emoji-extension.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Editor } from '@barocss/editor-core';
+import { EmojiExtension } from '../src/emoji';
+
+const recordedTransactions: any[][] = [];
+const commitMock = vi.fn();
+
+vi.mock('@barocss/model', () => {
+  return {
+    transaction: (_editor: Editor, operations: any[]) => {
+      recordedTransactions.push(operations);
+      return { commit: commitMock };
+    },
+    control: (_nodeId: string, ops: any[]) => ops,
+    splitTextNode: (pos: number) => ({ type: 'splitTextNode', payload: { splitPosition: pos } }),
+    addChild: (parentId: string, child: any, position?: number) => ({
+      type: 'addChild',
+      payload: { parentId, child, position }
+    })
+  };
+});
+
+function createFakeEditor(dataStore: any, schema?: any): Editor & { __getCommand: (name: string) => any } {
+  const commands: Record<string, any> = {};
+  return {
+    registerCommand: (cmd: any) => {
+      commands[cmd.name] = cmd;
+    },
+    __getCommand(name: string) {
+      return commands[name];
+    },
+    dataStore,
+    getActiveSchema: () => schema
+  } as Editor & { __getCommand: (name: string) => any; dataStore: any };
+}
+
+describe('EmojiExtension', () => {
+  beforeEach(() => {
+    recordedTransactions.length = 0;
+    commitMock.mockReset();
+    commitMock.mockResolvedValue({ success: true });
+  });
+
+  it('insertEmoji command is registered', () => {
+    const editor = createFakeEditor({});
+    const ext = new EmojiExtension();
+    ext.onCreate(editor);
+    const cmd = editor.__getCommand('insertEmoji');
+    expect(cmd).toBeDefined();
+    expect(cmd.canExecute(editor, { shortcode: ':smile:' })).toBe(true);
+    expect(cmd.canExecute(editor, { unicode: '😀' })).toBe(true);
+    expect(cmd.canExecute(editor, {})).toBe(false);
+    expect(cmd.canExecute(editor)).toBe(false);
+  });
+
+  it('insertEmoji canExecute is false when schema has no emoji type', async () => {
+    const schema = { getNodeType: () => null };
+    const dataStore = {
+      getNode: (id: string) => (id === 'text-1' ? { sid: 'text-1', stype: 'inline-text', text: 'Hi', parentId: 'p-1' } : id === 'p-1' ? { sid: 'p-1', stype: 'paragraph', content: ['text-1'], parentId: 'doc-1' } : null),
+      getActiveSchema: () => schema
+    };
+    const editor = createFakeEditor(dataStore, schema);
+    const ext = new EmojiExtension();
+    ext.onCreate(editor);
+    const cmd = editor.__getCommand('insertEmoji');
+    const result = await cmd.execute(editor, {
+      shortcode: ':smile:',
+      selection: { type: 'range', startNodeId: 'text-1', endNodeId: 'text-1', startOffset: 1, endOffset: 1 }
+    });
+    expect(result).toBe(false);
+  });
+
+  it('insertEmoji execute builds addChild when schema has emoji', async () => {
+    const schema = {
+      getNodeType: (stype: string) => (stype === 'emoji' ? { group: 'inline' } : stype === 'paragraph' ? { group: 'block' } : stype === 'inline-text' ? { group: 'inline' } : null)
+    };
+    const dataStore = {
+      getNode: (id: string) => {
+        if (id === 'text-1') return { sid: 'text-1', stype: 'inline-text', text: 'Hi', parentId: 'p-1' };
+        if (id === 'p-1') return { sid: 'p-1', stype: 'paragraph', content: ['text-1'], parentId: 'doc-1' };
+        return null;
+      },
+      getActiveSchema: () => schema
+    };
+    const editor = createFakeEditor(dataStore, schema);
+    const ext = new EmojiExtension();
+    ext.onCreate(editor);
+    const cmd = editor.__getCommand('insertEmoji');
+    await cmd.execute(editor, {
+      unicode: '😀',
+      selection: { type: 'range', startNodeId: 'text-1', endNodeId: 'text-1', startOffset: 2, endOffset: 2 }
+    });
+    expect(recordedTransactions.length).toBeGreaterThanOrEqual(1);
+    const ops = recordedTransactions.flat();
+    const addChildOp = ops.find((o: any) => o.type === 'addChild');
+    expect(addChildOp).toBeDefined();
+    expect(addChildOp.payload.child.stype).toBe('emoji');
+    expect(addChildOp.payload.child.attributes?.unicode).toBe('😀');
+  });
+});


### PR DESCRIPTION
## Summary

1. **Extensions**: `insertEmoji` command (EmojiExtension)
   - Payload: `shortcode?`, `unicode?`, `selection?`
   - Inserts standard `emoji` node at selection (splitTextNode + addChild when needed)
   - Schema must include `emoji` node type
   - Test: `packages/extensions/test/emoji-extension.test.ts`

2. **Converter**: HTML rules for standard schema nodes
   - **Emoji**: Parser matches `<span data-emoji>` (data-shortcode, data-unicode); converter outputs `<span data-emoji data-shortcode="..." data-unicode="...">…</span>`
   - **Paragraph placeholder**: Parser reads `data-placeholder` on `<p>`; converter outputs `data-placeholder` when `node.attributes.placeholder` is set; other `data-*` attributes preserved

3. **Docs**: `packages/converter/docs/standard-schema-html.md` — emoji and paragraph placeholder round-trip

Closes #175

Made with [Cursor](https://cursor.com)