### PR TITLE
chore: update pnpm lockfile for editor-core @barocss/extensions dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,9 @@ importers:
       '@barocss/datastore':
         specifier: workspace:*
         version: link:../datastore
+      '@barocss/extensions':
+        specifier: workspace:*
+        version: link:../extensions
       '@barocss/model':
         specifier: workspace:*
         version: link:../model


### PR DESCRIPTION
Updates `pnpm-lock.yaml` so `pnpm install --frozen-lockfile` passes in CI after `@barocss/extensions` was added to `packages/editor-core/package.json`.

Closes #210

Made with [Cursor](https://cursor.com)