### PR TITLE
fix: editor-core type-check (TS6138, TS2345)

### DIFF
--- a/.changeset/fix-editor-core-type-check.md
+++ b/.changeset/fix-editor-core-type-check.md
@@ -1,0 +1,5 @@
+---
+"@barocss/editor-core": patch
+---
+
+Fix editor-core type-check: resolve unused `_selection` in SetSelectionCommand and type Extension `onSelectionChange` to accept `ModelSelection | SelectionState`.

--- a/packages/editor-core/src/commands.ts
+++ b/packages/editor-core/src/commands.ts
@@ -134,6 +134,7 @@ export class SetSelectionCommand implements Command {
   execute(state: DocumentState): DocumentState {
     // Selection is managed separately in Editor and SelectionManager.
     // Keep DocumentState immutable by returning the same shape.
+    void this._selection; // retained for command identity / future use
     return { ...state };
   }
 }

--- a/packages/editor-core/src/types.ts
+++ b/packages/editor-core/src/types.ts
@@ -255,7 +255,7 @@ export interface Extension {
   // After hooks (notification for core model changes)
   // For type safety. Alternatively, you can use editor.on() events for more flexibility.
   onTransaction?(editor: Editor, transaction: Transaction): void;
-  onSelectionChange?(editor: Editor, selection: SelectionState): void;
+  onSelectionChange?(editor: Editor, selection: SelectionState | ModelSelection): void;
   onContentChange?(editor: Editor, content: DocumentState): void;
   
   // State extension


### PR DESCRIPTION
Resolves CI type-check failures in editor-core (and dependent packages: datastore, extensions, model, converter).

- **commands.ts**: `_selection` declared but never read → reference in `execute()` via `void this._selection`.
- **types.ts**: `onSelectionChange` typed as `SelectionState` only → accept `SelectionState | ModelSelection`.

Closes #213

Made with [Cursor](https://cursor.com)