### PR TITLE
docs: redesign homepage, update diagrams, fix broken links

### DIFF
--- a/apps/docs-site/docs/architecture/overview.md
+++ b/apps/docs-site/docs/architecture/overview.md
@@ -5,9 +5,9 @@ Barocss Editor uses a **model-first, DSL-first architecture**. All operations wo
 ## Core Structure
 
 ```
-Model → DSL → VNodeBuilder → VNode → DOMReconcile → DOM
-         ↑
-     element, data, when, component, slot, portal
+                         ┌── VNodeBuilder → VNode → DOMReconcile → DOM
+Model → DSL → Registry ─┤
+                         └── buildToReact → ReactNode → React DOM
 ```
 
 ## DSL-First Philosophy
@@ -15,24 +15,32 @@ Model → DSL → VNodeBuilder → VNode → DOMReconcile → DOM
 In Barocss, **everything** is defined using DSL:
 
 - **Templates**: `define('paragraph', element('p', {}, [slot('content')]))`
-- **Marks**: `defineMark('bold', element('strong', {}, [data('text')]))`
+- **Marks**: `defineMark('bold', element('strong', {}, [data('text')]))` or `defineMark('bold', external(BoldComponent))`
 - **Decorators**: `defineDecorator('highlight', element('span', {}, []))`
 - **Operations**: `defineOperationDSL('insertText', (p) => insertText({ text: p.text }))`
 
 This unified approach provides consistency, type safety, and composability across all definitions.
 
-## Complete Pipeline
+## Dual Rendering Pipeline
+
+The same DSL templates power **two rendering targets**:
+
+### DOM Path (renderer-dom)
 
 ```
-1. DSL Layer (packages/dsl)
-   └─ element('p', {...}, [data('text')]) → Template
-
-2. VNode Builder (packages/renderer-dom)
-   └─ Template × Data → VNode
-
-3. DOM Reconcile (packages/renderer-dom)
-   └─ VNode × VNode → DOM
+1. DSL Layer → Template
+2. VNodeBuilder: Template × Data → VNode (virtual DOM)
+3. DOMReconcile: prevVNode vs nextVNode → minimal DOM updates
 ```
+
+### React Path (renderer-react)
+
+```
+1. DSL Layer → Template
+2. buildToReact: Template × Data → ReactNode (no VNode step)
+```
+
+Both paths share the same template definitions — you define once and render to either target.
 
 ## Role of Each Layer
 
@@ -40,28 +48,39 @@ This unified approach provides consistency, type safety, and composability acros
 **Role**: Functional template definition
 
 - `element()` - HTML element template
-- `data()` - Data binding  
+- `data()` - Data binding
 - `when()` - Conditional rendering
 - `component()` - Component template
 - `slot()` - Slot template
 - `portal()` - Portal template
+- `external()` - Wrap React components or DOM mount/unmount objects
 
-All builders are pure functions (Pure Functions)
+All builders are pure functions.
 
 **Input**: Builder parameters
 **Output**: Template
 
-### 2. VNodeBuilder (packages/renderer-dom)
+### 2a. VNodeBuilder (packages/renderer-dom)
 **Role**: Convert DSL templates to VNode
 
 - Template lookup from Registry
 - Data binding (data(), className, style)
 - Component resolution
 - Conditional rendering (build time)
-- `when()` conditions are evaluated at build time and converted to regular VNode
 
 **Input**: Template × Model data
 **Output**: VNode tree
+
+### 2b. buildToReact (packages/renderer-react)
+**Role**: Convert DSL templates directly to ReactNode
+
+- Same template lookup from Registry
+- Same data binding and component resolution
+- Supports `external(ReactComponent)` for marks and blocks
+- No VNode intermediate — outputs ReactNode directly
+
+**Input**: Template × Model data
+**Output**: ReactNode
 
 ### 3. DOMReconcile (packages/renderer-dom)
 **Role**: Convert VNode differences to DOM changes
