### PR TITLE
fix: clipboard paste pipeline and drag-drop reorder payload bugs

### DIFF
--- a/packages/editor-view-dom/src/editor-view-dom.ts
+++ b/packages/editor-view-dom/src/editor-view-dom.ts
@@ -497,21 +497,24 @@ export class EditorViewDOM implements IEditorViewDOM {
   }
 
   handlePaste(event: ClipboardEvent): void {
-    // Do not intercept paste during IME composition
-    // Leave paste within composition string to IME/browser
     if (this._isComposing) {
       return;
     }
 
     event.preventDefault();
-    
+
     const clipboardData = event.clipboardData;
     if (!clipboardData) return;
 
+    const html = clipboardData.getData('text/html');
     const text = clipboardData.getData('text/plain');
-    if (text) {
-      this.insertText(text);
-    }
+
+    if (!html && !text) return;
+
+    this.editor.executeCommand('paste', {
+      clipboardHtml: html || undefined,
+      clipboardText: text || undefined,
+    });
   }
 
   handleDrop(event: DragEvent): void {

--- a/packages/extensions/src/copy-paste.ts
+++ b/packages/extensions/src/copy-paste.ts
@@ -73,7 +73,12 @@ export class CopyPasteExtension implements Extension {
     // paste
     editor.registerCommand({
       name: 'paste',
-      execute: async (ed: any, payload?: { selection?: ModelSelection; nodes?: INode[] }) => {
+      execute: async (ed: any, payload?: {
+        selection?: ModelSelection;
+        nodes?: INode[];
+        clipboardHtml?: string;
+        clipboardText?: string;
+      }) => {
         let selection = payload?.selection || ed.selection;
         if (!selection || selection.type !== 'range') {
           return false;
@@ -81,39 +86,44 @@ export class CopyPasteExtension implements Extension {
 
         let nodes: INode[] | undefined = payload?.nodes;
 
-        // Read from Clipboard if nodes are not provided in payload
+        // Resolve clipboard data: prefer inline payload from DOM event, then fall back to Clipboard API
         if (!nodes || nodes.length === 0) {
-          const clip = await this._readClipboard();
-          // 1) Internal JSON format (assume result from application/x-barocss, etc.)
-          if (clip.json && Array.isArray(clip.json)) {
-            nodes = clip.json;
+          let clipHtml = payload?.clipboardHtml;
+          let clipText = payload?.clipboardText;
+
+          if (!clipHtml && !clipText) {
+            const clip = await this._readClipboard();
+            clipHtml = clip.html;
+            clipText = clip.text;
+            if (clip.json && Array.isArray(clip.json)) {
+              nodes = clip.json;
+            }
           }
-          // 2) HTML format: distinguish Office / Google Docs / Notion / general HTML
-          if ((!nodes || nodes.length === 0) && clip.html && this._htmlConverter) {
+
+          // 1) HTML format: distinguish Office / Google Docs / Notion / general HTML
+          if ((!nodes || nodes.length === 0) && clipHtml && this._htmlConverter) {
             try {
-              const source = this._detectHtmlSource(clip.html);
-              let htmlForParse = clip.html;
+              const source = this._detectHtmlSource(clipHtml);
+              let htmlForParse = clipHtml;
               if (source === 'office') {
                 htmlForParse = cleanOfficeHTML(htmlForParse);
               }
-              // Google Docs / Notion have registerGoogleDocsHTMLRules / registerNotionHTMLRules
-              // already called in onCreate, so just pass HTML here
               nodes = this._htmlConverter.parse(htmlForParse, 'html') as INode[];
             } catch {
               // fallback to text
             }
           }
-          // 3) text/plain: branch based on heuristic check for markdown
-          if ((!nodes || nodes.length === 0) && clip.text) {
-            if (this._looksLikeMarkdown(clip.text)) {
+          // 2) text/plain: branch based on heuristic check for markdown
+          if ((!nodes || nodes.length === 0) && clipText) {
+            if (this._looksLikeMarkdown(clipText)) {
               try {
                 const md = new MarkdownConverter();
-                nodes = md.parse(clip.text, 'markdown-gfm') as INode[];
+                nodes = md.parse(clipText, 'markdown-gfm') as INode[];
               } catch {
-                nodes = this._textToNodes(clip.text);
+                nodes = this._textToNodes(clipText);
               }
             } else {
-              nodes = this._textToNodes(clip.text);
+              nodes = this._textToNodes(clipText);
             }
           }
         }
@@ -128,8 +138,7 @@ export class CopyPasteExtension implements Extension {
       },
       canExecute: (ed: any, payload?: any) => {
         const selection: ModelSelection | undefined = payload?.selection || ed.selection;
-        const nodes: any[] | undefined = payload?.nodes;
-        return !!selection && selection.type === 'range' && Array.isArray(nodes) && nodes.length > 0;
+        return !!selection && selection.type === 'range';
       }
     });
 
@@ -187,31 +196,60 @@ export class CopyPasteExtension implements Extension {
     return nodes;
   }
 
-  // Provides a hook that can be replaced by tests/callers instead of actual browser Clipboard API.
-  // Default implementation only writes text using navigator.clipboard.writeText if in browser environment.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected async _writeClipboard(data: ClipboardLike): Promise<void> {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+
     try {
-      if (typeof navigator !== 'undefined' && (navigator as any).clipboard?.writeText && data.text) {
-        await (navigator as any).clipboard.writeText(data.text);
+      // Prefer ClipboardItem API to write both text/plain and text/html
+      if (typeof ClipboardItem !== 'undefined' && navigator.clipboard.write) {
+        const items: Record<string, Blob> = {};
+        if (data.text) {
+          items['text/plain'] = new Blob([data.text], { type: 'text/plain' });
+        }
+        if (data.html) {
+          items['text/html'] = new Blob([data.html], { type: 'text/html' });
+        }
+        if (Object.keys(items).length > 0) {
+          await navigator.clipboard.write([new ClipboardItem(items)]);
+          return;
+        }
+      }
+      // Fallback: write text only
+      if (data.text && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(data.text);
       }
     } catch {
-      // ignore clipboard errors
+      // ignore clipboard errors — permission denied, etc.
     }
   }
 
-  /**
-   * Reads data from Clipboard.
-   * Default implementation only supports text-based.
-   */
   protected async _readClipboard(): Promise<ClipboardLike> {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return {};
+
     try {
-      if (typeof navigator !== 'undefined' && (navigator as any).clipboard?.readText) {
-        const text = await (navigator as any).clipboard.readText();
+      // Prefer ClipboardItem API to read both text/plain and text/html
+      if (typeof ClipboardItem !== 'undefined' && navigator.clipboard.read) {
+        const items = await navigator.clipboard.read();
+        const result: ClipboardLike = {};
+        for (const item of items) {
+          if (item.types.includes('text/html')) {
+            const blob = await item.getType('text/html');
+            result.html = await blob.text();
+          }
+          if (item.types.includes('text/plain')) {
+            const blob = await item.getType('text/plain');
+            result.text = await blob.text();
+          }
+        }
+        if (result.html || result.text) return result;
+      }
+      // Fallback: read text only
+      if (navigator.clipboard.readText) {
+        const text = await navigator.clipboard.readText();
         return { text };
       }
     } catch {
-      // ignore
+      // ignore — permission denied, etc.
     }
     return {};
   }

--- a/packages/extensions/src/drag-drop.ts
+++ b/packages/extensions/src/drag-drop.ts
@@ -1,5 +1,5 @@
 import { Editor, Extension } from '@barocss/editor-core';
-import { transaction, control } from '@barocss/model';
+import { transaction, reorderChildren } from '@barocss/model';
 
 export interface DragDropExtensionOptions {
   enabled?: boolean;
@@ -65,12 +65,20 @@ export class DragDropExtension implements Extension {
       if (this._dragState) {
         e.preventDefault();
         this._onDragMove(e.clientY);
+        this._autoScroll(e.clientY);
       }
     });
 
     document.addEventListener('mouseup', () => {
       if (this._dragState) {
         this._endDrag(editor);
+      }
+    });
+
+    document.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && this._dragState) {
+        e.preventDefault();
+        this._cleanupDrag();
       }
     });
   }
@@ -169,14 +177,28 @@ export class DragDropExtension implements Extension {
     const currentIndex = parent.content.indexOf(blockId);
     if (currentIndex === -1 || currentIndex === targetIndex) return false;
 
-    const ops = [
-      ...control(node.parentId, [
-        { type: 'reorderChildren', payload: { childId: blockId, newIndex: targetIndex } } as any
-      ])
-    ];
+    const newOrder = [...parent.content];
+    newOrder.splice(currentIndex, 1);
+    const insertAt = Math.min(targetIndex, newOrder.length);
+    newOrder.splice(insertAt, 0, blockId);
 
-    const result = await transaction(editor, ops).commit();
+    const result = await transaction(editor, [reorderChildren(node.parentId, newOrder) as any]).commit();
     return result.success;
+  }
+
+  private _autoScroll(clientY: number): void {
+    const container = this._getContentContainer();
+    if (!container) return;
+
+    const rect = container.getBoundingClientRect();
+    const threshold = 40;
+    const speed = 8;
+
+    if (clientY < rect.top + threshold) {
+      container.scrollTop -= speed;
+    } else if (clientY > rect.bottom - threshold) {
+      container.scrollTop += speed;
+    }
   }
 
   private _getContentContainer(): HTMLElement | null {

--- a/packages/extensions/test/copy-paste-extension.test.ts
+++ b/packages/extensions/test/copy-paste-extension.test.ts
@@ -119,6 +119,60 @@ describe('CopyPasteExtension', () => {
     });
   });
 
+  it('paste: clipboardText 로 전달받은 텍스트를 paragraph 노드로 변환하여 paste 한다', async () => {
+    const editor = new FakeEditor() as any;
+    const ext = new CopyPasteExtension();
+    ext.onCreate(editor);
+
+    const cmd = editor.__getCommand('paste');
+    expect(cmd).toBeDefined();
+
+    const selection: ModelSelection = {
+      type: 'range',
+      startNodeId: 'p1',
+      startOffset: 0,
+      endNodeId: 'p1',
+      endOffset: 0,
+      collapsed: true,
+      direction: 'forward'
+    };
+
+    editor.selection = selection;
+
+    const result = await cmd!.execute(editor, { clipboardText: 'Hello World' });
+    expect(result).toBe(true);
+    expect(recordedTransactions).toHaveLength(1);
+    expect(commitMock).toHaveBeenCalledTimes(1);
+
+    const ops = recordedTransactions[0];
+    expect(ops).toHaveLength(1);
+    expect(ops[0].type).toBe('paste');
+    const pastedNodes = ops[0].payload.data.nodes;
+    expect(pastedNodes).toHaveLength(1);
+    expect(pastedNodes[0].stype).toBe('paragraph');
+    expect(pastedNodes[0].content[0].text).toBe('Hello World');
+  });
+
+  it('paste: canExecute 는 range selection 만 있으면 true (nodes 불필요)', () => {
+    const editor = new FakeEditor() as any;
+    const ext = new CopyPasteExtension();
+    ext.onCreate(editor);
+
+    const cmd = editor.__getCommand('paste');
+    const selection: ModelSelection = {
+      type: 'range',
+      startNodeId: 'p1',
+      startOffset: 0,
+      endNodeId: 'p1',
+      endOffset: 0,
+      collapsed: true,
+      direction: 'forward'
+    };
+
+    expect(cmd!.canExecute(editor, { selection })).toBe(true);
+    expect(cmd!.canExecute(editor, {})).toBe(false);
+  });
+
   it('cut: non-collapsed range selection 이 있으면 cut operation 으로 transaction 을 실행한다', async () => {
     const editor = new FakeEditor() as any;
     const ext = new CopyPasteExtension();

--- a/packages/extensions/test/drag-drop-extension.test.ts
+++ b/packages/extensions/test/drag-drop-extension.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DragDropExtension } from '../src/drag-drop';
+
+const recordedTransactions: any[][] = [];
+const commitMock = vi.fn();
+
+vi.mock('@barocss/model', () => {
+  return {
+    transaction: (_editor: any, operations: any[]) => {
+      recordedTransactions.push(operations);
+      return { commit: commitMock };
+    },
+    reorderChildren: (parentId: string, childIds: string[]) => ({
+      type: 'reorderChildren',
+      payload: { parentId, childIds }
+    })
+  };
+});
+
+function createFakeEditor(nodes: Record<string, any>) {
+  const commands = new Map<string, any>();
+  return {
+    dataStore: {
+      getNode: (id: string) => nodes[id] || null,
+    },
+    registerCommand(cmd: any) {
+      commands.set(cmd.name, cmd);
+    },
+    __getCommand(name: string) {
+      return commands.get(name);
+    }
+  };
+}
+
+describe('DragDropExtension', () => {
+  beforeEach(() => {
+    recordedTransactions.length = 0;
+    commitMock.mockReset();
+    commitMock.mockResolvedValue({ success: true });
+  });
+
+  it('moveBlockToPosition: reorderChildren 에 올바른 childIds 배열을 전달한다', async () => {
+    const nodes: Record<string, any> = {
+      root: { sid: 'root', parentId: null, content: ['a', 'b', 'c', 'd'] },
+      a: { sid: 'a', parentId: 'root' },
+      b: { sid: 'b', parentId: 'root' },
+      c: { sid: 'c', parentId: 'root' },
+      d: { sid: 'd', parentId: 'root' },
+    };
+
+    const editor = createFakeEditor(nodes);
+    const ext = new DragDropExtension();
+    (ext as any)._getContentContainer = () => null;
+    ext.onCreate(editor as any);
+
+    const cmd = editor.__getCommand('moveBlockToPosition');
+    expect(cmd).toBeDefined();
+
+    // Move 'c' (index 2) to index 0 → expected order: [c, a, b, d]
+    const result = await cmd!.execute(editor, { blockId: 'c', targetIndex: 0 });
+    expect(result).toBe(true);
+    expect(recordedTransactions).toHaveLength(1);
+
+    const op = recordedTransactions[0][0];
+    expect(op.type).toBe('reorderChildren');
+    expect(op.payload.parentId).toBe('root');
+    expect(op.payload.childIds).toEqual(['c', 'a', 'b', 'd']);
+  });
+
+  it('moveBlockToPosition: 같은 위치 이동은 no-op', async () => {
+    const nodes: Record<string, any> = {
+      root: { sid: 'root', parentId: null, content: ['a', 'b', 'c'] },
+      a: { sid: 'a', parentId: 'root' },
+      b: { sid: 'b', parentId: 'root' },
+      c: { sid: 'c', parentId: 'root' },
+    };
+
+    const editor = createFakeEditor(nodes);
+    const ext = new DragDropExtension();
+    (ext as any)._getContentContainer = () => null;
+    ext.onCreate(editor as any);
+
+    const cmd = editor.__getCommand('moveBlockToPosition');
+    const result = await cmd!.execute(editor, { blockId: 'b', targetIndex: 1 });
+    expect(result).toBe(false);
+    expect(recordedTransactions).toHaveLength(0);
+  });
+
+  it('moveBlockToPosition: 존재하지 않는 블록은 false 반환', async () => {
+    const nodes: Record<string, any> = {
+      root: { sid: 'root', parentId: null, content: ['a'] },
+      a: { sid: 'a', parentId: 'root' },
+    };
+
+    const editor = createFakeEditor(nodes);
+    const ext = new DragDropExtension();
+    (ext as any)._getContentContainer = () => null;
+    ext.onCreate(editor as any);
+
+    const cmd = editor.__getCommand('moveBlockToPosition');
+    const result = await cmd!.execute(editor, { blockId: 'nonexistent', targetIndex: 0 });
+    expect(result).toBe(false);
+  });
+
+  it('moveBlockToPosition: 마지막 위치로 이동', async () => {
+    const nodes: Record<string, any> = {
+      root: { sid: 'root', parentId: null, content: ['a', 'b', 'c'] },
+      a: { sid: 'a', parentId: 'root' },
+      b: { sid: 'b', parentId: 'root' },
+      c: { sid: 'c', parentId: 'root' },
+    };
+
+    const editor = createFakeEditor(nodes);
+    const ext = new DragDropExtension();
+    (ext as any)._getContentContainer = () => null;
+    ext.onCreate(editor as any);
+
+    const cmd = editor.__getCommand('moveBlockToPosition');
+    // Move 'a' (index 0) to index 2 → expected: [b, c, a]
+    const result = await cmd!.execute(editor, { blockId: 'a', targetIndex: 2 });
+    expect(result).toBe(true);
+
+    const op = recordedTransactions[0][0];
+    expect(op.payload.childIds).toEqual(['b', 'c', 'a']);
+  });
+
+  it('moveBlockToPosition: targetIndex 가 범위를 초과하면 끝에 배치', async () => {
+    const nodes: Record<string, any> = {
+      root: { sid: 'root', parentId: null, content: ['a', 'b', 'c'] },
+      a: { sid: 'a', parentId: 'root' },
+      b: { sid: 'b', parentId: 'root' },
+      c: { sid: 'c', parentId: 'root' },
+    };
+
+    const editor = createFakeEditor(nodes);
+    const ext = new DragDropExtension();
+    (ext as any)._getContentContainer = () => null;
+    ext.onCreate(editor as any);
+
+    const cmd = editor.__getCommand('moveBlockToPosition');
+    // Move 'a' (index 0) to index 99 → clamped to end: [b, c, a]
+    const result = await cmd!.execute(editor, { blockId: 'a', targetIndex: 99 });
+    expect(result).toBe(true);
+
+    const op = recordedTransactions[0][0];
+    expect(op.payload.childIds).toEqual(['b', 'c', 'a']);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes critical bugs in clipboard and drag-drop subsystems discovered during code audit.

- **Clipboard paste**: `EditorViewDOM.handlePaste()` was calling `insertText()` directly, bypassing `CopyPasteExtension`'s rich HTML/Markdown/Office/Google Docs/Notion parsing. Now properly forwards HTML+text via `executeCommand('paste')`.
- **Clipboard write/read**: Upgraded from `writeText()`/`readText()` to `ClipboardItem` API, enabling HTML format on copy/cut/paste round-trip.
- **paste canExecute**: Relaxed guard to only require range selection (nodes resolved at execution time from clipboard data).
- **DragDrop reorder**: Fixed critical payload bug — `_moveBlock()` was sending `{ childId, newIndex }` but `reorderChildren` expects `{ parentId, childIds: string[] }`. Now builds correct reordered array.
- **DragDrop UX**: Added ESC key handler to cancel drag, and auto-scroll near container edges.

## Test plan
- [x] All 93 extension tests pass (including 5 new tests)
- [x] All 407 model tests pass
- [x] All 765 datastore tests pass
- [x] reorderChildren operation test passes (4 tests)
- [x] TypeScript compilation clean on editor-view-dom and extensions
- [x] New `drag-drop-extension.test.ts` covers: reorder correctness, no-op same-index, nonexistent block, last-position, overflow-index clamping
- [x] New copy-paste tests cover: clipboardText passthrough, canExecute without nodes

Closes #244


Made with [Cursor](https://cursor.com)