### PR TITLE
fix(editor-view-dom): guard null range in classifyC2 DOM selection fallback

### DIFF
--- a/packages/editor-view-dom/src/dom-sync/dom-change-classifier.ts
+++ b/packages/editor-view-dom/src/dom-sync/dom-change-classifier.ts
@@ -473,7 +473,7 @@ function classifyC2(
       modelSelection: options.modelSelection,
       calculatedOffsets: { startOffset, endOffset }
     });
-  } else {
+  } else if (range) {
     // Calculate offset based on DOM selection
     const converted = convertDOMSelectionToModelOffsets(
       range,
@@ -503,6 +503,9 @@ function classifyC2(
         ? 'DOM offset converted to model offset using inline-text walker'
         : 'DOM offset conversion failed, fallback offsets used'
     });
+  } else {
+    startOffset = 0;
+    endOffset = endModelNode.text?.length || 0;
   }
   
   // Recalculate prevText (using accurate offset)


### PR DESCRIPTION
## Summary

- Fix TS2345: `Range | null` not assignable to `Range` in `dom-change-classifier.ts` line 479
- Add null guard on `range` before passing to `convertDOMSelectionToModelOffsets`
- Add safe fallback offsets (0, text length) when range is unavailable

## Root cause

`range` is only set when `hasSelection` is true (line 333), but the `else` branch at line 476 that calls `convertDOMSelectionToModelOffsets(range, ...)` can be reached via the `hasMultiNodeHint` path where `range` remains `null`.

## Test plan

- [x] `pnpm tsc` — TS2345 error resolved (only pre-existing TS6133 unused variable warnings remain)

Closes #226

Made with [Cursor](https://cursor.com)