### PR TITLE
fix: add 'default' export condition for webpack/Docusaurus SSR compatibility

### DIFF
--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -58,6 +58,8 @@ const config: Config = {
         configureWebpack(config, isServer) {
           return {
             resolve: {
+              // Ensure 'import' condition is available for ESM workspace packages
+              conditionNames: ['import', ...(isServer ? ['node', 'require'] : ['browser']), 'module', 'webpack', 'default'],
               // Allow .js imports to resolve to .ts files
               extensionAlias: {
                 '.js': ['.ts', '.tsx', '.js', '.jsx'],

--- a/packages/collaboration-liveblocks/package.json
+++ b/packages/collaboration-liveblocks/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "files": [
@@ -43,7 +44,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/collaboration-yjs/package.json
+++ b/packages/collaboration-yjs/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "files": [
@@ -43,7 +44,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "files": [
@@ -39,7 +40,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/converter/package.json
+++ b/packages/converter/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "files": [
@@ -53,7 +54,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "files": [
@@ -42,7 +43,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/devtool/package.json
+++ b/packages/devtool/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "publishConfig": {
@@ -19,7 +20,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/dom-observer/package.json
+++ b/packages/dom-observer/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "publishConfig": {
@@ -19,7 +20,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/dsl/package.json
+++ b/packages/dsl/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "publishConfig": {
@@ -19,7 +20,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/editor-core/package.json
+++ b/packages/editor-core/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "files": [
@@ -55,7 +56,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/editor-view-dom/package.json
+++ b/packages/editor-view-dom/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "scripts": {
@@ -59,7 +60,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/editor-view-react/package.json
+++ b/packages/editor-view-react/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "scripts": {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "files": [
@@ -51,7 +52,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "files": [
@@ -55,7 +56,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/renderer-dom/package.json
+++ b/packages/renderer-dom/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "publishConfig": {
@@ -19,7 +20,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "scripts": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "publishConfig": {
@@ -19,7 +20,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "files": [
@@ -46,7 +47,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     },
     "files": [

--- a/packages/text-analyzer/package.json
+++ b/packages/text-analyzer/package.json
@@ -39,7 +39,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }


### PR DESCRIPTION
## Summary

Closes #234

Fixes docs-site build failure caused by missing `"default"` fallback in all workspace packages' `exports` field.

**Problem**: Webpack's SSR compilation resolves under conditions `["require","module","webpack","production","node"]` which doesn't include `"import"`. All 18 workspace packages only defined `"types"` + `"import"`, causing `Module not found` errors.

**Fix**:
- Add `"default"` fallback condition to all 18 packages' exports (both dev-time `./src/index.ts` and publishConfig `./dist/index.js`)
- Add explicit `conditionNames` to docs-site webpack plugin to include `"import"` as a safety net

## Test plan
- [x] `pnpm build` succeeds in `apps/docs-site` (previously failed)
- [x] All package.json exports now include `"default"` condition

Made with [Cursor](https://cursor.com)