### PR TITLE
fix(editor-core): Vitest resolve alias use relative path for CI

### DIFF
--- a/packages/editor-core/vitest.config.ts
+++ b/packages/editor-core/vitest.config.ts
@@ -1,4 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   test: {
@@ -8,9 +12,9 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@barocss/datastore': '/Users/user/github/barocss/barocss-editor/packages/datastore/src/index.ts',
-      '@barocss/model': '/Users/user/github/barocss/barocss-editor/packages/model/src/index.ts',
-      '@barocss/schema': '/Users/user/github/barocss/barocss-editor/packages/schema/src/index.ts',
+      '@barocss/datastore': path.resolve(__dirname, '../datastore/src/index.ts'),
+      '@barocss/model': path.resolve(__dirname, '../model/src/index.ts'),
+      '@barocss/schema': path.resolve(__dirname, '../schema/src/index.ts'),
     }
   }
 });


### PR DESCRIPTION
## Summary
Resolves #201. Fixes editor-core Vitest failing in CI with `Failed to resolve import "@barocss/model"`.

## Cause
`vitest.config.ts` used hardcoded absolute paths (`/Users/user/github/barocss/barocss-editor/...`) for `resolve.alias`, which do not exist in CI (`/home/runner/work/barocss-editor/barocss-editor/...`).

## Change
- Use `path.resolve(__dirname, '../datastore/src/index.ts')` (and same for model, schema) so aliases work in any checkout path.
- Derive `__dirname` in ESM via `path.dirname(fileURLToPath(import.meta.url))`.

## Verification
- `pnpm test:run` in packages/editor-core passes locally.


Made with [Cursor](https://cursor.com)