### PR TITLE
chore: exclude apps/ packages from changeset releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,10 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
+    "@barocss/docs-site",
+    "@barocss/editor-decorator-test",
+    "@barocss/editor-react",
+    "@barocss/editor-test"
   ]
 }
 


### PR DESCRIPTION
## Summary

- Add all 4 `apps/` workspace packages to `.changeset/config.json` `ignore` list
- Prevents accidental version bumps and npm publishing of internal test/demo apps

## Changes

`.changeset/config.json`:
```json
"ignore": [
  "@barocss/docs-site",
  "@barocss/editor-decorator-test",
  "@barocss/editor-react",
  "@barocss/editor-test"
]
```

## Test plan

- [x] Verified `changeset status` does not include apps packages

Closes #224

Made with [Cursor](https://cursor.com)