### PR TITLE
fix: editor-view-react type-check TS2774 (selection-handler)

### DIFF
--- a/.changeset/fix-editor-view-react-type-check.md
+++ b/.changeset/fix-editor-view-react-type-check.md
@@ -1,0 +1,5 @@
+---
+"@barocss/editor-view-react": patch
+---
+
+Fix type-check TS2774 in selection-handler: remove redundant querySelector check (HTMLElement always has it).

--- a/packages/editor-view-react/src/selection-handler.ts
+++ b/packages/editor-view-react/src/selection-handler.ts
@@ -21,7 +21,7 @@ export class ReactSelectionHandler {
   private _isProgrammaticChange = false;
   private _getScopeRoot(): ParentNode {
     const contentEditableElement = this.getContentEditableElement();
-    if (contentEditableElement && contentEditableElement.querySelector) {
+    if (contentEditableElement) {
       return contentEditableElement;
     }
     return document;


### PR DESCRIPTION
Resolves CI type-check failure: remove redundant `querySelector` check in `_getScopeRoot` (HTMLElement always has it).

Closes #216

Made with [Cursor](https://cursor.com)