### PR TITLE
feat(model): add getDocumentSize, updateMark DSL, and improvements doc

### DIFF
--- a/packages/model/docs/model-improvements.md
+++ b/packages/model/docs/model-improvements.md
@@ -1,0 +1,74 @@
+# Model package: improvements and optional enhancements
+
+Review of `@barocss/model` against its role (transaction execution, operations, selection resolution, position/size) and optional enhancements. References: DataStore gap analysis, ProseMirror model, SPEC.md.
+
+---
+
+## 1. Current model scope
+
+- **Transaction**: Lock → overlay → run operations → resolve selectionAfter → commit; one TransactionResult per run.
+- **Operations**: defineOperation + defineOperationDSL; payload + TransactionContext (dataStore, schema, selection); return ok/error/inverse/selectionAfter.
+- **Selection resolution**: After all ops, selectionAfter = lastCreatedBlock’s caret or context.selection.current; applied to view when applySelectionToView !== false.
+- **PositionCalculator**: Absolute position ↔ nodeId + offset; getNodePath, getParentId, getSiblingIndex, getTextLength, calculateDistance, isTextNode, isContainerNode.
+- **DSL**: transaction(editor, ops).commit(); control(nodeId, ops); node/textNode/mark builders; operations exported from operations-dsl.
+
+---
+
+## 2. Role vs other packages
+
+| Responsibility        | Owner        | Note                                      |
+|-----------------------|-------------|-------------------------------------------|
+| Position/size         | **model**   | PositionCalculator; datastore stays by-id  |
+| Document size (total) | **model**   | Optional getDocumentSize() on calculator |
+| Slice / copy-paste    | **model**   | copy, paste, cut operations               |
+| Undo/redo             | editor-core | HistoryManager, inverse ops               |
+| Schema definition     | @barocss/schema | model uses schema from context        |
+| CRDT / sync           | adapters    | datastore emit/apply operations           |
+
+No overlap issues; optional improvements are additive.
+
+---
+
+## 3. Optional enhancements (implemented or recommended)
+
+### 3.1 PositionCalculator.getDocumentSize()
+
+- **Goal**: ProseMirror-style total document “size” (number of positions in the linear model).
+- **Place**: `PositionCalculator` in model (same counting as findNodeByAbsolutePosition).
+- **Behavior**: Traverse root and return total offset (node boundaries + text length); 0 when no root or empty.
+- **Status**: Implemented in `position.ts`; tests in `test/operations/position.exec.test.ts`.
+
+### 3.2 updateMark DSL
+
+- **Goal**: Use updateMark from DSL like other ops: `control(nodeId, [ updateMark(markType, range, newAttrs) ])` and `updateMark(nodeId, markType, range, newAttrs)`.
+- **Place**: `operations-dsl/updateMark.ts` + export in `operations-dsl/index.ts`.
+- **Status**: Implemented; runtime was in `operations/updateMark.ts`; DSL added and exported; tests in `updateMark.exec.test.ts`.
+
+### 3.3 TransactionContext.schema type
+
+- **Goal**: Replace `schema?: any` with `schema?: Schema` (from `@barocss/schema`) for type safety.
+- **Place**: `types.ts` (TransactionContext).
+- **Status**: Optional; low risk, improves editor/extension typings.
+
+### 3.4 Model package docs
+
+- **Goal**: Single place for “what model owns” and “optional improvements” (this doc).
+- **Place**: `packages/model/docs/model-improvements.md`.
+- **Status**: Done.
+
+---
+
+## 4. What not to change
+
+- **Position/size API**: Stays in model (PositionCalculator); datastore remains node/ID-centric.
+- **Operation semantics**: Still defined by exec tests and SPEC.md; new ops follow the same defineOperation + DSL + exec test flow.
+- **Selection resolution**: Flow (ops → resolve selectionAfter → commit → updateSelection) remains as in SPEC and transaction-selection.md.
+
+---
+
+## 5. References
+
+- Model SPEC: `packages/model/SPEC.md`
+- DataStore gap analysis: `packages/datastore/docs/datastore-gap-analysis.md`
+- Transaction/selection: `docs/transaction-selection.md`, `docs/selection-application-flow.md`
+- Operation creation: `.cursor/skills/model-operation-creation/SKILL.md`

