### PR TITLE
fix: editor-view-dom type-check TS2339 (getAttribute on Node)

### DIFF
--- a/packages/editor-view-dom/src/dom-sync/dom-change-classifier.ts
+++ b/packages/editor-view-dom/src/dom-sync/dom-change-classifier.ts
@@ -1009,8 +1009,8 @@ function detectSpecialCase(
       .find((value): value is DomChangeCase => value !== null);
     if (directCase) return directCase;
 
-    if (mutation.attributeName) {
-      const attr = mutation.target?.getAttribute?.(mutation.attributeName);
+    if (mutation.attributeName && mutation.target instanceof Element) {
+      const attr = mutation.target.getAttribute(mutation.attributeName);
       if (attr && attr.toLowerCase().includes('autocorrect')) {
         return 'C4_AUTO_CORRECT';
       }


### PR DESCRIPTION
Narrow `mutation.target` with `instanceof Element` before calling `getAttribute` in dom-change-classifier (MutationRecord.target is Node; getAttribute is on Element).

Closes #218

Made with [Cursor](https://cursor.com)