### PR TITLE
fix: footer text invisible due to background color override

### DIFF
--- a/apps/docs-site/src/css/custom.css
+++ b/apps/docs-site/src/css/custom.css
@@ -66,7 +66,17 @@ html[data-theme='light'] body { background-color: #ffffff; color: #1e293b; }
 /* ────────────── Navbar / Footer ────────────── */
 
 .navbar { box-shadow: 0 1px 0 rgba(15, 23, 42, 0.06); }
-.footer { background-color: var(--ifm-background-surface-color); border-top: 1px solid var(--ifm-color-emphasis-200); }
+
+.footer--dark {
+  --ifm-footer-background-color: #0f172a;
+  --ifm-footer-color: #cbd5e1;
+  --ifm-footer-link-color: #e2e8f0;
+  --ifm-footer-title-color: #f1f5f9;
+}
+
+.footer--dark .footer__link-item:hover {
+  color: #ffffff;
+}
 
 .menu__link--sublist-caret::after { transform: scale(0.75) rotateZ(0deg); }
 .menu__list-item--collapsed .menu__link--sublist-caret::after { transform: scale(0.75) rotateZ(90deg); }


### PR DESCRIPTION
## Summary
- `.footer` CSS override was setting background to white while Docusaurus dark footer uses white text → text invisible
- Replace with explicit `--ifm-footer-*` variables on `.footer--dark` (navy `#0f172a` background, slate text)

Closes #238

## Test plan
- [x] `pnpm build` passes
- [ ] Footer text visible in both light and dark modes

Made with [Cursor](https://cursor.com)