--- a/packages/model/src/operations-dsl/index.ts
+++ b/packages/model/src/operations-dsl/index.ts
@@ -24,6 +24,7 @@ export * from './replaceText';
 export * from './cloneNodeWithChildren';
 export * from './copyNode';
 export * from './toggleMark';
+export * from './updateMark';
 export * from './removeMark';
 export * from './wrap';
 export * from './unwrap';

--- a/packages/model/src/operations-dsl/updateMark.ts
+++ b/packages/model/src/operations-dsl/updateMark.ts
@@ -1,0 +1,26 @@
+import { defineOperationDSL } from '../operations/define-operation-dsl';
+
+/**
+ * updateMark operation DSL
+ *
+ * - control(nodeId, [ updateMark(markType, range, newAttrs) ]) → payload: { markType, range, newAttrs }
+ * - updateMark(nodeId, markType, range, newAttrs) → payload: { nodeId, markType, range, newAttrs }
+ */
+export type UpdateMarkOperationPayload =
+  | { markType: string; range: [number, number]; newAttrs: Record<string, unknown> }
+  | { nodeId: string; markType: string; range: [number, number]; newAttrs: Record<string, unknown> };
+
+export const updateMark = defineOperationDSL(
+  (
+    ...args:
+      | [string, [number, number], Record<string, unknown>]
+      | [string, string, [number, number], Record<string, unknown>]
+  ) => {
+    if (args.length === 3) {
+      const [markType, range, newAttrs] = args as [string, [number, number], Record<string, unknown>];
+      return { type: 'updateMark', payload: { markType, range, newAttrs } } as { type: 'updateMark'; payload: UpdateMarkOperationPayload };
+    }
+    const [nodeId, markType, range, newAttrs] = args as [string, string, [number, number], Record<string, unknown>];
+    return { type: 'updateMark', payload: { nodeId, markType, range, newAttrs } } as { type: 'updateMark'; payload: UpdateMarkOperationPayload };
+  }
+);