@@ -143,29 +162,28 @@ reconcileChildren(wip, prevChildren, nextChildren) {
 5. **children reconcile** must set created DOM nodes in child WIP's domNode
 6. **finalizeDOMUpdate** prevents duplicate append (`isAlreadyInDOM` check)
 
-## File Structure
+## Package Map
 
 ```
 packages/
-├─ schema/              # Schema definition
-├─ dsl/                 # DSL Layer ⭐
-│  ├─ template-builders.ts  # element, data, when, component
-│  ├─ types.ts             # Template types
-│  └─ registry.ts          # Template registry
-├─ vnode/              # VNodeBuilder
-│  └─ factory.ts       # DSL Template → VNode conversion
-├─ model/              # Model data
-├─ renderer-dom/
-│  ├─ dom-renderer.ts           # High-level wrapper
-│  ├─ dom-reconcile.ts          # Main reconcile
-│  ├─ work-in-progress.ts       # WIP interfaces
-│  ├─ work-in-progress-manager.ts
-│  ├─ change-detection.ts       # Change detection
-│  ├─ dom-processor.ts          # DOM manipulation
-│  ├─ component-manager.ts      # Component lifecycle
-│  ├─ portal-manager.ts        # Portal rendering
-│  └─ dom-operations.ts        # DOM utilities
-└─ datastore/         # Data management
+├─ schema/                 # Document structure and validation
+├─ datastore/              # Transactional node store (overlay/COW)
+├─ model/                  # Operations, transactions, undo/redo
+├─ dsl/                    # Declarative template builders ⭐
+├─ renderer-dom/           # VNode reconciliation → DOM
+├─ renderer-react/         # Direct → ReactNode (no VNode)
+├─ editor-core/            # Commands, selection, extensions, history
+├─ editor-view-dom/        # DOM input handling, selection sync
+├─ editor-view-react/      # React view layer with hooks
+├─ extensions/             # 30+ built-in extensions
+├─ collaboration/          # CRDT/OT base adapter
+├─ collaboration-yjs/      # Yjs adapter
+├─ collaboration-liveblocks/ # Liveblocks adapter
+├─ converter/              # HTML/Markdown/LaTeX/PDF conversion
+├─ shared/                 # Platform, keybinding, i18n utilities
+├─ text-analyzer/          # Smart text diff (LCP/LCS)
+├─ dom-observer/           # DOM mutation observer
+└─ devtool/                # Dev tools (tree view, event log)
 ```
 
 ## Usage Examples
@@ -208,7 +226,10 @@ define('article', element('article',
 
 ## Related Documents
 
-- [Package Structure](./packages) - Learn about each package's role and how to extend the editor
 - [Core Concepts: Rendering](../concepts/rendering) - Understand the rendering pipeline
+- [Renderer DOM](./renderer-dom) - DOM rendering with VNode reconciliation
+- [Renderer React](./renderer-react) - React rendering (no VNode)
+- [Editor View DOM](./editor-view-dom) - DOM view layer
+- [Editor View React](./editor-view-react) - React view layer
 - [Practical Examples](./practical-examples) - Real-world usage examples
 

--- a/apps/docs-site/docs/getting-started.md
+++ b/apps/docs-site/docs/getting-started.md
@@ -2,14 +2,9 @@
 id: getting-started
 title: Getting Started
 sidebar_label: Getting Started
+slug: /getting-started
 ---
 
-# Getting Started
+import {Redirect} from '@docusaurus/router';
 
-Use this page as the entry point into the Barocss Editor documentation.
-
-- **Installation**: step-by-step installation instructions for all required packages. See [`installation`](./installation.md).
-- **Quick Start**: minimal end‑to‑end example from empty project to a working editor instance. See [`quick-start`](./quick-start.md).
-- **Basic Usage**: core editing flows and how the main APIs are used in practice. See [`basic-usage`](./basic-usage.md).
-
-Each of these documents is maintained independently; this page only routes to them and does not duplicate their content.
+<Redirect to="/docs/introduction" />

--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -103,7 +103,7 @@ const config: Config = {
           items: [
             {
               label: 'Getting Started',
-              to: '/docs/getting-started',
+              to: '/docs/introduction',
             },
             {
               label: 'API Reference',

--- a/apps/docs-site/src/components/ArchitectureDiagram.tsx
+++ b/apps/docs-site/src/components/ArchitectureDiagram.tsx
@@ -22,61 +22,98 @@ export default function ArchitectureDiagram() {
 
     const diagramDefinition = `graph TB
     subgraph datalayer["Data Layer"]
-        Model["Model<br/>@barocss/model<br/>Document Data"]
-        Schema["Schema<br/>@barocss/schema<br/>Structure Definition"]
-        DataStore["DataStore<br/>@barocss/datastore<br/>Transactional Store"]
+        Schema["Schema<br/>@barocss/schema"]
+        DataStore["DataStore<br/>@barocss/datastore"]
+        Model["Model<br/>@barocss/model"]
     end
 
     subgraph templatelayer["Template Layer"]
-        DSL["DSL<br/>@barocss/dsl<br/>Template Definition"]
-        Registry["Registry<br/>@barocss/dsl<br/>Template Lookup"]
+        DSL["DSL<br/>@barocss/dsl"]
+        Registry["Registry<br/>Template Lookup"]
     end
 
     subgraph renderinglayer["Rendering Layer"]
-        VNodeBuilder["VNodeBuilder<br/>@barocss/renderer-dom<br/>Template → VNode"]
-        VNode["VNode<br/>@barocss/renderer-dom<br/>Virtual DOM"]
-        DOMReconcile["DOMReconcile<br/>@barocss/renderer-dom<br/>VNode → DOM"]
+        direction LR
+        subgraph dompath["DOM Path"]
+            VNodeBuilder["VNodeBuilder"]
+            VNode["VNode"]
+            DOMReconcile["DOMReconcile"]
+        end
+        subgraph reactpath["React Path"]
+            BuildToReact["buildToReact"]
+            ReactNode["ReactNode"]
+        end
     end
 
     subgraph editorlayer["Editor Layer"]
-        EditorCore["Editor Core<br/>@barocss/editor-core<br/>Commands & Context"]
-        EditorView["Editor View<br/>@barocss/editor-view-dom<br/>Input & Selection"]
+        EditorCore["Editor Core<br/>@barocss/editor-core"]
+        EditorViewDOM["Editor View DOM<br/>@barocss/editor-view-dom"]
+        EditorViewReact["Editor View React<br/>@barocss/editor-view-react"]
+    end
+
+    subgraph extlayer["Extensions & Collaboration"]
+        Extensions["Extensions<br/>@barocss/extensions"]
+        Collaboration["Collaboration<br/>@barocss/collaboration"]
+        Converter["Converter<br/>@barocss/converter"]
     end
 
     subgraph output["Output"]
-        DOM["DOM<br/>Rendered Output"]
+        DOM["DOM"]
+        ReactDOM["React DOM"]
     end
 
-    Model --> DSL
-    Schema --> Model
+    Schema --> DataStore
     DataStore --> Model
+    Model --> DSL
     DSL --> Registry
+
     Registry --> VNodeBuilder
+    Registry --> BuildToReact
     Model --> VNodeBuilder
+    Model --> BuildToReact
+
     VNodeBuilder --> VNode
     VNode --> DOMReconcile
     DOMReconcile --> DOM
-    
-    EditorCore --> Model
-    EditorView --> EditorCore
-    EditorView --> DOMReconcile
+    BuildToReact --> ReactNode
+    ReactNode --> ReactDOM
 
-    style Model fill:#3b82f6,stroke:#2563eb,color:#fff
-    style DSL fill:#60a5fa,stroke:#3b82f6,color:#fff
-    style VNode fill:#93c5fd,stroke:#60a5fa,color:#000
-    style DOM fill:#dbeafe,stroke:#93c5fd,color:#000
-    style EditorCore fill:#f59e0b,stroke:#d97706,color:#fff
-    style EditorView fill:#fbbf24,stroke:#f59e0b,color:#000
+    EditorCore --> Model
+    EditorViewDOM --> EditorCore
+    EditorViewDOM --> DOMReconcile
+    EditorViewReact --> EditorCore
+    EditorViewReact --> BuildToReact
+
+    Extensions --> EditorCore
+    Collaboration --> DataStore
+    Converter --> Model
+
     style Schema fill:#8b5cf6,stroke:#7c3aed,color:#fff
     style DataStore fill:#8b5cf6,stroke:#7c3aed,color:#fff
+    style Model fill:#3b82f6,stroke:#2563eb,color:#fff
+    style DSL fill:#60a5fa,stroke:#3b82f6,color:#fff
     style Registry fill:#60a5fa,stroke:#3b82f6,color:#fff
     style VNodeBuilder fill:#93c5fd,stroke:#60a5fa,color:#000
+    style VNode fill:#93c5fd,stroke:#60a5fa,color:#000
     style DOMReconcile fill:#a5b4fc,stroke:#818cf8,color:#000
-    style datalayer fill:#f3f4f6,stroke:#8b5cf6,stroke-width:2px
-    style templatelayer fill:#f3f4f6,stroke:#60a5fa,stroke-width:2px
-    style renderinglayer fill:#f3f4f6,stroke:#93c5fd,stroke-width:2px
-    style editorlayer fill:#f3f4f6,stroke:#f59e0b,stroke-width:2px
-    style output fill:#f3f4f6,stroke:#dbeafe,stroke-width:2px`;
+    style BuildToReact fill:#34d399,stroke:#10b981,color:#000
+    style ReactNode fill:#34d399,stroke:#10b981,color:#000
+    style DOM fill:#dbeafe,stroke:#93c5fd,color:#000
+    style ReactDOM fill:#d1fae5,stroke:#34d399,color:#000
+    style EditorCore fill:#f59e0b,stroke:#d97706,color:#fff
+    style EditorViewDOM fill:#fbbf24,stroke:#f59e0b,color:#000
+    style EditorViewReact fill:#fbbf24,stroke:#f59e0b,color:#000
+    style Extensions fill:#fb923c,stroke:#f97316,color:#000
+    style Collaboration fill:#fb923c,stroke:#f97316,color:#000
+    style Converter fill:#fb923c,stroke:#f97316,color:#000
+    style datalayer fill:#f5f3ff,stroke:#8b5cf6,stroke-width:2px
+    style templatelayer fill:#eff6ff,stroke:#60a5fa,stroke-width:2px
+    style renderinglayer fill:#f0f9ff,stroke:#93c5fd,stroke-width:2px
+    style dompath fill:#eff6ff,stroke:#93c5fd,stroke-width:1px
+    style reactpath fill:#ecfdf5,stroke:#34d399,stroke-width:1px
+    style editorlayer fill:#fffbeb,stroke:#f59e0b,stroke-width:2px
+    style extlayer fill:#fff7ed,stroke:#fb923c,stroke-width:2px
+    style output fill:#f9fafb,stroke:#d1d5db,stroke-width:2px`;
 
     const id = `architecture-diagram-${Date.now()}`;
     const mermaidDiv = document.createElement('div');

--- a/apps/docs-site/src/components/RenderingPipelineDiagram.tsx
+++ b/apps/docs-site/src/components/RenderingPipelineDiagram.tsx
@@ -21,21 +21,35 @@ export default function RenderingPipelineDiagram() {
     });
 
     const diagramDefinition = `graph LR
-    Model["Model<br/>Document Data<br/>{stype, sid, text}"]
-    Registry["Registry<br/>@barocss/dsl<br/>Template Lookup"]
-    Template["Template<br/>DSL Definition<br/>element, data, when"]
-    VNodeBuilder["VNodeBuilder<br/>@barocss/renderer-dom<br/>Template × Data"]
-    VNode["VNode<br/>Virtual DOM<br/>Tree Structure"]
-    DOMReconcile["DOMReconcile<br/>@barocss/renderer-dom<br/>Diff & Update"]
-    DOM["DOM<br/>Rendered Output<br/>HTML Elements"]
+    Model["Model<br/>{stype, sid, text}"]
+    Registry["Registry<br/>Template Lookup"]
+    Template["Template<br/>DSL Definition"]
 
-    Model -->|"1. Query by stype"| Registry
-    Registry -->|"2. Get Template"| Template
-    Template -->|"3. Build VNode"| VNodeBuilder
-    Model -->|"4. Apply Data"| VNodeBuilder
-    VNodeBuilder -->|"5. Generate"| VNode
-    VNode -->|"6. Reconcile"| DOMReconcile
-    DOMReconcile -->|"7. Update"| DOM
+    subgraph domRenderer["renderer-dom"]
+        VNodeBuilder["VNodeBuilder<br/>Template × Data"]
+        VNode["VNode<br/>Virtual DOM"]
+        DOMReconcile["DOMReconcile<br/>Diff & Patch"]
+    end
+
+    subgraph reactRenderer["renderer-react"]
+        BuildToReact["buildToReact<br/>Template × Data"]
+        ReactOutput["ReactNode<br/>React Elements"]
+    end
+
+    DOM["DOM"]
+    ReactDOM["React DOM"]
+
+    Model -->|"1. stype"| Registry
+    Registry -->|"2. lookup"| Template
+    Template -->|"3a. DOM path"| VNodeBuilder
+    Template -->|"3b. React path"| BuildToReact
+    Model -->|"data"| VNodeBuilder
+    Model -->|"data"| BuildToReact
+    VNodeBuilder -->|"4a."| VNode
+    VNode -->|"5a. reconcile"| DOMReconcile
+    DOMReconcile -->|"6a."| DOM
+    BuildToReact -->|"4b."| ReactOutput
+    ReactOutput -->|"5b."| ReactDOM
 
     style Model fill:#3b82f6,stroke:#2563eb,color:#fff
     style Registry fill:#60a5fa,stroke:#3b82f6,color:#fff
@@ -43,7 +57,12 @@ export default function RenderingPipelineDiagram() {
     style VNodeBuilder fill:#93c5fd,stroke:#60a5fa,color:#000
     style VNode fill:#93c5fd,stroke:#60a5fa,color:#000
     style DOMReconcile fill:#a5b4fc,stroke:#818cf8,color:#000
-    style DOM fill:#dbeafe,stroke:#93c5fd,color:#000`;
+    style BuildToReact fill:#34d399,stroke:#10b981,color:#000
+    style ReactOutput fill:#34d399,stroke:#10b981,color:#000
+    style DOM fill:#dbeafe,stroke:#93c5fd,color:#000
+    style ReactDOM fill:#d1fae5,stroke:#34d399,color:#000
+    style domRenderer fill:#eff6ff,stroke:#93c5fd,stroke-width:2px
+    style reactRenderer fill:#ecfdf5,stroke:#34d399,stroke-width:2px`;
 
     const id = `rendering-pipeline-${Date.now()}`;
     const mermaidDiv = document.createElement('div');

--- a/apps/docs-site/src/css/custom.css
+++ b/apps/docs-site/src/css/custom.css
@@ -10,17 +10,23 @@
   --ifm-color-primary-light: #3b82f6;
   --ifm-color-primary-lighter: #60a5fa;
   --ifm-color-primary-lightest: #93c5fd;
-  
-  /* Custom variables for light mode (default) */
-  --homepage-border-color: var(--ifm-color-emphasis-300);
+
+  --homepage-border-color: var(--ifm-color-emphasis-200);
   --homepage-bg-color: var(--ifm-background-color);
-  --homepage-text-secondary: var(--ifm-color-content-secondary);
+  --homepage-text-secondary: #64748b;
   --homepage-card-bg: var(--ifm-background-surface-color);
-  --homepage-section-bg: var(--ifm-color-emphasis-100);
+  --homepage-section-bg: #f8fafc;
   --homepage-heading-color: var(--ifm-heading-color);
 }
 
-/* Global typography tweaks for documentation pages */
+[data-theme='dark'] {
+  --homepage-border-color: var(--ifm-color-emphasis-300);
+  --homepage-text-secondary: #94a3b8;
+  --homepage-section-bg: var(--ifm-color-emphasis-100);
+}
+
+/* ────────────── Global typography ────────────── */
+
 main .markdown {
   max-width: 860px;
   margin: 0 auto;
@@ -28,73 +34,45 @@ main .markdown {
   line-height: 1.7;
 }
 
-main .markdown h1,
-main .markdown h2,
-main .markdown h3 {
-  letter-spacing: -0.01em;
-}
+main .markdown h1 { font-size: 2.4rem; margin-bottom: 1.2rem; letter-spacing: -0.02em; }
+main .markdown h2 { font-size: 1.6rem; margin-top: 2.4rem; margin-bottom: 0.9rem; letter-spacing: -0.01em; }
+main .markdown h3 { font-size: 1.25rem; margin-top: 1.8rem; margin-bottom: 0.6rem; }
+main .markdown p  { margin-bottom: 0.9rem; }
+main .markdown ul, main .markdown ol { margin-top: 0.4rem; margin-bottom: 0.9rem; }
 
-main .markdown h1 {
-  font-size: 2.4rem;
-  margin-bottom: 1.2rem;
-}
+/* ────────────── Code blocks ────────────── */
 
-main .markdown h2 {
-  font-size: 1.6rem;
-  margin-top: 2.4rem;
-  margin-bottom: 0.9rem;
-}
-
-main .markdown h3 {
-  font-size: 1.25rem;
-  margin-top: 1.8rem;
-  margin-bottom: 0.6rem;
-}
-
-main .markdown p {
-  margin-bottom: 0.9rem;
-}
-
-main .markdown ul,
-main .markdown ol {
-  margin-top: 0.4rem;
-  margin-bottom: 0.9rem;
-}
-
-/* Code blocks and inline code */
 .theme-code-block {
   border-radius: 8px;
   border: 1px solid var(--ifm-color-emphasis-200);
-  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04);
 }
+.theme-code-block pre { font-size: 0.9rem; }
+.markdown code { border-radius: 4px; padding: 0.1rem 0.3rem; }
 
-.theme-code-block pre {
-  font-size: 0.9rem;
-}
+/* ────────────── Light / dark backgrounds ────────────── */
 
-.markdown code {
-  border-radius: 4px;
-  padding: 0.1rem 0.3rem;
-}
-
-/* Light mode - explicit white background */
 html:not([data-theme='dark']),
 html[data-theme='light'] {
   --ifm-background-color: #ffffff;
   --ifm-background-surface-color: #ffffff;
 }
 
-/* Dark mode - use Docusaurus defaults */
-[data-theme='dark'] {
-  --homepage-border-color: var(--ifm-color-emphasis-300);
-  --homepage-bg-color: var(--ifm-background-color);
-  --homepage-text-secondary: var(--ifm-color-content-secondary);
-  --homepage-card-bg: var(--ifm-background-surface-color);
-  --homepage-section-bg: var(--ifm-color-emphasis-100);
-  --homepage-heading-color: var(--ifm-heading-color);
-}
+html:not([data-theme='dark']) body,
+html[data-theme='light'] body { background-color: #ffffff; color: #1e293b; }
 
-/* Editor demo container */
+[data-theme='dark'] body { background-color: var(--ifm-background-color); color: var(--ifm-font-color-base); }
+
+/* ────────────── Navbar / Footer ────────────── */
+
+.navbar { box-shadow: 0 1px 0 rgba(15, 23, 42, 0.06); }
+.footer { background-color: var(--ifm-background-surface-color); border-top: 1px solid var(--ifm-color-emphasis-200); }
+
+.menu__link--sublist-caret::after { transform: scale(0.75) rotateZ(0deg); }
+.menu__list-item--collapsed .menu__link--sublist-caret::after { transform: scale(0.75) rotateZ(90deg); }
+
+/* ────────────── Editor demo ────────────── */
+
 .editor-demo {
   border: 1px solid var(--homepage-border-color);
   border-radius: 8px;
@@ -103,281 +81,308 @@ html[data-theme='light'] {
   margin: 1rem 0;
   background: var(--homepage-card-bg);
 }
-
-.editor-demo .document {
-  line-height: 1.6;
-}
-
-.editor-demo .heading {
-  margin: 1.5em 0 0.5em 0;
-  font-weight: 600;
-}
-
-.editor-demo .heading h1 {
-  font-size: 2em;
-  color: var(--ifm-heading-color);
-}
-
-.editor-demo .heading h2 {
-  font-size: 1.5em;
-  color: var(--ifm-heading-color);
-}
-
-.editor-demo .paragraph {
-  margin: 0.5em 0;
-}
-
-.editor-demo .text {
-  display: inline;
-}
-
-.editor-demo .mark-bold {
-  font-weight: bold;
-}
-
-.editor-demo .mark-italic {
-  font-style: italic;
-}
-
-.editor-demo .barocss-editor-content {
-  outline: none;
-}
-
+.editor-demo .document  { line-height: 1.6; }
+.editor-demo .heading   { margin: 1.5em 0 0.5em 0; font-weight: 600; }
+.editor-demo .heading h1 { font-size: 2em; color: var(--ifm-heading-color); }
+.editor-demo .heading h2 { font-size: 1.5em; color: var(--ifm-heading-color); }
+.editor-demo .paragraph  { margin: 0.5em 0; }
+.editor-demo .text       { display: inline; }
+.editor-demo .mark-bold   { font-weight: bold; }
+.editor-demo .mark-italic { font-style: italic; }
+.editor-demo .barocss-editor-content { outline: none; }
 .editor-demo .barocss-editor-content:focus {
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
   border-radius: 4px;
 }
 
-/* Homepage card styles */
-.homepage-card {
-  padding: 1.5rem;
-  border: 1px solid var(--homepage-border-color);
-  border-radius: 8px;
-  background: var(--homepage-card-bg);
-  transition: all 0.2s ease;
-  color: var(--ifm-font-color-base);
+/* ═══════════════════════════════════════════════
+   HOMEPAGE
+   ═══════════════════════════════════════════════ */
+
+.homepage {
+  background: var(--ifm-background-color);
 }
 
-.homepage-card h3 {
-  color: var(--homepage-heading-color);
-  font-weight: 600;
+.homepage-container {
+  max-width: 1140px;
+  margin: 0 auto;
+  padding: 0 2rem 4rem;
+}
+
+/* ── Shared section helpers ── */
+
+.section-title {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
   margin-bottom: 0.75rem;
-  font-size: 1.25rem;
-  line-height: 1.4;
+  color: var(--homepage-heading-color);
 }
 
-.homepage-card p {
-  color: var(--ifm-font-color-base);
+.section-subtitle {
+  text-align: center;
+  color: var(--homepage-text-secondary);
+  max-width: 640px;
+  margin: 0 auto 2.5rem;
+  font-size: 1.05rem;
   line-height: 1.6;
 }
 
-.homepage-card:hover {
-  border-color: var(--ifm-color-emphasis-400);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  transform: translateY(-2px);
+/* ── Hero ── */
+
+.hero-section {
+  text-align: center;
+  padding: 5rem 0 4rem;
 }
 
-.homepage-card code {
-  background: var(--ifm-code-background);
-  color: var(--ifm-code-color);
-  padding: 0.125rem 0.375rem;
-  border-radius: 4px;
-  font-size: 0.875em;
+.hero-badge {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--ifm-color-primary-lighter);
+  color: var(--ifm-color-primary);
+  background: rgba(37, 99, 235, 0.06);
+  margin-bottom: 1.5rem;
 }
 
-.homepage-section {
-  background: var(--homepage-section-bg);
-  padding: 2rem;
-  border-radius: 12px;
+[data-theme='dark'] .hero-badge {
+  background: rgba(96, 165, 250, 0.12);
+  border-color: rgba(96, 165, 250, 0.3);
+}
+
+.hero-title {
+  font-size: clamp(2.2rem, 5vw, 3.2rem);
+  font-weight: 800;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  max-width: 780px;
+  margin: 0 auto 1.25rem;
+}
+
+.hero-highlight {
+  background: linear-gradient(135deg, var(--ifm-color-primary), #7c3aed);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  line-height: 1.65;
+  color: var(--homepage-text-secondary);
+  max-width: 620px;
+  margin: 0 auto 2rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.hero-actions .button--outline {
+  border-color: var(--homepage-border-color);
   color: var(--ifm-font-color-base);
 }
+.hero-actions .button--outline:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  background: transparent;
+}
 
-.homepage-section h2 {
-  color: var(--homepage-heading-color);
+.hero-github-btn::before {
+  content: '';
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  margin-right: 6px;
+  vertical-align: -3px;
+  background: currentColor;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 .5C5.37.5 0 5.78 0 12.292c0 5.211 3.438 9.63 8.205 11.188.6.111.82-.254.82-.567 0-.28-.01-1.022-.015-2.005-3.338.711-4.042-1.582-4.042-1.582-.546-1.361-1.333-1.724-1.333-1.724-1.09-.73.083-.716.083-.716 1.205.083 1.838 1.215 1.838 1.215 1.07 1.803 2.809 1.282 3.495.981.108-.763.417-1.282.76-1.577-2.665-.295-5.466-1.309-5.466-5.827 0-1.287.465-2.339 1.235-3.164-.135-.298-.54-1.497.105-3.121 0 0 1.005-.316 3.3 1.209A11.707 11.707 0 0 1 12 6.545c1.02.005 2.047.138 3.006.404 2.28-1.525 3.285-1.209 3.285-1.209.645 1.624.24 2.823.12 3.121.765.825 1.23 1.877 1.23 3.164 0 4.53-2.805 5.527-5.475 5.817.42.354.81 1.077.81 2.182 0 1.578-.015 2.846-.015 3.229 0 .309.21.678.825.56C20.565 21.917 24 17.495 24 12.292 24 5.78 18.627.5 12 .5'/%3E%3C/svg%3E") no-repeat center / contain;
+}
+
+.hero-install {
+  display: inline-block;
+  background: var(--homepage-section-bg);
+  border: 1px solid var(--homepage-border-color);
+  border-radius: 8px;
+  padding: 0.6rem 1.25rem;
+  font-size: 0.85rem;
+  font-family: var(--ifm-font-family-monospace);
+  color: var(--ifm-font-color-base);
+  user-select: all;
+}
+
+[data-theme='dark'] .hero-install {
+  background: var(--ifm-color-emphasis-100);
+}
+
+/* ── Features ── */
+
+.features-section { padding: 3rem 0; }
+
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.25rem;
+}
+
+.feature-card {
+  padding: 1.5rem;
+  border: 1px solid var(--homepage-border-color);
+  border-radius: 10px;
+  background: var(--homepage-card-bg);
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+
+.feature-card h3 {
+  font-size: 1.1rem;
   font-weight: 700;
+  margin: 0 0 0.5rem;
+  color: var(--homepage-heading-color);
 }
 
-/* CodeBlock in homepage section - reduce padding */
-.homepage-section .theme-code-block {
-  margin-bottom: 0;
-}
-
-.homepage-section .theme-code-block pre {
-  padding: 0.875rem 1rem;
+.feature-card p {
+  font-size: 0.92rem;
+  line-height: 1.6;
   margin: 0;
-}
-
-.homepage-section .theme-code-block pre code {
-  padding: 0;
-}
-
-/* Main headings on homepage */
-main h1,
-main h2 {
-  color: var(--homepage-heading-color);
-  font-weight: 700;
-}
-
-.homepage-text-secondary {
   color: var(--homepage-text-secondary);
 }
 
-/* Body and HTML background - explicit for light mode */
-html:not([data-theme='dark']),
-html[data-theme='light'],
-html:not([data-theme='dark']) body,
-html[data-theme='light'] body {
-  background-color: #ffffff !important;
-  color: #213547;
+.feature-card:hover {
+  border-color: var(--ifm-color-primary-lighter);
+  box-shadow: 0 4px 16px rgba(37, 99, 235, 0.06);
+  transform: translateY(-2px);
 }
 
-/* Dark mode - use Docusaurus variables */
-[data-theme='dark'] html,
-[data-theme='dark'] body {
-  background-color: var(--ifm-background-color);
-  color: var(--ifm-font-color-base);
+/* ── Demo ── */
+
+.demo-section { padding: 3rem 0; }
+
+/* ── Code steps ── */
+
+.code-section { padding: 3rem 0; }
+
+.code-steps {
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
-/* Main content area */
-html:not([data-theme='dark']) main,
-html[data-theme='light'] main {
-  background-color: #ffffff !important;
-  color: #213547;
+.code-step-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-primary);
+  margin-bottom: 0.5rem;
 }
 
-[data-theme='dark'] main {
-  background-color: var(--ifm-background-color);
-  color: var(--ifm-font-color-base);
-}
+/* ── Architecture ── */
 
-/* Ensure Layout background */
-html:not([data-theme='dark']) .main-wrapper,
-html[data-theme='light'] .main-wrapper {
-  background-color: #ffffff !important;
-}
+.architecture-section { padding: 3rem 0; }
 
-[data-theme='dark'] .main-wrapper {
-  background-color: var(--ifm-background-color);
-}
+/* ── Packages ── */
 
-/* Docusaurus root elements */
-html:not([data-theme='dark']) #__docusaurus,
-html[data-theme='light'] #__docusaurus {
-  background-color: #ffffff !important;
-}
+.packages-section { padding: 3rem 0; }
 
-[data-theme='dark'] #__docusaurus {
-  background-color: var(--ifm-background-color);
-}
-
-/* Navbar and footer */
-.navbar {
-  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.06);
-}
-
-.footer {
-  background-color: var(--ifm-background-surface-color);
-  border-top: 1px solid var(--ifm-color-emphasis-200);
-}
-
-/* Sidebar category caret icon size (collapsed + expanded) */
-.menu__link--sublist-caret::after {
-  /* default (expanded) direction + smaller size */
-  transform: scale(0.75) rotateZ(0deg);
-}
-
-.menu__list-item--collapsed .menu__link--sublist-caret::after {
-  /* collapsed state uses the same 90deg rotation as the base theme, but scaled down */
-  transform: scale(0.75) rotateZ(90deg);
-}
-
-/* Footer layout styles */
-footer.theme-layout-footer {
-  background-color: var(--ifm-color-content);
-}
-
-/* Package list styles */
 .package-list {
-  max-width: 900px;
+  max-width: 720px;
   margin: 0 auto;
 }
 
 .package-item {
   display: grid;
-  grid-template-columns: 220px 1fr;
-  gap: 1.5rem;
-  padding: 0.875rem 0;
+  grid-template-columns: 240px 1fr;
+  gap: 1rem;
+  padding: 0.6rem 0;
   border-bottom: 1px solid var(--homepage-border-color);
-  align-items: start;
+  align-items: baseline;
 }
 
-.package-item:last-child {
-  border-bottom: none;
-}
+.package-item:last-child { border-bottom: none; }
 
 .package-name {
-  font-size: 0.9rem;
-  font-weight: 500;
+  font-size: 0.85rem;
+  font-weight: 600;
   color: var(--ifm-color-primary);
   font-family: var(--ifm-font-family-monospace);
   white-space: nowrap;
 }
 
 .package-description {
-  color: var(--ifm-font-color-base);
-  line-height: 1.6;
-  font-size: 0.95rem;
+  color: var(--homepage-text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.5;
 }
 
-@media (max-width: 768px) {
-  .package-item {
-    grid-template-columns: 1fr;
-    gap: 0.5rem;
-  }
-  
-  .package-name {
-    font-weight: 600;
-  }
+@media (max-width: 640px) {
+  .package-item { grid-template-columns: 1fr; gap: 0.25rem; }
 }
 
-/* Documentation links styles */
+/* ── Doc links ── */
+
+.docs-links-section {
+  padding: 3rem 0 2rem;
+  border-top: 1px solid var(--homepage-border-color);
+  margin-top: 2rem;
+}
+
 .doc-links {
-  max-width: 800px;
+  max-width: 720px;
   margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 0.75rem;
 }
 
 .doc-link {
   display: block;
   padding: 1rem 1.25rem;
   border: 1px solid var(--homepage-border-color);
-  border-radius: 6px;
+  border-radius: 8px;
   text-decoration: none;
-  transition: all 0.2s ease;
+  transition: border-color 0.15s, background 0.15s;
   color: inherit;
 }
 
 .doc-link:hover {
   border-color: var(--ifm-color-primary);
-  background-color: var(--ifm-color-emphasis-100);
+  background: rgba(37, 99, 235, 0.03);
   text-decoration: none;
-  transform: translateX(4px);
 }
+
+[data-theme='dark'] .doc-link:hover { background: rgba(96, 165, 250, 0.06); }
 
 .doc-link-title {
   display: block;
   font-weight: 600;
-  font-size: 1.1rem;
-  margin-bottom: 0.25rem;
+  font-size: 1rem;
+  margin-bottom: 0.2rem;
   color: var(--homepage-heading-color);
 }
 
 .doc-link-desc {
   display: block;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   color: var(--homepage-text-secondary);
-  line-height: 1.5;
+  line-height: 1.45;
 }
 
+/* ── Responsive ── */
+
+@media (max-width: 768px) {
+  .hero-section { padding: 3rem 0 2.5rem; }
+  .hero-title { font-size: 2rem; }
+  .features-grid { grid-template-columns: 1fr; }
+  .doc-links { grid-template-columns: 1fr; }
+}

--- a/apps/docs-site/src/pages/index.tsx
+++ b/apps/docs-site/src/pages/index.tsx
@@ -6,245 +6,247 @@ import EditorDemo from '@site/src/components/EditorDemo';
 import ArchitectureDiagram from '@site/src/components/ArchitectureDiagram';
 import RenderingPipelineDiagram from '@site/src/components/RenderingPipelineDiagram';
 
-export default function Home(): JSX.Element {
+function HeroSection() {
   return (
-    <Layout
-      title="Barocss Editor"
-      description="A powerful document editor with DSL-based rendering">
-      <main style={{ padding: '3rem 0', backgroundColor: 'var(--ifm-background-color)' }}>
-        <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '0 2rem' }}>
-          {/* Hero Section */}
-          <div style={{ textAlign: 'center', marginBottom: '4rem' }}>
-            <h1 style={{ fontSize: '3.5rem', marginBottom: '1rem', fontWeight: 700, letterSpacing: '-0.02em' }}>
-              Barocss Editor
-            </h1>
-            <p style={{ fontSize: '1.25rem', marginBottom: '2rem', maxWidth: '700px', margin: '0 auto 2rem', lineHeight: '1.6' }} className="homepage-text-secondary">
-              A powerful document editor with DSL-based rendering, built for extensibility and performance.
-            </p>
-            <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center', flexWrap: 'wrap' }}>
-              <Link
-                className="button button--primary button--lg"
-                to="/docs/getting-started">
-                Get Started
-              </Link>
-              <Link
-                className="button button--secondary button--lg"
-                to="/docs/installation">
-                Installation
-              </Link>
-              <Link
-                className="button button--secondary button--lg"
-                href="https://github.com/barocss/barocss-editor">
-                View on GitHub
-              </Link>
-            </div>
+    <section className="hero-section">
+      <div className="hero-badge">Open Source Document Editor</div>
+      <h1 className="hero-title">
+        Build powerful editors with{' '}
+        <span className="hero-highlight">model-first architecture</span>
+      </h1>
+      <p className="hero-subtitle">
+        Barocss Editor provides a declarative DSL, efficient reconciliation, and extensible
+        plugin system — supporting both DOM and React rendering targets.
+      </p>
+      <div className="hero-actions">
+        <Link className="button button--primary button--lg" to="/docs/introduction">
+          Get Started
+        </Link>
+        <Link className="button button--outline button--lg" to="/docs/installation">
+          Installation
+        </Link>
+        <Link
+          className="button button--outline button--lg hero-github-btn"
+          href="https://github.com/barocss/barocss-editor">
+          GitHub
+        </Link>
+      </div>
+      <div className="hero-install">
+        <code>pnpm add @barocss/editor-core @barocss/editor-view-dom @barocss/schema @barocss/dsl @barocss/extensions</code>
+      </div>
+    </section>
+  );
+}
+
+const FEATURES = [
+  {
+    title: 'Declarative DSL',
+    desc: 'Define templates with pure functions — element, data, slot, when. Predictable, testable, and composable across templates, marks, and decorators.',
+  },
+  {
+    title: 'Model-First',
+    desc: 'All editing operations work on the model, not the DOM. Enables reliable undo/redo, real-time collaboration, and deterministic testing.',
+  },
+  {
+    title: 'Dual Renderer',
+    desc: 'Same DSL templates render to both DOM (VNode reconciliation) and React (direct ReactNode). Choose the rendering target that fits your stack.',
+  },
+  {
+    title: 'Extensible',
+    desc: '30+ built-in extensions for formatting, tables, code blocks, math, and more. Create custom commands, keybindings, and decorators with a clean API.',
+  },
+  {
+    title: 'Type-Safe',
+    desc: 'Full TypeScript support with schema validation. Catch structural errors at compile time with strongly typed props for blocks and marks.',
+  },
+  {
+    title: 'Collaboration Ready',
+    desc: 'Built-in adapters for Yjs and Liveblocks. AwarenessManager for cursors, ConflictResolver for concurrent edits, BaseAdapter for custom backends.',
+  },
+] as const;
+
+function FeaturesSection() {
+  return (
+    <section className="features-section">
+      <h2 className="section-title">Why Barocss Editor</h2>
+      <div className="features-grid">
+        {FEATURES.map((f) => (
+          <div key={f.title} className="feature-card">
+            <h3>{f.title}</h3>
+            <p>{f.desc}</p>
           </div>
+        ))}
+      </div>
+    </section>
+  );
+}
 
-          {/* Features Grid */}
-          <div style={{ marginBottom: '4rem' }}>
-            <h2 style={{ textAlign: 'center', marginBottom: '2rem', fontSize: '2.25rem', fontWeight: 700, letterSpacing: '-0.01em' }}>Features</h2>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1.5rem' }}>
-              <div className="homepage-card">
-                <h3 style={{ marginTop: 0 }}>🎨 Declarative DSL</h3>
-                <p>Define templates using functional DSL (element, data, when, component). Pure functions that make rendering predictable and testable.</p>
-              </div>
-              <div className="homepage-card">
-                <h3 style={{ marginTop: 0 }}>📦 Model-First Architecture</h3>
-                <p>All editing operations work on the model, not the DOM. This ensures consistency and makes undo/redo, collaboration, and testing easier.</p>
-              </div>
-              <div className="homepage-card">
-                <h3 style={{ marginTop: 0 }}>🔧 Extensible</h3>
-                <p>Create custom extensions and decorators easily. Plugin-based architecture allows you to add new commands and features without modifying core code.</p>
-              </div>
-              <div className="homepage-card">
-                <h3 style={{ marginTop: 0 }}>🛡️ Type-Safe</h3>
-                <p>Full TypeScript support with schema validation. Catch errors at compile time and get excellent IDE autocomplete.</p>
-              </div>
-              <div className="homepage-card">
-                <h3 style={{ marginTop: 0 }}>⚡ Fast Rendering</h3>
-                <p>Efficient reconciliation with minimal DOM updates. Only changed parts are updated, similar to React's diffing algorithm.</p>
-              </div>
-              <div className="homepage-card">
-                <h3 style={{ marginTop: 0 }}>🌐 Framework Agnostic</h3>
-                <p>Core logic independent of UI frameworks. Use with React, Vue, or vanilla JavaScript. Render to any target you need.</p>
-              </div>
-            </div>
-          </div>
+function DemoSection() {
+  return (
+    <section className="demo-section">
+      <h2 className="section-title">Try It Out</h2>
+      <p className="section-subtitle">
+        Edit the text below to see the editor in action.
+      </p>
+      <EditorDemo />
+    </section>
+  );
+}
 
-          {/* Try It Out */}
-          <div style={{ marginBottom: '4rem' }}>
-            <h2 style={{ textAlign: 'center', marginBottom: '2rem', fontSize: '2.25rem', fontWeight: 700, letterSpacing: '-0.01em' }}>Try It Out</h2>
-            <p style={{ textAlign: 'center', color: '#666', marginBottom: '2rem' }}>
-              Edit the text below to see Barocss Editor in action. Try formatting with <strong>bold</strong> and <em>italic</em> text!
-            </p>
-            <EditorDemo />
-          </div>
+function CodeExampleSection() {
+  return (
+    <section className="code-section">
+      <h2 className="section-title">Simple Setup</h2>
+      <p className="section-subtitle">
+        Four steps to a working editor — schema, templates, store, and view.
+      </p>
+      <div className="code-steps">
+        <div className="code-step">
+          <div className="code-step-label">1 — Schema</div>
+          <CodeBlock language="typescript">
+            {`import { createSchema } from '@barocss/schema';
 
-          {/* Quick Start */}
-          <div style={{ marginBottom: '4rem' }} className="homepage-section">
-            <h2 style={{ marginTop: 0, fontSize: '2.25rem', fontWeight: 700, letterSpacing: '-0.01em' }}>Quick Start</h2>
-            <p style={{ fontSize: '1.1rem', marginBottom: '1.5rem' }}>
-              Get started with Barocss Editor in minutes. Install the core packages and create your first editor instance.
-            </p>
-            <div style={{ marginBottom: '1.5rem' }}>
-              <CodeBlock language="bash">
-                {`pnpm add @barocss/editor-core @barocss/editor-view-dom @barocss/schema`}
-              </CodeBlock>
-            </div>
-            <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
-              <Link
-                className="button button--primary button--lg"
-                to="/docs/getting-started">
-                Read Getting Started Guide
-              </Link>
-              <Link
-                className="button button--secondary button--lg"
-                to="/docs/examples/basic-editor">
-                View Examples
-              </Link>
-            </div>
-          </div>
-
-          {/* Code Example */}
-          <div style={{ marginBottom: '4rem' }}>
-            <h2 style={{ textAlign: 'center', marginBottom: '1rem', fontSize: '2.25rem', fontWeight: 700, letterSpacing: '-0.01em' }}>Simple Example</h2>
-            <p style={{ textAlign: 'center', marginBottom: '2rem', maxWidth: '800px', margin: '0 auto 2rem' }} className="homepage-text-secondary">
-              Here's a simple example showing how to create a basic editor with a paragraph node.
-            </p>
-            <div style={{ maxWidth: '900px', margin: '0 auto' }}>
-              <div style={{ marginBottom: '1.5rem' }}>
-                <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '0.75rem', color: 'var(--homepage-heading-color)' }}>1. Define Schema</h3>
-                <CodeBlock language="typescript">
-                  {`import { createSchema } from '@barocss/schema';
-
-const schema = createSchema('my-doc', {
+const schema = createSchema('doc', {
   topNode: 'document',
   nodes: {
-    document: { 
-      name: 'document', 
-      group: 'document', 
-      content: 'block+' 
-    },
-    paragraph: { 
-      name: 'paragraph', 
-      group: 'block', 
-      content: 'inline*' 
-    },
-    'inline-text': { 
-      name: 'inline-text', 
-      group: 'inline' 
-    }
-  }
+    document: { name: 'document', group: 'document', content: 'block+' },
+    paragraph: { name: 'paragraph', group: 'block', content: 'inline*' },
+    'inline-text': { name: 'inline-text', group: 'inline' },
+  },
 });`}
-                </CodeBlock>
-              </div>
-              
-              <div style={{ marginBottom: '1.5rem' }}>
-                <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '0.75rem', color: 'var(--homepage-heading-color)' }}>2. Define Templates</h3>
-                <CodeBlock language="typescript">
-                  {`import { define, element, data, slot } from '@barocss/dsl';
+          </CodeBlock>
+        </div>
+        <div className="code-step">
+          <div className="code-step-label">2 — Templates</div>
+          <CodeBlock language="typescript">
+            {`import { define, element, data, slot } from '@barocss/dsl';
 
-define('paragraph', element('p', {
-  className: 'paragraph'
-}, [slot('content')]));
-
-define('inline-text', element('span', {
-  className: 'text'
-}, [data('text', '')]));`}
-                </CodeBlock>
-              </div>
-              
-              <div style={{ marginBottom: '1.5rem' }}>
-                <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '0.75rem', color: 'var(--homepage-heading-color)' }}>3. Create DataStore</h3>
-                <CodeBlock language="typescript">
-                  {`import { DataStore } from '@barocss/datastore';
+define('paragraph', element('p', { className: 'paragraph' }, [slot('content')]));
+define('inline-text', element('span', {}, [data('text', '')]));`}
+          </CodeBlock>
+        </div>
+        <div className="code-step">
+          <div className="code-step-label">3 — DataStore</div>
+          <CodeBlock language="typescript">
+            {`import { DataStore } from '@barocss/datastore';
 
 const dataStore = new DataStore(undefined, schema);`}
-                </CodeBlock>
-              </div>
-              
-              <div style={{ marginBottom: '1.5rem' }}>
-                <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '0.75rem', color: 'var(--homepage-heading-color)' }}>4. Create Editor</h3>
-                <CodeBlock language="typescript">
-                  {`import { Editor } from '@barocss/editor-core';
+          </CodeBlock>
+        </div>
+        <div className="code-step">
+          <div className="code-step-label">4 — Editor</div>
+          <CodeBlock language="typescript">
+            {`import { Editor } from '@barocss/editor-core';
 import { EditorViewDOM } from '@barocss/editor-view-dom';
 import { createCoreExtensions } from '@barocss/extensions';
 
-const editor = new Editor({
-  dataStore,
-  schema,
-  extensions: createCoreExtensions()
-});
+const editor = new Editor({ dataStore, schema, extensions: createCoreExtensions() });
+new EditorViewDOM(editor, container).mount();`}
+          </CodeBlock>
+        </div>
+      </div>
+      <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+        <Link className="button button--secondary button--lg" to="/docs/quick-start">
+          Full Quick Start Guide
+        </Link>
+      </div>
+    </section>
+  );
+}
 
-const view = new EditorViewDOM(editor, container);
-view.mount();`}
-                </CodeBlock>
-              </div>
-            </div>
-            <div style={{ textAlign: 'center', marginTop: '2rem' }}>
-              <Link
-                className="button button--secondary button--lg"
-                to="/docs/examples/basic-editor">
-                View More Examples
-              </Link>
-            </div>
-          </div>
+function ArchitectureSection() {
+  return (
+    <section className="architecture-section">
+      <h2 className="section-title">Architecture</h2>
+      <p className="section-subtitle">
+        Model-first architecture with dual rendering targets. Same DSL templates power both DOM and React outputs.
+      </p>
+      <ArchitectureDiagram />
+      <div style={{ marginTop: '3rem' }}>
+        <h3 className="section-title" style={{ fontSize: '1.5rem' }}>Rendering Pipeline</h3>
+        <p className="section-subtitle">
+          Shared template layer fans out to DOM reconciliation or direct React element construction.
+        </p>
+        <RenderingPipelineDiagram />
+      </div>
+      <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+        <Link className="button button--secondary button--lg" to="/docs/architecture/overview">
+          Architecture Deep Dive
+        </Link>
+      </div>
+    </section>
+  );
+}
 
-          {/* Architecture Overview */}
-          <div style={{ marginBottom: '4rem' }}>
-            <h2 style={{ textAlign: 'center', marginBottom: '1rem', fontSize: '2.25rem', fontWeight: 700, letterSpacing: '-0.01em' }}>Architecture</h2>
-            <p style={{ textAlign: 'center', marginBottom: '2rem', maxWidth: '800px', margin: '0 auto 2rem' }} className="homepage-text-secondary">
-              Model-first architecture with declarative DSL. All operations work on the model, ensuring consistency and testability.
-            </p>
-            <ArchitectureDiagram />
-            
-            <div style={{ marginTop: '4rem' }}>
-              <h3 style={{ textAlign: 'center', marginBottom: '1.5rem', fontSize: '1.75rem', fontWeight: 600 }}>Rendering Pipeline</h3>
-              <p style={{ textAlign: 'center', marginBottom: '2rem', maxWidth: '800px', margin: '0 auto 2rem' }} className="homepage-text-secondary">
-                How data flows from Model to DOM through DSL templates and efficient reconciliation.
-              </p>
-              <RenderingPipelineDiagram />
-            </div>
-            
-            <div style={{ textAlign: 'center', marginTop: '2rem' }}>
-              <Link
-                className="button button--secondary button--lg"
-                to="/docs/architecture/overview">
-                Learn More About Architecture
-              </Link>
-            </div>
-          </div>
+const PACKAGES = [
+  { name: '@barocss/schema', desc: 'Document structure and validation' },
+  { name: '@barocss/datastore', desc: 'Transactional node store with overlay/COW' },
+  { name: '@barocss/model', desc: 'Operations, transactions, undo/redo' },
+  { name: '@barocss/dsl', desc: 'Declarative template builders' },
+  { name: '@barocss/renderer-dom', desc: 'VNode reconciliation to DOM' },
+  { name: '@barocss/renderer-react', desc: 'Direct React element output' },
+  { name: '@barocss/editor-core', desc: 'Commands, selection, extensions, history' },
+  { name: '@barocss/editor-view-dom', desc: 'DOM input, selection sync, decorators' },
+  { name: '@barocss/editor-view-react', desc: 'React view layer with hooks' },
+  { name: '@barocss/extensions', desc: '30+ built-in extensions' },
+  { name: '@barocss/collaboration', desc: 'CRDT/OT base adapter' },
+  { name: '@barocss/converter', desc: 'HTML/Markdown/LaTeX/PDF conversion' },
+] as const;
 
-          {/* Documentation Links */}
-          <div style={{ marginTop: '4rem', paddingTop: '3rem', borderTop: '2px solid var(--homepage-border-color)' }}>
-            <h2 style={{ textAlign: 'center', marginBottom: '2rem', fontSize: '2.25rem', fontWeight: 700, letterSpacing: '-0.01em' }}>Documentation</h2>
-            <div className="doc-links">
-              <Link to="/docs/getting-started" className="doc-link">
-                <span className="doc-link-title">🚀 Getting Started</span>
-                <span className="doc-link-desc">Learn the basics of Barocss Editor and create your first editor instance</span>
-              </Link>
-              <Link to="/docs/guides/extension-design" className="doc-link">
-                <span className="doc-link-title">🔌 Extension Design</span>
-                <span className="doc-link-desc">Create custom extensions to add new commands and functionality</span>
-              </Link>
-              <Link to="/docs/guides/decorator-guide" className="doc-link">
-                <span className="doc-link-title">🎨 Decorator Guide</span>
-                <span className="doc-link-desc">Add temporary UI elements like highlights, comments, and selection indicators</span>
-              </Link>
-              <Link to="/docs/architecture/overview" className="doc-link">
-                <span className="doc-link-title">🏗️ Architecture</span>
-                <span className="doc-link-desc">Understand how packages are structured and how they connect together</span>
-              </Link>
-              <Link to="/docs/architecture/packages" className="doc-link">
-                <span className="doc-link-title">📦 Package Structure</span>
-                <span className="doc-link-desc">Learn about each package's role and how to extend the editor</span>
-              </Link>
-              <Link to="/docs/api/reference" className="doc-link">
-                <span className="doc-link-title">📚 API Reference</span>
-                <span className="doc-link-desc">Complete API documentation for all packages and their exports</span>
-              </Link>
-            </div>
+function PackagesSection() {
+  return (
+    <section className="packages-section">
+      <h2 className="section-title">Packages</h2>
+      <p className="section-subtitle">Modular monorepo — use only what you need.</p>
+      <div className="package-list">
+        {PACKAGES.map((p) => (
+          <div key={p.name} className="package-item">
+            <span className="package-name">{p.name}</span>
+            <span className="package-description">{p.desc}</span>
           </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const DOC_LINKS = [
+  { to: '/docs/introduction', title: 'Introduction', desc: 'Why Barocss Editor and how it differs from other editors' },
+  { to: '/docs/installation', title: 'Installation', desc: 'Install core and optional packages with your package manager' },
+  { to: '/docs/quick-start', title: 'Quick Start', desc: 'End-to-end example: schema to a working editor in 5 minutes' },
+  { to: '/docs/concepts/rendering', title: 'Rendering', desc: 'How DSL templates become DOM and React elements' },
+  { to: '/docs/guides/extension-design', title: 'Extension Design', desc: 'Create commands, keybindings, and decorators' },
+  { to: '/docs/api/reference', title: 'API Reference', desc: 'Complete API docs for every package' },
+] as const;
+
+function DocsLinksSection() {
+  return (
+    <section className="docs-links-section">
+      <h2 className="section-title">Documentation</h2>
+      <div className="doc-links">
+        {DOC_LINKS.map((d) => (
+          <Link key={d.to} to={d.to} className="doc-link">
+            <span className="doc-link-title">{d.title}</span>
+            <span className="doc-link-desc">{d.desc}</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function Home(): JSX.Element {
+  return (
+    <Layout title="Barocss Editor" description="A powerful document editor with DSL-based rendering">
+      <main className="homepage">
+        <div className="homepage-container">
+          <HeroSection />
+          <FeaturesSection />
+          <DemoSection />
+          <CodeExampleSection />
+          <ArchitectureSection />
+          <PackagesSection />
+          <DocsLinksSection />
         </div>
       </main>
     </Layout>


### PR DESCRIPTION
## Summary
- Redesign homepage with professional layout (hero badge, gradient title, structured sections)
- Update architecture diagram to include renderer-react, editor-view-react, extensions, collaboration, converter
- Update rendering pipeline to show dual paths (DOM + React)
- Fix broken links (/docs/getting-started → /docs/introduction)
- Update architecture/overview.md with React rendering path and full package map

Closes #236

## Test plan
- [x] pnpm build on docs-site passes
- [ ] Verify homepage renders correctly
- [ ] Verify architecture diagrams render
- [ ] Verify links work

Made with [Cursor](https://cursor.com)