### PR TITLE
chore: editor-view-dom shared types; editor-view-react addDecorator(DecoratorGenerator); spec/README

### DIFF
--- a/packages/editor-view-dom/src/editor-view-dom.ts
+++ b/packages/editor-view-dom/src/editor-view-dom.ts
@@ -8,7 +8,7 @@ import type { PatternDecoratorConfig, DecoratorGenerator } from '@barocss/shared
 import { DecoratorRegistry, DecoratorPrebuilder, type Decorator, type DecoratorQueryOptions, type DecoratorModel } from './decorator';
 import { DOMRenderer } from '@barocss/renderer-dom';
 import { RendererRegistry } from '@barocss/dsl';
-import type { DecoratorExportData } from './types';
+import type { DecoratorExportData, LoadDecoratorsPatternFunctions } from './types';
 import { getKeyString } from '@barocss/shared';
 
 export class EditorViewDOM implements IEditorViewDOM {
@@ -1839,26 +1839,7 @@ export class EditorViewDOM implements IEditorViewDOM {
    * }
    * ```
    */
-  loadDecorators(
-    data: DecoratorExportData,
-    patternFunctions?: Record<string, {
-      extractData: (match: RegExpMatchArray) => Record<string, any>;
-      createDecorator: (
-        nodeId: string,
-        startOffset: number,
-        endOffset: number,
-        extractedData: Record<string, any>
-      ) => {
-        sid: string;
-        target: {
-          sid: string;
-          startOffset: number;
-          endOffset: number;
-        };
-        data?: Record<string, any>;
-      };
-    }>
-  ): void {
+  loadDecorators(data: DecoratorExportData, patternFunctions?: LoadDecoratorsPatternFunctions): void {
     // Remove all existing decorators
     this.decoratorManager.clear();
     this.patternDecoratorConfigManager.clear();

--- a/packages/editor-view-dom/src/types.ts
+++ b/packages/editor-view-dom/src/types.ts
@@ -1,6 +1,16 @@
 import { Editor } from '@barocss/editor-core';
 import type { RendererRegistry, ModelData } from '@barocss/dsl';
+import type {
+  DecoratorExportData,
+  LoadDecoratorsPatternFunctions,
+  DecoratorQueryOptions,
+  DecoratorTypeSchema,
+  Decorator,
+  DecoratorGenerator,
+} from '@barocss/shared';
 // TreeDocument is removed - use ModelData (sid, stype) directly
+
+export type { DecoratorExportData, LoadDecoratorsPatternFunctions };
 
 export interface LayerConfiguration {
   contentEditable?: {
@@ -99,21 +109,8 @@ export interface IEditorViewDOM {
   render(tree?: ModelData | any): void;        // ModelData format (uses sid, stype) or exported from editor
   
   // Decorator management API
-  getDecorators?(options?: any): any[];        // Query decorator list
-  
-  // Decorator type definition (optional)
-  defineDecoratorType(
-    type: string,
-    category: 'layer' | 'inline' | 'block',
-    schema: {
-      description?: string;
-      dataSchema?: Record<string, {
-        type: 'string' | 'number' | 'boolean' | 'array' | 'object';
-        required?: boolean;
-        default?: any;
-      }>;
-    }
-  ): void;
+  getDecorators?(options?: DecoratorQueryOptions): (Decorator | DecoratorGenerator)[];
+  defineDecoratorType(type: string, category: 'layer' | 'inline' | 'block', schema: DecoratorTypeSchema): void;
   
   // Lifecycle
   destroy(): void;
@@ -161,29 +158,4 @@ export interface TextChangeAnalysisOptions {
     beforeText?: string;    // Leading context
     afterText?: string;     // Trailing context
   };
-}
-
-/**
- * Decorator Export/Import 타입
- */
-export interface DecoratorExportData {
-  version: string;
-  targetDecorators: Array<{
-    sid: string;
-    stype: string;
-    category: 'layer' | 'inline' | 'block';
-    data?: Record<string, any>;
-    target: any;
-    enabled?: boolean;
-  }>;
-  patternDecorators: Array<{
-    sid: string;  // Unified from id → sid
-    stype: string;
-    category: 'inline' | 'block' | 'layer';
-    pattern: { source: string; flags: string }; // RegExp converted to string
-    priority?: number;
-    enabled?: boolean;
-    // extractData and createDecorator are functions, so excluded
-    // Functions provided in patternFunctions parameter are used on load
-  }>;
 }

--- a/packages/editor-view-react/README.md
+++ b/packages/editor-view-react/README.md
@@ -48,9 +48,11 @@ import { EditorView } from '@barocss/editor-view-react';
 
 ## API
 
-- **EditorView** — Composite view. Props: `editor`, `options?` (registry, className, layers), `children?` (custom layer content).
+- **EditorView** — Composite view. Props: `editor`, `options?` (registry, className, layers), `children?` (custom layer content). Supports `ref` for imperative handle (EditorViewHandle).
 - **EditorView.ContentLayer** — Props: `options?` (registry, className, editable). Editor is from EditorViewContext (use inside EditorView).
 - **EditorView.Layer** — Props: `layer` ('decorator' | 'selection' | 'context' | 'custom'), `className?`, `style?`, `children?`.
+
+**Ref API (EditorViewHandle)** — When using `ref` on EditorView: `addDecorator(Decorator | DecoratorGenerator)`, `removeDecorator`, `updateDecorator`, `getDecorators(options?)`, `getDecorator`, `exportDecorators`, `loadDecorators`, `contentEditableElement`, `convertModelSelectionToDOM`, `convertDOMSelectionToModel`, `convertStaticRangeToModel`, `defineDecoratorType`, and refs to `decoratorManager`, `remoteDecoratorManager`, `patternDecoratorConfigManager`, `decoratorGeneratorManager`. See editor-view-react-spec.md § 3.3.
 
 ## Docs
 

--- a/packages/editor-view-react/docs/editor-view-react-spec.md
+++ b/packages/editor-view-react/docs/editor-view-react-spec.md
@@ -96,7 +96,7 @@ No dependency on **editor-view-dom** or **renderer-dom**.
 | useEditorViewContext | Hook | Returns EditorViewContextValue; throws if not inside Provider. |
 | useOptionalEditorViewContext | Hook | Returns value or null. |
 | createMutationObserverManager | Function | (onMutations) => ReactMutationObserverManager. |
-| Types | — | EditorViewOptions, EditorViewProps, EditorViewContentLayerOptions, EditorViewLayerOptions, EditorViewLayersConfig, EditorViewLayerType, EditorViewViewState, EditorViewContextValue, ReactMutationObserverManager. |
+| Types | — | EditorViewOptions, EditorViewProps, EditorViewRef, EditorViewHandle, EditorViewContentLayerOptions, EditorViewLayerOptions, EditorViewLayersConfig, EditorViewLayerType, DecoratorExportData, LoadDecoratorsPatternFunctions, DecoratorQueryOptions, DecoratorTypeSchema, ModelSelection, EditorViewViewState, EditorViewContextValue, ReactMutationObserverManager. |
 
 ### 3.2 EditorView Props
 
@@ -107,9 +107,25 @@ No dependency on **editor-view-dom** or **renderer-dom**.
   - **layers**: EditorViewLayersConfig — content?, decorator?, selection?, context?, custom? (optional className/style overrides; all four overlay layers are always rendered).
 - **children**: ReactNode (rendered inside CustomLayer after overlay decorators).
 
-Decorators are managed internally; use ref.addDecorator / ref.removeDecorator / ref.getDecorators when using a ref on EditorView.
+Decorators are managed internally; use the ref API (EditorViewHandle) when using a ref on EditorView.
 
-### 3.3 EditorViewContentLayer Props
+### 3.3 EditorView ref (EditorViewHandle)
+
+When using `ref` on EditorView, the following are exposed (parity with editor-view-dom where applicable):
+
+- **addDecorator(decorator: Decorator | DecoratorGenerator)** — Add a target decorator or register a DecoratorGenerator (function-based decorators). Generators are registered with `decoratorGeneratorManager` and their output is included in merged decorators.
+- **removeDecorator(id)**, **updateDecorator(id, updates)** — Remove or update a decorator by id.
+- **getDecorators(options?: DecoratorQueryOptions)** — Return merged decorators (local + remote + pattern-generated + generator-generated), optionally filtered/sorted by category, type, nodeId, enabledOnly, sortBy, sortOrder.
+- **getDecorator(id)** — Return a single decorator or generator by id (searches merged, then local, then remote).
+- **exportDecorators()**, **loadDecorators(data, patternFunctions?)** — Serialize/restore target and pattern decorators; pattern functions provided at load time for pattern logic.
+- **contentEditableElement** — HTMLElement | null (content-editable root).
+- **convertModelSelectionToDOM(sel)**, **convertDOMSelectionToModel(selection)**, **convertStaticRangeToModel(staticRange)** — Selection conversion between model and DOM/StaticRange.
+- **defineDecoratorType(type, category, schema)** — Register a decorator type schema (DecoratorTypeSchema) for validation and defaults when adding decorators; uses shared DecoratorSchemaRegistry.
+- **decoratorManager**, **remoteDecoratorManager**, **patternDecoratorConfigManager**, **decoratorGeneratorManager** — Refs to the shared manager instances (nullable).
+
+Types: `DecoratorExportData`, `LoadDecoratorsPatternFunctions`, `DecoratorQueryOptions`, `DecoratorTypeSchema`, `ModelSelection` are exported from the package (re-exported from `@barocss/shared` where applicable).
+
+### 3.4 EditorViewContentLayer Props
 
 - **options**: Optional.
   - **registry**: RendererRegistry (default getGlobalRegistry()).
@@ -118,7 +134,7 @@ Decorators are managed internally; use ref.addDecorator / ref.removeDecorator / 
 
 Decorators are taken from internal DecoratorManager (context); no options.decorators or getDecorators. Editor is taken from EditorViewContext only.
 
-### 3.4 EditorViewLayer Props
+### 3.5 EditorViewLayer Props
 
 - **layer**: 'decorator' | 'selection' | 'context' | 'custom'.
 - **className**: Optional string.
@@ -127,7 +143,7 @@ Decorators are taken from internal DecoratorManager (context); no options.decora
 
 Default classNames and zIndex per layer: decorator (barocss-editor-decorators, 10), selection (barocss-editor-selection, 100), context (barocss-editor-context, 200), custom (barocss-editor-custom, 1000). Position absolute, pointer-events: none.
 
-### 3.5 EditorView Static Subcomponents
+### 3.6 EditorView Static Subcomponents
 
 - **EditorView.ContentLayer** = EditorViewContentLayer.
 - **EditorView.Layer** = EditorViewLayer (generic; pass layer prop).

--- a/packages/editor-view-react/docs/improvement-opportunities.md
+++ b/packages/editor-view-react/docs/improvement-opportunities.md
@@ -1,0 +1,66 @@
+# editor-view-dom / editor-view-react 개선 후보
+
+editor-view-dom과 editor-view-react를 비교·분석한 결과, 아래 개선이 가능하다.
+
+**적용 완료 (1–4번)**: DecoratorExportData/LoadDecoratorsPatternFunctions shared 통일, addDecorator(DecoratorGenerator) 지원, IEditorViewDOM 타입 정리, 스펙/README 업데이트.
+
+---
+
+## 1. editor-view-dom
+
+### 1.1 DecoratorExportData·LoadDecoratorsPatternFunctions를 shared에서 사용
+
+- **현재**: `packages/editor-view-dom/src/types.ts`에 `DecoratorExportData`가 로컬로 정의되어 있고, `loadDecorators`의 `patternFunctions`는 인라인 타입으로만 정의됨.
+- **개선**: `DecoratorExportData`, `LoadDecoratorsPatternFunctions`를 `@barocss/shared`에서 import하고, editor-view-dom의 types에서 해당 정의 제거. `loadDecorators` 시그니처에 `LoadDecoratorsPatternFunctions` 사용.
+- **효과**: 타입 중복 제거, shared와 시그니처 일치.
+
+### 1.2 IEditorViewDOM 타입 정리
+
+- **현재**: `getDecorators?(options?: any): any[]`로 되어 있음.
+- **개선**: `getDecorators(options?: DecoratorQueryOptions): (Decorator | DecoratorGenerator)[]`로 명시. `defineDecoratorType`의 `schema` 인자 타입을 shared의 `DecoratorTypeSchema`로 통일.
+- **효과**: 타입 안정성·자동완성 개선, editor-view-react와 개념적 일치.
+
+---
+
+## 2. editor-view-react
+
+### 2.1 addDecorator에 DecoratorGenerator 지원
+
+- **현재**: `addDecorator(decorator: Decorator)`만 받음. editor-view-dom은 `addDecorator(decorator: Decorator | DecoratorGenerator)`를 지원함.
+- **개선**: `EditorViewHandle.addDecorator(decorator: Decorator | DecoratorGenerator)`로 확장. `DecoratorGenerator`인 경우 `decoratorGeneratorManagerRef.current?.registerGenerator(generator, bumpDecoratorVersion)` 호출 후 `bumpDecoratorVersion()` 호출.
+- **효과**: DOM 뷰와 동일하게 generator 기반 데코레이터 등록 가능, API 일치.
+
+### 2.2 ref.destroy() (선택)
+
+- **현재**: editor-view-dom은 `view.destroy()`로 이벤트/observer/레이어 정리. editor-view-react는 언마운트 시 `useEffect` cleanup으로 observer 해제·이벤트 해제.
+- **개선**: ref에 `destroy?(): void`를 두고, 호출 시 데코레이터 매니저 clear·버전 bump 등 선택적 정리만 수행. React는 언마운트가 곧 정리이므로 필수는 아님.
+- **효과**: DOM과 동일한 “명시적 정리” API를 쓰고 싶을 때 사용 가능. 우선순위는 낮음.
+
+---
+
+## 3. 공통·문서
+
+### 3.1 스펙/README 반영
+
+- **editor-view-react**: `editor-view-react-spec.md`, `README.md`에 최근 추가된 ref API 반영  
+  (`defineDecoratorType`, `convertStaticRangeToModel`, `getDecorators(options?)`, `DecoratorSchemaRegistry` 사용).
+- **editor-view-dom**: README/문서에 `LoadDecoratorsPatternFunctions`, `DecoratorQueryOptions` 등 shared 타입 사용 여부 명시.
+
+### 3.2 테스트
+
+- **editor-view-react**: `addDecorator(DecoratorGenerator)` 지원 시, generator 등록 후 `getDecorators()`에 반영되는지 한 번 더 검증하는 테스트 추가.
+- **editor-view-dom**: `DecoratorExportData`를 shared에서 쓰도록 바꾼 뒤, 기존 export/load 관련 테스트가 그대로 통과하는지 확인.
+
+---
+
+## 우선순위 제안
+
+| 순서 | 항목 | 패키지 | 비고 |
+|------|------|--------|------|
+| 1 | DecoratorExportData·LoadDecoratorsPatternFunctions를 shared로 통일 | editor-view-dom | 타입 일원화 |
+| 2 | addDecorator(DecoratorGenerator) 지원 | editor-view-react | DOM과 API parity |
+| 3 | IEditorViewDOM getDecorators·defineDecoratorType 타입 정리 | editor-view-dom | 타입 품질 |
+| 4 | 스펙/README 업데이트 | 둘 다 | 유지보수성 |
+| 5 | ref.destroy() (선택) | editor-view-react | 필요 시 추가 |
+
+원하면 위 항목별로 이슈/PR 단위로 나눠서 적용할 수 있다.

--- a/packages/editor-view-react/src/EditorView.tsx
+++ b/packages/editor-view-react/src/EditorView.tsx
@@ -80,6 +80,14 @@ const EditorViewRoot = forwardRef<EditorViewRef, { options: EditorViewProps['opt
         if (!apiRef.current) {
           apiRef.current = {
             addDecorator(decorator) {
+              if ('generate' in decorator) {
+                decoratorGeneratorManagerRef.current?.registerGenerator(
+                  decorator as import('@barocss/shared').DecoratorGenerator,
+                  bumpDecoratorVersion
+                );
+                bumpDecoratorVersion();
+                return;
+              }
               decoratorManagerRef.current?.add(decorator);
             },
             removeDecorator(id) {

--- a/packages/editor-view-react/src/types.ts
+++ b/packages/editor-view-react/src/types.ts
@@ -2,6 +2,7 @@ import type { Editor } from '@barocss/editor-core';
 import type { RendererRegistry } from '@barocss/dsl';
 import type {
   Decorator,
+  DecoratorGenerator,
   DecoratorManager,
   RemoteDecoratorManager,
   PatternDecoratorConfigManager,
@@ -29,7 +30,7 @@ export type ModelSelection =
 
 /** Imperative handle for EditorView: decorator management and selection/convenience APIs. */
 export interface EditorViewHandle {
-  addDecorator(decorator: Decorator): void;
+  addDecorator(decorator: Decorator | DecoratorGenerator): void;
   removeDecorator(id: string): void;
   updateDecorator(id: string, updates: Partial<Decorator>): void;
   getDecorators(options?: DecoratorQueryOptions): Decorator[];

--- a/packages/editor-view-react/test/EditorView.test.tsx
+++ b/packages/editor-view-react/test/EditorView.test.tsx
@@ -128,6 +128,20 @@ describe('EditorView', () => {
     expect(d).toBeTruthy();
     expect((d as { data?: { color?: string } }).data?.color).toBe('yellow');
   });
+
+  it('ref.addDecorator accepts DecoratorGenerator and registers it', () => {
+    const editor = mockEditor();
+    const ref = createRef<any>();
+    render(<EditorView ref={ref} editor={editor} />);
+    const generator = {
+      sid: 'gen-1',
+      generate: () => [],
+    };
+    act(() => {
+      ref.current.addDecorator(generator);
+    });
+    expect(ref.current.decoratorGeneratorManager?.getGenerator('gen-1')).toBe(generator);
+  });
 });
 
 describe('EditorViewLayer', () => {


### PR DESCRIPTION
## What changed

- **editor-view-dom**: Use `DecoratorExportData`, `LoadDecoratorsPatternFunctions`, `DecoratorQueryOptions`, `DecoratorTypeSchema`, `Decorator`, `DecoratorGenerator` from `@barocss/shared`. Remove local `DecoratorExportData`; `loadDecorators` uses `LoadDecoratorsPatternFunctions`. `IEditorViewDOM.getDecorators(options?: DecoratorQueryOptions): (Decorator | DecoratorGenerator)[]`, `defineDecoratorType(..., schema: DecoratorTypeSchema)`.
- **editor-view-react**: `addDecorator(decorator: Decorator | DecoratorGenerator)`; register generator and `bumpDecoratorVersion`. Test for `addDecorator(DecoratorGenerator)`.
- **Docs**: editor-view-react-spec § 3.3 ref API, README Ref API, improvement-opportunities.md.

## Verification

- [x] `pnpm --filter @barocss/editor-view-react test:run`
- [x] `pnpm --filter @barocss/editor-view-dom test:run`

## Related

- Closes #195

Made with [Cursor](https://cursor.com)