### PR TITLE
chore(changeset): clear ignore list in config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,9 +8,6 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "@barocss/test-app",
-    "@barocss/editor-test",
-    "@barocss/editor-decorator-test"
   ]
 }
 


### PR DESCRIPTION
Remove `@barocss/test-app`, `@barocss/editor-test`, `@barocss/editor-decorator-test` from changeset `ignore` so those packages can be versioned by changesets if needed.

Made with [Cursor](https://cursor.com)