--- a/packages/model/src/position.ts
+++ b/packages/model/src/position.ts
@@ -88,6 +88,46 @@ export class PositionCalculator {
   }
 
   /**
+   * Returns the total document size (number of positions in the linear model).
+   * Same counting as findNodeByAbsolutePosition: node boundaries + text length.
+   * Returns 0 when there is no root or the store is empty.
+   *
+   * @returns Total size (last valid position index + 1)
+   *
+   * @example
+   * ```typescript
+   * const size = calculator.getDocumentSize();
+   * // 42 - document has 42 positions (0..41)
+   * ```
+   */
+  getDocumentSize(): number {
+    let currentOffset = 0;
+
+    const traverse = (nodeId: string): void => {
+      const node = this._dataStore.getNode(nodeId);
+      if (!node) return;
+
+      currentOffset += 1; // node start
+
+      if (node.text) currentOffset += node.text.length;
+
+      if (node.content) {
+        for (const childId of node.content) {
+          traverse(childId as string);
+        }
+      }
+
+      currentOffset += 1; // node end
+    };
+
+    const rootNode = this._dataStore.getRootNode();
+    if (!rootNode) return 0;
+
+    traverse(rootNode.sid!);
+    return currentOffset;
+  }
+
+  /**
    * Converts nodeId + offset to absolute position.
    * 
    * This method converts the given node ID and offset within that node

--- a/packages/model/test/operations/position.exec.test.ts
+++ b/packages/model/test/operations/position.exec.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DataStore } from '@barocss/datastore';
+import { Schema } from '@barocss/schema';
+import { PositionCalculator } from '../../src/position';
+
+describe('PositionCalculator getDocumentSize', () => {
+  let dataStore: DataStore;
+  let schema: Schema;
+  let calculator: PositionCalculator;
+
+  beforeEach(() => {
+    schema = new Schema('test-schema', {
+      nodes: {
+        document: { name: 'document', group: 'document', content: 'block+' },
+        paragraph: { name: 'paragraph', group: 'block', content: 'inline*' },
+        'inline-text': { name: 'inline-text', group: 'inline' }
+      },
+      marks: {}
+    });
+    dataStore = new DataStore(undefined, schema);
+    calculator = new PositionCalculator(dataStore);
+  });
+
+  it('returns 0 when there is no root', () => {
+    expect(calculator.getDocumentSize()).toBe(0);
+  });
+
+  it('returns size for root with one text node', () => {
+    dataStore.setNode({ sid: 'doc', stype: 'document', content: ['p1'] } as any);
+    dataStore.setNode({ sid: 'p1', stype: 'paragraph', content: ['t1'], parentId: 'doc' } as any);
+    dataStore.setNode({ sid: 't1', stype: 'inline-text', text: 'Hi', parentId: 'p1' } as any);
+    dataStore.setRootNodeId('doc');
+
+    // doc: 1 + (p1: 1 + (t1: 1 + 2 + 1) + 1) + 1 = 1 + 6 + 1 = 8
+    expect(calculator.getDocumentSize()).toBe(8);
+  });
+
+  it('matches findNodeByAbsolutePosition: size is one past last valid position', () => {
+    dataStore.setNode({ sid: 'doc', stype: 'document', content: ['p1'] } as any);
+    dataStore.setNode({ sid: 'p1', stype: 'paragraph', content: ['t1'], parentId: 'doc' } as any);
+    dataStore.setNode({ sid: 't1', stype: 'inline-text', text: 'AB', parentId: 'p1' } as any);
+    dataStore.setRootNodeId('doc');
+
+    const size = calculator.getDocumentSize();
+    expect(calculator.findNodeByAbsolutePosition(size)).toBeNull();
+    const lastValid = calculator.findNodeByAbsolutePosition(size - 1);
+    expect(lastValid).not.toBeNull();
+    // Last character "B" of "AB" is at offset 1 in t1 (position 4 in doc)
+    const atLastChar = calculator.findNodeByAbsolutePosition(size - 4);
+    expect(atLastChar?.nodeId).toBe('t1');
+    expect(atLastChar?.offset).toBe(1);
+  });
+});

--- a/packages/model/test/operations/updateMark.exec.test.ts
+++ b/packages/model/test/operations/updateMark.exec.test.ts
@@ -5,6 +5,7 @@ import { DataStore } from '@barocss/datastore';
 import { SelectionManager } from '@barocss/editor-core';
 import { createTransactionContext } from '../../src/create-transaction-context';
 import { Schema } from '@barocss/schema';
+import { updateMark as updateMarkDsl } from '../../src/operations-dsl/updateMark';
 
 describe('updateMark operation (exec)', () => {
   let dataStore: DataStore;
@@ -47,6 +48,17 @@ describe('updateMark operation (exec)', () => {
     const op = globalOperationRegistry.get('updateMark');
     await expect(op!.execute({ type: 'updateMark', payload: { nodeId: 't1', markType: 'bold', range: [3, 2], newAttrs: {} } } as any, context))
       .rejects.toThrow();
+  });
+
+  describe('updateMark DSL', () => {
+    it('builds descriptor (control: markType, range, newAttrs)', () => {
+      const dsl = updateMarkDsl('bold', [0, 5], { b: 2 });
+      expect(dsl).toEqual({ type: 'updateMark', payload: { markType: 'bold', range: [0, 5], newAttrs: { b: 2 } } });
+    });
+    it('builds descriptor (direct: nodeId, markType, range, newAttrs)', () => {
+      const dsl = updateMarkDsl('t1', 'bold', [0, 5], { b: 2 });
+      expect(dsl).toEqual({ type: 'updateMark', payload: { nodeId: 't1', markType: 'bold', range: [0, 5], newAttrs: { b: 2 } } });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- **PositionCalculator**: Add `getDocumentSize()` (total document position count; ProseMirror-style).
- **updateMark DSL**: Add `operations-dsl/updateMark.ts` and export; support `control(nodeId, [ updateMark(...) ])` and `updateMark(nodeId, ...)`.
- **Docs**: Add `packages/model/docs/model-improvements.md` (role vs datastore/editor-core, optional enhancements).
- **Tests**: `position.exec.test.ts` for getDocumentSize; updateMark.exec.test.ts DSL tests.

Closes #183

Made with [Cursor](https://cursor.com)