### PR TITLE
docs: update docs-site for full extension coverage, fix API errors, add React guide

### DIFF
--- a/apps/docs-site/docs/api/extensions-api.md
+++ b/apps/docs-site/docs/api/extensions-api.md
@@ -119,12 +119,12 @@ editor.use(extension);
 
 ### UnderlineExtension
 
-Provides underline formatting functionality.
+Provides underline formatting functionality. Supports cross-node selections.
 
 **Location**: `packages/extensions/src/underline.ts`
 
 **Commands:**
-- `toggleUnderline` - Toggles underline formatting
+- `toggleUnderline` - Toggles underline formatting (works across multiple nodes)
 
 **Example:**
 ```typescript
@@ -136,12 +136,12 @@ editor.use(extension);
 
 ### StrikethroughExtension
 
-Provides strikethrough formatting functionality.
+Provides strikethrough formatting functionality. Supports cross-node selections.
 
 **Location**: `packages/extensions/src/strikethrough.ts`
 
 **Commands:**
-- `toggleStrikethrough` - Toggles strikethrough formatting
+- `toggleStrikethrough` - Toggles strikethrough formatting (works across multiple nodes)
 
 **Example:**
 ```typescript
@@ -153,7 +153,7 @@ editor.use(extension);
 
 ### HeadingExtension
 
-Provides heading functionality.
+Provides heading functionality. The `removeHeading` command correctly transforms a heading back to a paragraph using `transformNode` within a transaction (supports undo/redo).
 
 **Location**: `packages/extensions/src/heading.ts`
 
@@ -167,6 +167,7 @@ interface HeadingExtensionOptions {
 
 **Commands:**
 - `setHeading` - Sets heading level
+- `removeHeading` - Converts heading to paragraph (via `transformNode('paragraph')`)
 - `toggleHeading` - Toggles heading on/off
 
 **Keybindings:**
@@ -182,6 +183,42 @@ interface HeadingExtensionOptions {
 import { HeadingExtension, createHeadingExtension } from '@barocss/extensions';
 
 const extension = createHeadingExtension({ levels: [1, 2, 3] });
+editor.use(extension);
+```
+
+### ListExtension
+
+Provides bullet list and ordered list functionality.
+
+**Location**: `packages/extensions/src/list.ts`
+
+**Commands:**
+- `toggleBulletList` - Toggles unordered (bullet) list
+- `toggleOrderedList` - Toggles ordered (numbered) list
+- `splitListItem` - Splits list item at cursor (Enter key behavior in lists)
+
+**Example:**
+```typescript
+import { ListExtension } from '@barocss/extensions';
+
+const extension = new ListExtension();
+editor.use(extension);
+```
+
+### BlockquoteExtension
+
+Provides blockquote functionality.
+
+**Location**: `packages/extensions/src/blockquote.ts`
+
+**Commands:**
+- `toggleBlockquote` - Toggles blockquote on/off
+
+**Example:**
+```typescript
+import { BlockquoteExtension } from '@barocss/extensions';
+
+const extension = new BlockquoteExtension();
 editor.use(extension);
 ```
 
@@ -370,6 +407,7 @@ Creates core extensions (required extensions that are always included by default
 - `SelectAllExtension` - Select all
 - `IndentExtension` - Structural indentation
 - `CopyPasteExtension` - Clipboard operations
+- `HardBreakExtension` - Line break (Shift+Enter)
 
 **Note**: Core extensions are automatically registered in Editor constructor, so they are excluded from other extension sets.
 
@@ -392,6 +430,8 @@ Creates basic extensions (formatting extensions).
 - `BoldExtension` - Bold formatting
 - `ItalicExtension` - Italic formatting
 - `HeadingExtension` - Heading support
+- `ListExtension` - Bullet/ordered list support
+- `BlockquoteExtension` - Blockquote support
 
 **Note**: Core extensions are automatically registered, so they are excluded.
 
@@ -431,16 +471,12 @@ editor.use(...extensions);
 
 #### `ExtensionSets.rich()`
 
-Rich text editing extensions (Bold, Italic, Underline, Heading).
+Full rich text editing extensions (all formatting, rich content, marks, document structure).
 
 **Returns:**
 - `Extension[]` - Array of extensions
 
-**Includes:**
-- `BoldExtension`
-- `ItalicExtension`
-- `UnderlineExtension`
-- `HeadingExtension`
+**Includes all `createRichExtensions()`** — see the [full list](#createrichextensions-extension) above.
 
 **Example:**
 ```typescript
@@ -610,85 +646,238 @@ const editor = new Editor({
 
 Provides link insertion and editing functionality.
 
-**Location**: `packages/extensions/src/link.ts`
-
-**Commands:**
-- `insertLink` - Inserts a link
-- `removeLink` - Removes a link
+**Commands:** `insertLink`, `removeLink`
 
 ### ImageExtension
 
 Provides image insertion functionality.
 
-**Location**: `packages/extensions/src/image.ts`
-
-**Commands:**
-- `insertImage` - Inserts an image
+**Commands:** `insertImage`
 
 ### CodeBlockExtension
 
 Provides code block functionality.
 
-**Location**: `packages/extensions/src/code-block.ts`
-
-**Commands:**
-- `insertCodeBlock` - Inserts a code block
-- `toggleCodeBlock` - Toggles code block
+**Commands:** `insertCodeBlock`, `toggleCodeBlock`
 
 ### HorizontalRuleExtension
 
 Provides horizontal rule insertion.
 
-**Location**: `packages/extensions/src/horizontal-rule.ts`
-
-**Commands:**
-- `insertHorizontalRule` - Inserts a horizontal rule
+**Commands:** `insertHorizontalRule`
 
 ### TableExtension
 
-Provides table creation and editing.
+Provides table creation and editing (bTable, bTableRow, bTableCell, etc.).
 
-**Location**: `packages/extensions/src/table.ts`
-
-**Commands:**
-- `insertTable` - Inserts a table
+**Commands:** `insertTable`
 
 ### CalloutExtension
 
-Provides callout/admonition blocks.
+Provides callout/admonition blocks (info, warning, error, success, note, tip).
 
-**Location**: `packages/extensions/src/callout.ts`
-
-**Commands:**
-- `insertCallout` - Inserts a callout block
+**Commands:** `insertCallout`
 
 ### ChecklistExtension
 
-Provides checklist/task list functionality.
+Provides checklist/task list functionality. Uses transactions for undo/redo support.
 
-**Location**: `packages/extensions/src/checklist.ts`
-
-**Commands:**
-- `insertChecklist` - Inserts a checklist
-- `toggleChecklistItem` - Toggles a checklist item
+**Commands:** `insertChecklist`, `toggleChecklistItem`
 
 ### MathBlockExtension
 
-Provides math equation blocks (KaTeX/MathJax).
+Provides math equation blocks (KaTeX).
 
-**Location**: `packages/extensions/src/math-block.ts`
-
-**Commands:**
-- `insertMathBlock` - Inserts a math block
+**Commands:** `insertMathBlock`
 
 ### CommentExtension
 
-Provides comment/annotation functionality.
+Provides comment/annotation functionality (commentThread).
 
-**Location**: `packages/extensions/src/comment.ts`
+**Commands:** `insertComment`
+
+### HardBreakExtension
+
+Provides line break within a block (Shift+Enter).
+
+**Commands:** `insertHardBreak`
+
+### PageBreakExtension
+
+Provides page break insertion (atom block).
+
+**Commands:** `insertPageBreak`
+
+### MathInlineExtension
+
+Provides inline math equation insertion (KaTeX).
+
+**Commands:** `insertMathInline` — payload: `{ tex?: string }`
+
+### PullQuoteExtension
+
+Provides pull quote blocks (distinct from blockquote).
+
+**Commands:** `insertPullQuote` — payload: `{ text?: string }`
+
+### ColumnsExtension
+
+Provides multi-column layout (columns/column nodes).
 
 **Commands:**
-- `insertComment` - Inserts a comment
+- `insertColumns` — payload: `{ count?: number }` (default: 2)
+- `addColumn` — payload: `{ columnsId: string }`
+- `removeColumn` — payload: `{ columnsId: string, columnId: string }`
+
+### TocExtension
+
+Provides table of contents insertion (atom block).
+
+**Commands:** `insertToc`
+
+### DetailsExtension
+
+Provides collapsible content blocks (bDetails/bSummary).
+
+**Commands:** `insertDetails` — payload: `{ summary?: string }`
+
+### DescriptionListExtension
+
+Provides description list blocks (descList/descTerm/descDef).
+
+**Commands:**
+- `insertDescriptionList`
+- `addDescriptionItem` — payload: `{ descListId: string }`
+
+### FigureExtension
+
+Provides figure with caption (bFigure/bFigcaption).
+
+**Commands:**
+- `insertFigure` — payload: `{ src?: string, alt?: string, caption?: string }`
+- `setFigcaption` — payload: `{ figureId: string, caption?: string }`
+
+### MediaExtension
+
+Provides video, audio, and embed insertion.
+
+**Commands:**
+- `insertVideo` — payload: `{ src: string, poster?: string }`
+- `insertAudio` — payload: `{ src: string }`
+- `insertEmbed` — payload: `{ provider: string, id: string, title?: string }`
+
+## Mark Extensions
+
+### CodeMarkExtension
+
+Provides inline code mark (Ctrl+E).
+
+**Commands:** `toggleCode`
+
+### HighlightExtension
+
+Provides text highlight mark with configurable color.
+
+**Commands:** `toggleHighlight` — payload: `{ color?: string }` (default: `#ffeb3b`)
+
+### FontColorExtension
+
+Provides text color and background color marks.
+
+**Commands:**
+- `setFontColor` — payload: `{ color: string }`
+- `removeFontColor`
+- `setBgColor` — payload: `{ color: string }`
+- `removeBgColor`
+
+### SubSuperExtension
+
+Provides subscript and superscript marks.
+
+**Commands:** `toggleSubscript`, `toggleSuperscript`
+
+### FontSizeExtension
+
+Provides font size mark.
+
+**Commands:**
+- `setFontSize` — payload: `{ size: string }` (e.g. `'18px'`)
+- `removeFontSize`
+
+### FontFamilyExtension
+
+Provides font family mark.
+
+**Commands:**
+- `setFontFamily` — payload: `{ family: string }` (e.g. `'Georgia'`)
+- `removeFontFamily`
+
+### TextFormattingExtension
+
+Aggregates less-common text-style marks into one extension.
+
+**Toggle commands** (no additional payload needed):
+- `toggleSmallCaps` — smallCaps mark
+- `toggleKbd` — kbd mark (keyboard key)
+- `toggleSpoiler` — spoiler mark
+
+**Apply commands** (require `value` in payload):
+- `setLetterSpacing` — letterSpacing mark (`{ value: '0.2em' }`)
+- `setWordSpacing` — wordSpacing mark
+- `setLineHeight` — lineHeight mark
+- `setTextShadow` — textShadow mark
+
+**Multi-attr commands** (require `attrs` in payload):
+- `setBorder` — border mark (`{ attrs: { style, width, color } }`)
+- `setSpanLang` — spanLang mark (`{ attrs: { lang, dir } }`)
+
+### MentionExtension
+
+Provides @mention mark.
+
+**Commands:** `insertMention` — payload: `{ id: string }`
+
+### FootnoteExtension
+
+Provides footnote definition (footnoteDef) and reference (footnoteRef mark).
+
+**Commands:**
+- `insertFootnote` — payload: `{ id: string, text?: string }` (creates both def + ref)
+- `insertFootnoteRef` — payload: `{ id: string }` (ref only)
+
+## Inline Atom Extensions
+
+### BookmarkExtension
+
+Provides bookmark anchor insertion.
+
+**Commands:** `insertBookmark` — payload: `{ id: string }`
+
+### FieldExtension
+
+Provides document field insertions (page number, date, title, etc.).
+
+**Commands:**
+- `insertFieldPageNumber`
+- `insertFieldPageCount`
+- `insertFieldDateTime` — payload: `{ format?: string }`
+- `insertFieldDocTitle`
+- `insertFieldAuthor`
+
+## Document Structure Extension
+
+### DocStructureExtension
+
+Aggregates document-level structural blocks.
+
+**Commands:**
+- `insertDocSection` — document section
+- `insertDocHeader` — document header
+- `insertDocFooter` — document footer
+- `insertBibliography` — bibliography block
+- `insertEndnote` — payload: `{ attrs: { id: string } }`
+- `insertIndexBlock` — index block
+- `insertChart` — payload: `{ attrs: { title?: string, values: string } }`
 
 ## UX Extensions
 
@@ -696,41 +885,43 @@ Provides comment/annotation functionality.
 
 Provides slash command menu (type `/` to see command palette).
 
-**Location**: `packages/extensions/src/slash-command.ts`
-
 ### FloatingToolbarExtension
 
 Provides floating toolbar that appears on text selection.
 
-**Location**: `packages/extensions/src/floating-toolbar.ts`
-
 ### DragDropExtension
 
-Provides block-level drag and drop.
+Provides block-level drag and drop with auto-scroll and ESC cancellation.
 
-**Location**: `packages/extensions/src/drag-drop.ts`
+**Commands:** `moveBlockToPosition`
 
 ### FindReplaceExtension
 
 Provides find and replace functionality.
 
-**Location**: `packages/extensions/src/find-replace.ts`
+**Commands:** `find`, `findAndReplace`
 
-**Commands:**
-- `find` - Opens find dialog
-- `findAndReplace` - Opens find and replace dialog
+**Keybindings:** `Mod+f` (find), `Mod+h` (find and replace)
 
 ---
 
 ### `createRichExtensions(): Extension[]`
 
-Creates rich content extensions (includes basic + rich content extensions).
+Creates all rich content extensions (includes basic + all schema-complete extensions).
 
-**Returns:**
-- `Extension[]` - Array of rich extensions
+**Returns:** `Extension[]`
 
-**Includes:**
-- All of `createBasicExtensions()` plus `UnderlineExtension`, `LinkExtension`, `ImageExtension`, `CodeBlockExtension`, `HorizontalRuleExtension`, `TableExtension`, `ChecklistExtension`, `CalloutExtension`, `MathBlockExtension`, `CommentExtension`
+**Includes all of `createBasicExtensions()` plus:**
+
+| Category | Extensions |
+|----------|-----------|
+| **Formatting** | Underline, StrikeThrough, CodeMark, Highlight, FontColor, SubSuper, FontSize, FontFamily, TextFormatting |
+| **Rich Content** | Link, Image, CodeBlock, HorizontalRule, Table, Checklist, Callout, MathBlock, MathInline, Comment, PageBreak |
+| **Block Structures** | PullQuote, Columns, Toc, Details, DescriptionList, Figure |
+| **Media** | Media (Video, Audio, Embed) |
+| **Inline Atoms** | Mention, Footnote, Bookmark, Field |
+| **Document** | DocStructure |
+| **Editing** | MoveBlock, DragDrop |
 
 **Example:**
 ```typescript
@@ -742,32 +933,93 @@ editor.use(...richExtensions);
 
 ## Extension Options Summary
 
-| Extension | Options | Default Keyboard Shortcut | Commands |
-|----------|---------|-------------------------|----------|
-| `TextExtension` | `enabled?` | - | `replaceText` |
-| `DeleteExtension` | `enabled?` | - | `deleteSelection`, `deleteBackward`, `deleteForward` |
-| `BoldExtension` | `enabled?`, `keyboardShortcut?` | `Mod+b` | `toggleBold` |
-| `ItalicExtension` | `enabled?`, `keyboardShortcut?` | `Mod+i` | `toggleItalic` |
-| `UnderlineExtension` | - | - | `toggleUnderline` |
-| `StrikethroughExtension` | - | - | `toggleStrikethrough` |
-| `HeadingExtension` | `enabled?`, `levels?` | `Mod+Alt+1-6` | `setHeading`, `toggleHeading` |
-| `ParagraphExtension` | - | - | `insertParagraph`, `setParagraph` |
-| `IndentExtension` | `enabled?` | `Tab`, `Shift+Tab` | `indent`, `outdent` |
-| `MoveSelectionExtension` | - | Arrow keys | `moveSelectionUp/Down/Left/Right` |
-| `MoveBlockExtension` | `enabled?` | `Mod+ArrowUp/Down` | `moveBlockUp`, `moveBlockDown` |
-| `SelectAllExtension` | - | `Mod+a` | `selectAll` |
-| `CopyPasteExtension` | - | `Mod+c/x/v` | `copy`, `cut`, `paste` |
-| `EscapeExtension` | - | `Escape` | `escape` |
-| `LinkExtension` | - | - | `insertLink`, `removeLink` |
-| `ImageExtension` | - | - | `insertImage` |
-| `CodeBlockExtension` | - | - | `insertCodeBlock`, `toggleCodeBlock` |
-| `HorizontalRuleExtension` | - | - | `insertHorizontalRule` |
-| `TableExtension` | - | - | `insertTable` |
-| `CalloutExtension` | - | - | `insertCallout` |
-| `ChecklistExtension` | - | - | `insertChecklist`, `toggleChecklistItem` |
-| `MathBlockExtension` | - | - | `insertMathBlock` |
-| `CommentExtension` | - | - | `insertComment` |
-| `FindReplaceExtension` | - | `Mod+f`, `Mod+h` | `find`, `findAndReplace` |
+### Core Extensions (always included)
+
+| Extension | Keybindings | Commands |
+|----------|------------|----------|
+| `TextExtension` | - | `replaceText` |
+| `DeleteExtension` | - | `deleteSelection`, `deleteBackward`, `deleteForward` |
+| `ParagraphExtension` | - | `insertParagraph`, `setParagraph` |
+| `MoveSelectionExtension` | Arrow keys, Shift+Arrow | `moveSelection*`, `extendSelection*` |
+| `SelectAllExtension` | `Mod+a` | `selectAll` |
+| `IndentExtension` | `Tab`, `Shift+Tab` | `indent`, `outdent` |
+| `CopyPasteExtension` | `Mod+c/x/v` | `copy`, `cut`, `paste` |
+| `EscapeExtension` | `Escape` | `escape` |
+| `HardBreakExtension` | - | `insertHardBreak` |
+
+### Basic Extensions
+
+| Extension | Keybindings | Commands |
+|----------|------------|----------|
+| `BoldExtension` | `Mod+b` | `toggleBold` |
+| `ItalicExtension` | `Mod+i` | `toggleItalic` |
+| `HeadingExtension` | `Mod+Alt+1-6` | `setHeading1-6`, `setHeading`, `removeHeading` |
+| `ListExtension` | - | `toggleBulletList`, `toggleOrderedList`, `splitListItem` |
+| `BlockquoteExtension` | - | `toggleBlockquote` |
+
+### Rich Extensions — Formatting Marks
+
+| Extension | Commands |
+|----------|----------|
+| `UnderlineExtension` | `toggleUnderline` |
+| `StrikeThroughExtension` | `toggleStrikeThrough` |
+| `CodeMarkExtension` | `toggleCode` |
+| `HighlightExtension` | `toggleHighlight` |
+| `FontColorExtension` | `setFontColor`, `removeFontColor`, `setBgColor`, `removeBgColor` |
+| `SubSuperExtension` | `toggleSubscript`, `toggleSuperscript` |
+| `FontSizeExtension` | `setFontSize`, `removeFontSize` |
+| `FontFamilyExtension` | `setFontFamily`, `removeFontFamily` |
+| `TextFormattingExtension` | `toggleSmallCaps`, `toggleKbd`, `toggleSpoiler`, `setLetterSpacing`, `setWordSpacing`, `setLineHeight`, `setTextShadow`, `setBorder`, `setSpanLang` |
+| `MentionExtension` | `insertMention` |
+| `FootnoteExtension` | `insertFootnote`, `insertFootnoteRef` |
+
+### Rich Extensions — Block Content
+
+| Extension | Commands |
+|----------|----------|
+| `LinkExtension` | `insertLink`, `removeLink` |
+| `ImageExtension` | `insertImage` |
+| `CodeBlockExtension` | `insertCodeBlock`, `toggleCodeBlock` |
+| `HorizontalRuleExtension` | `insertHorizontalRule` |
+| `PageBreakExtension` | `insertPageBreak` |
+| `TableExtension` | `insertTable` |
+| `ChecklistExtension` | `insertChecklist`, `toggleChecklistItem` |
+| `CalloutExtension` | `insertCallout` |
+| `MathBlockExtension` | `insertMathBlock` |
+| `MathInlineExtension` | `insertMathInline` |
+| `CommentExtension` | `insertComment` |
+| `PullQuoteExtension` | `insertPullQuote` |
+| `ColumnsExtension` | `insertColumns`, `addColumn`, `removeColumn` |
+| `TocExtension` | `insertToc` |
+| `DetailsExtension` | `insertDetails` |
+| `DescriptionListExtension` | `insertDescriptionList`, `addDescriptionItem` |
+| `FigureExtension` | `insertFigure`, `setFigcaption` |
+| `MediaExtension` | `insertVideo`, `insertAudio`, `insertEmbed` |
+| `BookmarkExtension` | `insertBookmark` |
+| `FieldExtension` | `insertFieldPageNumber`, `insertFieldPageCount`, `insertFieldDateTime`, `insertFieldDocTitle`, `insertFieldAuthor` |
+| `DocStructureExtension` | `insertDocSection`, `insertDocHeader`, `insertDocFooter`, `insertBibliography`, `insertEndnote`, `insertIndexBlock`, `insertChart` |
+
+### UX Extensions
+
+| Extension | Keybindings | Commands |
+|----------|------------|----------|
+| `MoveBlockExtension` | `Mod+ArrowUp/Down` | `moveBlockUp`, `moveBlockDown` |
+| `DragDropExtension` | - | `moveBlockToPosition` |
+| `FindReplaceExtension` | `Mod+f`, `Mod+h` | `find`, `findAndReplace` |
+| `SlashCommandExtension` | `/` | - |
+| `FloatingToolbarExtension` | - | - |
+
+---
+
+## Schema Coverage
+
+All 48 node types and 24 marks in the standard schema have corresponding extensions:
+
+```
+Nodes:  48/48 covered (100%)
+Marks:  24/24 covered (100%)
+Total commands: 90+
+```
 
 ---
 

--- a/apps/docs-site/docs/architecture/editor-view-dom.md
+++ b/apps/docs-site/docs/architecture/editor-view-dom.md
@@ -18,9 +18,8 @@ View layer connecting Editor and DOM. Bridges user interactions (typing, clickin
 ```typescript
 import { EditorViewDOM } from '@barocss/editor-view-dom';
 
-const container = document.getElementById('editor');
-const view = new EditorViewDOM(editor, container);
-view.mount();
+const container = document.getElementById('editor')!;
+const view = new EditorViewDOM(editor, { container });
 ```
 
 ## Core Features
@@ -116,11 +115,8 @@ Triggers rendering when model changes:
 ## View Lifecycle
 
 ```typescript
-// 1. Create view
-const view = new EditorViewDOM(editor, container);
-
-// 2. Mount (attaches event listeners, initial render)
-view.mount();
+// 1. Create view (attaches event listeners, initial render)
+const view = new EditorViewDOM(editor, { container });
 
 // 3. User interacts with editor
 // → View handles input

--- a/apps/docs-site/docs/architecture/editor-view-react.md
+++ b/apps/docs-site/docs/architecture/editor-view-react.md
@@ -179,7 +179,7 @@ Selection sync is bidirectional: DOM selection changes update the model, and mod
 | Aspect | editor-view-dom | editor-view-react |
 |--------|----------------|-------------------|
 | Rendering | `DOMRenderer` (VNode → DOM reconciliation) | `ReactRenderer` (DSL → ReactNode, React reconciliation) |
-| Mount | `new EditorViewDOM(editor, container)` then `view.mount()` | `<EditorView editor={editor} />` component |
+| Mount | `new EditorViewDOM(editor, { container })` | `<EditorView editor={editor} />` component |
 | Decorator API | `view.addDecorator()`, `view.removeDecorator()` | `viewRef.current.addDecorator()`, `viewRef.current.removeDecorator()` |
 | Layer structure | 5 layers (content, decorator, selection, context, custom) | Same 5 layers as React components |
 | Selection sync | Direct DOM manipulation | Same, via `ReactSelectionHandler` |

--- a/apps/docs-site/docs/architecture/extensions.md
+++ b/apps/docs-site/docs/architecture/extensions.md
@@ -13,9 +13,9 @@ Extensions are the primary way to extend editor functionality. They provide:
 ## Key Exports
 
 - `Extension` - Base extension interface
-- `createCoreExtensions()` - Basic editing extensions
-- `createBasicExtensions()` - Formatting extensions
-- `createRichExtensions()` - Rich text extensions
+- `createCoreExtensions()` - Basic editing extensions (text, delete, paragraph, selection, indent, clipboard, hard break)
+- `createBasicExtensions()` - Formatting extensions (bold, italic, heading, list, blockquote)
+- `createRichExtensions()` - Full schema coverage (formatting marks, rich content, media, document structure, inline atoms)
 
 ## Basic Usage
 
@@ -121,44 +121,82 @@ Pre-built extension sets provide common functionality:
 
 ### Core Extensions
 
-Basic editing operations:
-- `insertText` - Insert text
-- `deleteSelection` - Delete selected text
-- `moveCursorLeft/Right` - Cursor movement
-- `backspace` - Backspace key
-- `deleteForward` - Delete key
+Required editing primitives (auto-registered):
+- `TextExtension` - Text input, replace
+- `DeleteExtension` - Backspace, Delete
+- `ParagraphExtension` - Paragraph structure
+- `MoveSelectionExtension` - Arrow key cursor movement
+- `SelectAllExtension` - Select all (`Mod+a`)
+- `IndentExtension` - Tab/Shift+Tab indentation
+- `CopyPasteExtension` - Clipboard operations (`Mod+c/x/v`)
+- `EscapeExtension` - Escape key handling
+- `HardBreakExtension` - Line break within block (Shift+Enter)
 
 ### Basic Extensions
 
 Text formatting:
-- `bold` - Toggle bold
-- `italic` - Toggle italic
-- `underline` - Toggle underline
-- `strikeThrough` - Toggle strikethrough
+- `BoldExtension` - Toggle bold (`Mod+b`)
+- `ItalicExtension` - Toggle italic (`Mod+i`)
+- `HeadingExtension` - Heading levels 1-6 (`Mod+Alt+1-6`)
+- `ListExtension` - Bullet and numbered lists
+- `BlockquoteExtension` - Blockquotes
 
 ### Rich Extensions
 
-Advanced formatting and rich content:
-- `heading` - Heading levels
-- `list` - Bullet and numbered lists
-- `blockquote` - Blockquotes
-- `codeBlock` - Code blocks
-- `link` - Link insertion and editing
-- `image` - Image insertion
-- `horizontalRule` - Horizontal rules
-- `table` - Table creation and editing
-- `checklist` - Checklist/task lists
-- `callout` - Callout/admonition blocks
-- `mathBlock` - Math equation blocks
-- `comment` - Comment/annotation
+Full schema-complete extension set covering all 48 node types and 24 marks:
+
+**Formatting Marks:**
+- `UnderlineExtension` - Underline (cross-node)
+- `StrikeThroughExtension` - Strikethrough (cross-node)
+- `CodeMarkExtension` - Inline code
+- `HighlightExtension` - Text highlight
+- `FontColorExtension` - Font color and background color
+- `SubSuperExtension` - Subscript/superscript
+- `FontSizeExtension` - Font size
+- `FontFamilyExtension` - Font family
+- `TextFormattingExtension` - smallCaps, kbd, spoiler, letterSpacing, wordSpacing, lineHeight, textShadow, border, spanLang
+- `MentionExtension` - @mentions
+- `FootnoteExtension` - Footnote def/ref
+
+**Rich Content Blocks:**
+- `LinkExtension` - Link insert/remove
+- `ImageExtension` - Image insertion
+- `CodeBlockExtension` - Code blocks
+- `HorizontalRuleExtension` - Horizontal rules
+- `PageBreakExtension` - Page breaks
+- `TableExtension` - Table (table, row, cell, header)
+- `ChecklistExtension` - Checklist/task items
+- `CalloutExtension` - Callout/admonition
+- `MathBlockExtension` - Math equations (block)
+- `MathInlineExtension` - Math equations (inline)
+- `CommentExtension` - Comment threads
+
+**Block Structures:**
+- `PullQuoteExtension` - Pull quotes
+- `ColumnsExtension` - Multi-column layout
+- `TocExtension` - Table of contents
+- `DetailsExtension` - Collapsible content
+- `DescriptionListExtension` - Description lists
+- `FigureExtension` - Figure with caption
+
+**Media:**
+- `MediaExtension` - Video, audio, embed
+
+**Inline Atoms:**
+- `BookmarkExtension` - Bookmark anchors
+- `FieldExtension` - Document fields (page number, date, title, author)
+
+**Document Structure:**
+- `DocStructureExtension` - Section, header, footer, bibliography, endnote, index, chart
 
 ### UX Extensions
 
 User experience enhancements:
-- `slashCommand` - Slash command palette (`/`)
-- `floatingToolbar` - Floating toolbar on selection
-- `dragDrop` - Block-level drag and drop
-- `findReplace` - Find and replace (`Mod+f`, `Mod+h`)
+- `MoveBlockExtension` - Block reordering (`Mod+ArrowUp/Down`)
+- `DragDropExtension` - Block-level drag and drop
+- `SlashCommandExtension` - Slash command palette (`/`)
+- `FloatingToolbarExtension` - Floating toolbar on selection
+- `FindReplaceExtension` - Find and replace (`Mod+f`, `Mod+h`)
 
 ## Custom Extensions
 

--- a/apps/docs-site/docs/architecture/packages.md
+++ b/apps/docs-site/docs/architecture/packages.md
@@ -127,19 +127,21 @@ const editor = new Editor({
 ```
 
 #### `@barocss/extensions`
-**Purpose**: Built-in extensions and extension system
+**Purpose**: Built-in extensions and extension system (55+ extensions, 100% schema coverage)
 
 **Key Exports**:
 - `Extension` - Extension interface
-- `createCoreExtensions()` - Core editing extensions
-- `createBasicExtensions()` - Basic formatting extensions
+- `createCoreExtensions()` - Core editing extensions (text, delete, paragraph, clipboard, hard break, etc.)
+- `createBasicExtensions()` - Basic formatting extensions (bold, italic, heading, list, blockquote)
+- `createRichExtensions()` - Full rich content extensions (marks, media, document structure, inline atoms)
+- `ExtensionSets` - Predefined extension sets (basic, rich, minimal)
 
 **How to Use**:
 ```typescript
-import { createCoreExtensions, createBasicExtensions } from '@barocss/extensions';
+import { createCoreExtensions, createRichExtensions } from '@barocss/extensions';
 
 const editor = new Editor({
-  extensions: [...createCoreExtensions(), ...createBasicExtensions()]
+  extensions: [...createCoreExtensions(), ...createRichExtensions()]
 });
 ```
 
@@ -209,7 +211,7 @@ flowchart TD
 | `renderer-dom` | VNode → DOM rendering | Custom rendering logic |
 | `renderer-react` | Direct → ReactNode rendering | React components |
 | `editor-core` | Editor orchestration | Register commands |
-| `extensions` | 30+ built-in features | Create custom extensions |
+| `extensions` | 55+ built-in features (100% schema coverage) | Create custom extensions |
 | `editor-view-dom` | DOM view layer | Custom input handling |
 | `editor-view-react` | React view layer | React hooks integration |
 | `collaboration` | CRDT/OT base adapter | Custom backends |

--- a/apps/docs-site/docs/architecture/practical-examples.md
+++ b/apps/docs-site/docs/architecture/practical-examples.md
@@ -68,8 +68,8 @@ const editor = new Editor({
 });
 
 // 5. Create View (Editor-View-DOM Package)
-const container = document.getElementById('editor');
-const view = new EditorViewDOM(editor, container);
+const container = document.getElementById('editor')!;
+const view = new EditorViewDOM(editor, { container });
 // View automatically sets up event handlers and renders
 ```
 
@@ -322,7 +322,7 @@ This example shows a complete editing session from start to finish.
 const schema = createSchema(/* ... */);
 const dataStore = new DataStore(undefined, schema);
 const editor = new Editor({ dataStore, schema, extensions: [...] });
-const view = new EditorViewDOM(editor, container);
+const view = new EditorViewDOM(editor, { container });
 
 // 2. User types "Hello"
 // → View captures input

--- a/apps/docs-site/docs/basic-usage.md
+++ b/apps/docs-site/docs/basic-usage.md
@@ -109,12 +109,22 @@ The View connects the editor to the DOM and handles user input.
 ```typescript
 import { EditorViewDOM } from '@barocss/editor-view-dom';
 
-const container = document.getElementById('editor');
-const view = new EditorViewDOM(editor, container);
+const container = document.getElementById('editor')!;
+const view = new EditorViewDOM(editor, { container });
 view.mount();
 ```
 
 **Why?** The View synchronizes selection, handles input, and triggers rendering. Learn more in [Architecture: Editor-View-DOM](architecture/editor-view-dom).
+
+**Options:** `EditorViewDOMOptions` accepts additional configuration:
+
+```typescript
+const view = new EditorViewDOM(editor, {
+  container,
+  autoRender: true,       // Auto-render on model changes (default: true)
+  registry: myRegistry,   // Custom renderer registry
+});
+```
 
 ## Complete Example
 
@@ -153,13 +163,14 @@ const editor = new Editor({
 });
 
 // View
-const container = document.getElementById('editor');
-const view = new EditorViewDOM(editor, container);
+const container = document.getElementById('editor')!;
+const view = new EditorViewDOM(editor, { container });
 view.mount();
 ```
 
 ## Next Steps
 
+- **[React Editor Guide](guides/react-editor)** - Build the same editor in React
 - **[Core Concepts](concepts/schema-and-model)** - Deep dive into schema and model
 - **[Architecture](architecture/overview)** - Understand the complete architecture
 - **[Extending](guides/extension-design)** - Learn how to add custom features

--- a/apps/docs-site/docs/concepts/editor-core.md
+++ b/apps/docs-site/docs/concepts/editor-core.md
@@ -111,7 +111,7 @@ await editor.chain()
   .run();
 ```
 
-**Available chain methods:**
+**Available chain methods (partial list):**
 
 | Method | Command |
 |--------|---------|
@@ -119,10 +119,16 @@ await editor.chain()
 | `deleteSelection()` | Delete selected content |
 | `toggleBold()` | Toggle bold formatting |
 | `toggleItalic()` | Toggle italic formatting |
-| `toggleUnderline()` | Toggle underline formatting |
-| `toggleStrikeThrough()` | Toggle strikethrough formatting |
+| `toggleUnderline()` | Toggle underline formatting (cross-node) |
+| `toggleStrikeThrough()` | Toggle strikethrough formatting (cross-node) |
+| `toggleCode()` | Toggle inline code mark |
+| `toggleHighlight(color?)` | Toggle text highlight |
 | `setHeading(level)` | Set heading level (1-6) |
 | `insertParagraph()` | Insert new paragraph |
+| `insertHardBreak()` | Insert line break (Shift+Enter) |
+| `insertCodeBlock()` | Insert code block |
+| `insertTable()` | Insert table |
+| `insertChecklist()` | Insert checklist |
 | `focus()` | Focus the editor |
 
 **Execution:**

--- a/apps/docs-site/docs/examples/custom-extensions.md
+++ b/apps/docs-site/docs/examples/custom-extensions.md
@@ -64,8 +64,63 @@ const editor = new Editor({
 - **Keybinding**: Connecting keyboard shortcuts to commands
 - **Transaction Usage**: Using transactions to modify the document
 
+## Built-in Extension Examples
+
+The editor ships with 55+ built-in extensions covering all schema types. Here are a few patterns used in real extensions:
+
+### Mark Toggle (Cross-Node Support)
+
+Extensions like `UnderlineExtension` and `StrikethroughExtension` support toggling marks across multiple nodes:
+
+```typescript
+import { transaction, toggleMark } from '@barocss/model';
+
+const op = toggleMark(
+  selection.startNodeId, selection.startOffset,
+  selection.endNodeId, selection.endOffset,
+  'underline'
+);
+const result = await transaction(editor, [op]).commit();
+```
+
+### Block Insertion with addChild
+
+Block extensions like `ColumnsExtension` and `DetailsExtension` use `addChild` to insert structured content:
+
+```typescript
+import { transaction, control, addChild } from '@barocss/model';
+
+const result = await transaction(editor, [
+  ...control(rootNodeId, [
+    addChild({
+      node: {
+        stype: 'bDetails',
+        content: [
+          { stype: 'bSummary', content: [{ stype: 'inline-text', text: 'Click to expand' }] },
+          { stype: 'paragraph', content: [{ stype: 'inline-text', text: '' }] }
+        ]
+      }
+    })
+  ])
+]).commit();
+```
+
+### Attribute Mutation via Transaction
+
+The `ChecklistExtension` uses transactions for attribute changes to ensure undo/redo works:
+
+```typescript
+const ops = [
+  ...control(payload.nodeId, [
+    { type: 'setAttrs', payload: { attrs: { checked: !currentChecked } } }
+  ])
+];
+const result = await transaction(editor, ops).commit();
+```
+
 ## Next Steps
 
 - **[Extension Design Guide](../guides/extension-design)** - Complete guide on creating extensions
+- **[Extensions API Reference](../api/extensions-api)** - Full list of all 55+ built-in extensions
 - **[Decorators Example](./decorators)** - Learn about decorators
 - **[Architecture: Editor-Core](../architecture/editor-core)** - Understand the editor core

--- a/apps/docs-site/docs/guides/extension-design.md
+++ b/apps/docs-site/docs/guides/extension-design.md
@@ -264,18 +264,18 @@ Common operations from `@barocss/model`:
 ### ❌ Wrong Way: Direct DataStore Access
 
 ```typescript
-// ❌ NEVER do this
+// ❌ NEVER do this — real bug we fixed in ChecklistExtension
 private async _executeBadCommand(editor: Editor): Promise<boolean> {
   const dataStore = editor.dataStore;
   
-  // Direct modification - bypasses transactions
-  dataStore.updateNode('node-1', { text: 'Updated' });
+  // Direct modification — bypasses transactions
+  dataStore.setAttrs(nodeId, { checked: !currentChecked });
   
   // Problems:
-  // - No transaction guarantee
+  // - No undo/redo support (cannot Ctrl+Z)
   // - No lock management
   // - No history recording
-  // - No operation events
+  // - No operation events for collaboration
   // - No schema validation
   
   return true;
@@ -285,15 +285,16 @@ private async _executeBadCommand(editor: Editor): Promise<boolean> {
 ### ✅ Correct Way: Use Transactions
 
 ```typescript
-// ✅ Always use transactions
-import { transaction, control, updateNode } from '@barocss/model';
+// ✅ Always use transactions — correct pattern from ChecklistExtension
+import { transaction, control } from '@barocss/model';
 
 private async _executeGoodCommand(editor: Editor): Promise<boolean> {
-  const result = await transaction(editor, [
-    ...control('node-1', [
-      updateNode({ text: 'Updated' })
+  const ops = [
+    ...control(nodeId, [
+      { type: 'setAttrs', payload: { attrs: { checked: !currentChecked } } }
     ])
-  ]).commit();
+  ];
+  const result = await transaction(editor, ops).commit();
 
   return result.success;
 }

--- a/apps/docs-site/docs/guides/react-editor.md
+++ b/apps/docs-site/docs/guides/react-editor.md
@@ -1,0 +1,530 @@
+# React Editor Guide
+
+This guide walks you through building a fully functional Barocss Editor inside a React application — from scratch to a complete editor with toolbar, formatting, and custom React-rendered components.
+
+## Prerequisites
+
+- React 18+ project (Vite, Next.js, or CRA)
+- Basic understanding of [Schema & Model](../concepts/schema-and-model) and [Extensions](../architecture/extensions)
+
+## Installation
+
+```bash
+pnpm add @barocss/editor-core @barocss/editor-view-react @barocss/renderer-react \
+  @barocss/schema @barocss/datastore @barocss/dsl @barocss/extensions @barocss/model
+```
+
+## Step 1: Define Schema
+
+```typescript
+// schema.ts
+import { createSchema, getStandardSchemaDefinition } from '@barocss/schema';
+
+// Use the standard schema (48 node types + 24 marks)
+export const schema = createSchema('my-editor', getStandardSchemaDefinition());
+```
+
+Or define a minimal schema if you only need a subset:
+
+```typescript
+export const schema = createSchema('my-editor', {
+  topNode: 'document',
+  nodes: {
+    document: { name: 'document', group: 'document', content: 'block+' },
+    heading:  { name: 'heading',  group: 'block', content: 'inline*', attributes: { level: { default: 1 } } },
+    paragraph:{ name: 'paragraph',group: 'block', content: 'inline*' },
+    'inline-text': { name: 'inline-text', group: 'inline' },
+  },
+  marks: {
+    bold:   { name: 'bold',   group: 'text-style' },
+    italic: { name: 'italic', group: 'text-style' },
+    link:   { name: 'link',   group: 'text-style', attributes: { href: { default: '' } } },
+  }
+});
+```
+
+## Step 2: Register React Component Renderers
+
+In the React view, every node type and mark is rendered as a **React component** using `define()` + `external()`:
+
+```tsx
+// register-renderers.tsx
+import React from 'react';
+import { define, defineMark, external } from '@barocss/dsl';
+import type { BlockComponentProps, MarkComponentProps } from '@barocss/dsl';
+
+type BP = BlockComponentProps;
+type MP = MarkComponentProps;
+
+// Block components receive: { sid, stype, attributes, children, text, model }
+// Mark components receive:  { markType, attributes, text, children }
+
+function Document({ sid, stype, children }: BP) {
+  return (
+    <div className="document" data-bc-sid={sid} data-bc-stype={stype}>
+      {children}
+    </div>
+  );
+}
+
+function Heading({ sid, stype, attributes, children }: BP) {
+  const Tag = `h${attributes?.level || 1}` as any;
+  return (
+    <Tag className="heading" data-bc-sid={sid} data-bc-stype={stype}>
+      {children}
+    </Tag>
+  );
+}
+
+function Paragraph({ sid, stype, children }: BP) {
+  return (
+    <p className="paragraph" data-bc-sid={sid} data-bc-stype={stype}>
+      {children}
+    </p>
+  );
+}
+
+function InlineText({ sid, stype, text }: BP) {
+  return (
+    <span className="text" data-bc-sid={sid} data-bc-stype={stype}>
+      {text ?? ''}
+    </span>
+  );
+}
+
+// Mark components wrap their children
+function BoldMark({ children }: MP) {
+  return <strong>{children}</strong>;
+}
+
+function ItalicMark({ children }: MP) {
+  return <em>{children}</em>;
+}
+
+function LinkMark({ children, attributes }: MP) {
+  return (
+    <a href={attributes?.href ?? '#'} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  );
+}
+
+export function registerRenderers(): void {
+  define('document',    external(Document));
+  define('heading',     external(Heading));
+  define('paragraph',   external(Paragraph));
+  define('inline-text', external(InlineText));
+
+  defineMark('bold',   external(BoldMark));
+  defineMark('italic', external(ItalicMark));
+  defineMark('link',   external(LinkMark));
+}
+```
+
+**Important:** Every block component **must** set `data-bc-sid` and `data-bc-stype` on its root element — the renderer uses these attributes for selection sync and reconciliation.
+
+## Step 3: Create the Editor Instance
+
+```tsx
+// use-editor.ts
+import { useMemo } from 'react';
+import { DataStore } from '@barocss/datastore';
+import { Editor } from '@barocss/editor-core';
+import { createCoreExtensions, createBasicExtensions } from '@barocss/extensions';
+import { schema } from './schema';
+import type { ModelData } from '@barocss/dsl';
+
+const initialDocument: ModelData = {
+  sid: 'doc-1',
+  stype: 'document',
+  content: [
+    {
+      sid: 'p-1',
+      stype: 'paragraph',
+      content: [
+        { sid: 'text-1', stype: 'inline-text', text: 'Start typing here...' }
+      ]
+    }
+  ]
+};
+
+export function useEditor() {
+  return useMemo(() => {
+    const dataStore = new DataStore(undefined, schema);
+    const editor = new Editor({
+      dataStore,
+      schema,
+      editable: true,
+      extensions: [
+        ...createCoreExtensions(),
+        ...createBasicExtensions(),
+      ],
+    });
+    editor.loadDocument(initialDocument, 'my-editor');
+    return editor;
+  }, []);
+}
+```
+
+## Step 4: Render the Editor
+
+```tsx
+// App.tsx
+import { EditorView } from '@barocss/editor-view-react';
+import { getGlobalRegistry } from '@barocss/dsl';
+import { useEditor } from './use-editor';
+import { registerRenderers } from './register-renderers';
+
+// Register once at module level
+registerRenderers();
+
+export function App() {
+  const editor = useEditor();
+
+  return (
+    <div className="editor-app">
+      <EditorView
+        editor={editor}
+        options={{
+          registry: getGlobalRegistry(),
+          className: 'editor-root',
+          layers: {
+            content: { editable: true, className: 'editor-content' },
+          },
+        }}
+      />
+    </div>
+  );
+}
+```
+
+That's it — you now have a working React editor. The `EditorView` component handles:
+- Content rendering via `ReactRenderer`
+- Selection sync (DOM ↔ Model)
+- Input handling (text, composition/IME, keyboard)
+- Mutation observation
+- Layered decorator rendering
+
+## Step 5: Add a Toolbar
+
+Use the `useEditorViewContext` hook or direct `editor.executeCommand()` calls to add formatting controls:
+
+```tsx
+// Toolbar.tsx
+import { useCallback } from 'react';
+import type { Editor } from '@barocss/editor-core';
+
+interface ToolbarProps {
+  editor: Editor;
+}
+
+export function Toolbar({ editor }: ToolbarProps) {
+  const exec = useCallback(
+    (command: string, payload?: any) => editor.executeCommand(command, payload),
+    [editor]
+  );
+
+  return (
+    <div className="toolbar">
+      <button onClick={() => exec('toggleBold')} title="Bold (Ctrl+B)">
+        <b>B</b>
+      </button>
+      <button onClick={() => exec('toggleItalic')} title="Italic (Ctrl+I)">
+        <i>I</i>
+      </button>
+      <button onClick={() => exec('toggleUnderline')} title="Underline">
+        <u>U</u>
+      </button>
+      <span className="separator" />
+      <button onClick={() => exec('setHeading', { level: 1 })}>H1</button>
+      <button onClick={() => exec('setHeading', { level: 2 })}>H2</button>
+      <button onClick={() => exec('setHeading', { level: 3 })}>H3</button>
+      <span className="separator" />
+      <button onClick={() => exec('toggleBulletList')}>• List</button>
+      <button onClick={() => exec('toggleOrderedList')}>1. List</button>
+      <button onClick={() => exec('toggleBlockquote')}>Quote</button>
+    </div>
+  );
+}
+```
+
+Then compose it with the editor:
+
+```tsx
+export function App() {
+  const editor = useEditor();
+
+  return (
+    <div className="editor-app">
+      <Toolbar editor={editor} />
+      <EditorView
+        editor={editor}
+        options={{
+          registry: getGlobalRegistry(),
+          className: 'editor-root',
+          layers: {
+            content: { editable: true, className: 'editor-content' },
+          },
+        }}
+      />
+    </div>
+  );
+}
+```
+
+## Step 6: Using the Ref API
+
+The `EditorView` exposes an imperative ref for decorator management and selection control:
+
+```tsx
+import { useRef } from 'react';
+import { EditorView, type EditorViewRef } from '@barocss/editor-view-react';
+
+function MyEditor({ editor }: { editor: Editor }) {
+  const viewRef = useRef<EditorViewRef>(null);
+
+  const addHighlight = () => {
+    const sel = editor.selection;
+    if (!sel || sel.type !== 'range') return;
+
+    viewRef.current?.addDecorator({
+      sid: `hl-${Date.now()}`,
+      stype: 'highlight',
+      category: 'inline',
+      target: {
+        sid: sel.startNodeId,
+        startOffset: sel.startOffset,
+        endOffset: sel.endOffset,
+      },
+    });
+  };
+
+  return (
+    <>
+      <button onClick={addHighlight}>Highlight</button>
+      <EditorView ref={viewRef} editor={editor} options={{ registry: getGlobalRegistry() }} />
+    </>
+  );
+}
+```
+
+## Step 7: Custom Overlay Layers
+
+Render custom React components in overlay layers (above the content):
+
+```tsx
+import { EditorView, EditorViewContentLayer, EditorViewLayer } from '@barocss/editor-view-react';
+
+function FloatingToolbar() {
+  return <div className="floating-toolbar">Floating UI here</div>;
+}
+
+function FullEditor({ editor }: { editor: Editor }) {
+  return (
+    <EditorView editor={editor} options={{ registry: getGlobalRegistry() }}>
+      <EditorViewContentLayer options={{ editable: true }} />
+      <EditorViewLayer layer="decorator" />
+      <EditorViewLayer layer="selection" />
+      <EditorViewLayer layer="custom">
+        <FloatingToolbar />
+      </EditorViewLayer>
+    </EditorView>
+  );
+}
+```
+
+The five layers from bottom to top:
+
+| Layer | Purpose |
+|-------|---------|
+| **Content** | `contenteditable` div, renders model via `ReactRenderer` |
+| **Decorator** | Overlay for decorator highlights and widgets |
+| **Selection** | Overlay for custom selection rendering |
+| **Context** | Overlay for tooltips, context menus |
+| **Custom** | Overlay for arbitrary React children |
+
+## Step 8: Rich Content with External Components
+
+For complex node types, React components can use hooks, state, and effects:
+
+```tsx
+import { useRef, useEffect } from 'react';
+import type { BlockComponentProps } from '@barocss/dsl';
+import katex from 'katex';
+
+function MathBlock({ sid, stype, attributes }: BlockComponentProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const tex = attributes?.tex ?? '';
+
+  useEffect(() => {
+    if (!ref.current || !tex) return;
+    try {
+      katex.render(tex, ref.current, { displayMode: true, throwOnError: false });
+    } catch {
+      if (ref.current) ref.current.textContent = tex;
+    }
+  }, [tex]);
+
+  return (
+    <div
+      ref={ref}
+      className="math-block"
+      data-bc-sid={sid}
+      data-bc-stype={stype}
+    >
+      {tex ? null : '(empty equation)'}
+    </div>
+  );
+}
+
+define('mathBlock', external(MathBlock));
+```
+
+## Step 9: Context Hook for Nested Components
+
+Components rendered inside `EditorView` can access editor state via the context hook:
+
+```tsx
+import { useEditorViewContext } from '@barocss/editor-view-react';
+
+function WordCount() {
+  const { editor } = useEditorViewContext();
+  const dataStore = editor.dataStore;
+  // ... count words from dataStore nodes
+  return <span className="word-count">123 words</span>;
+}
+```
+
+Use `useOptionalEditorViewContext` if the component may render outside the editor:
+
+```tsx
+import { useOptionalEditorViewContext } from '@barocss/editor-view-react';
+
+function StatusBar() {
+  const ctx = useOptionalEditorViewContext();
+  if (!ctx) return <span>No editor</span>;
+  return <span>Editor ready</span>;
+}
+```
+
+## Complete Example
+
+Here's the full minimal setup:
+
+```tsx
+// main.tsx
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { createSchema } from '@barocss/schema';
+import { DataStore } from '@barocss/datastore';
+import { Editor } from '@barocss/editor-core';
+import { EditorView } from '@barocss/editor-view-react';
+import { define, defineMark, external, getGlobalRegistry } from '@barocss/dsl';
+import { createCoreExtensions, createBasicExtensions } from '@barocss/extensions';
+import type { BlockComponentProps, MarkComponentProps } from '@barocss/dsl';
+
+// 1. Schema
+const schema = createSchema('demo', {
+  topNode: 'document',
+  nodes: {
+    document:      { name: 'document',    group: 'document', content: 'block+' },
+    paragraph:     { name: 'paragraph',   group: 'block',    content: 'inline*' },
+    'inline-text': { name: 'inline-text', group: 'inline' },
+  },
+  marks: {
+    bold: { name: 'bold', group: 'text-style' },
+  }
+});
+
+// 2. React renderers
+define('document',    external(({ sid, stype, children }: BlockComponentProps) =>
+  <div data-bc-sid={sid} data-bc-stype={stype}>{children}</div>
+));
+define('paragraph',   external(({ sid, stype, children }: BlockComponentProps) =>
+  <p data-bc-sid={sid} data-bc-stype={stype}>{children}</p>
+));
+define('inline-text', external(({ sid, stype, text }: BlockComponentProps) =>
+  <span data-bc-sid={sid} data-bc-stype={stype}>{text ?? ''}</span>
+));
+defineMark('bold', external(({ children }: MarkComponentProps) =>
+  <strong>{children}</strong>
+));
+
+// 3. Editor
+const dataStore = new DataStore(undefined, schema);
+const editor = new Editor({
+  dataStore, schema, editable: true,
+  extensions: [...createCoreExtensions(), ...createBasicExtensions()],
+});
+editor.loadDocument({
+  sid: 'doc', stype: 'document',
+  content: [{
+    sid: 'p1', stype: 'paragraph',
+    content: [{ sid: 't1', stype: 'inline-text', text: 'Hello, React Editor!' }]
+  }]
+}, 'demo');
+
+// 4. Render
+function App() {
+  return (
+    <div style={{ maxWidth: 720, margin: '40px auto', border: '1px solid #ddd', borderRadius: 8 }}>
+      <div style={{ padding: '4px 8px', borderBottom: '1px solid #ddd', background: '#fafafa' }}>
+        <button onClick={() => editor.executeCommand('toggleBold')}><b>B</b></button>
+      </div>
+      <EditorView
+        editor={editor}
+        options={{
+          registry: getGlobalRegistry(),
+          layers: { content: { editable: true, className: 'content' } },
+        }}
+      />
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+```
+
+## Component Props Reference
+
+### Block Components (`BlockComponentProps`)
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `sid` | `string` | Node's unique schema ID |
+| `stype` | `string` | Node's schema type |
+| `attributes` | `Record<string, any>` | Node attributes from model |
+| `children` | `ReactNode` | Rendered child nodes |
+| `text` | `string \| undefined` | Text content (leaf nodes) |
+| `model` | `object` | Full model data |
+
+### Mark Components (`MarkComponentProps`)
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `markType` | `string` | Mark type name |
+| `attributes` | `Record<string, any>` | Mark attributes |
+| `text` | `string` | Text content of the run |
+| `children` | `ReactNode` | Inner content (text or nested marks) |
+
+## DOM vs React: When to Use Which
+
+| Criterion | `EditorViewDOM` | `EditorView` (React) |
+|-----------|----------------|---------------------|
+| App framework | Vanilla JS, non-React | React |
+| Renderer | `DOMRenderer` (VNode → DOM) | `ReactRenderer` (DSL → ReactNode) |
+| Reconciliation | Custom VNode diffing | React's built-in reconciler |
+| Component model | DSL `element()` templates | React components via `external()` |
+| Hooks & state | Not available | Full React lifecycle |
+| Mount API | `new EditorViewDOM(editor, { container })` | `<EditorView editor={editor} />` |
+| Decorator API | `view.addDecorator()` | `viewRef.current.addDecorator()` |
+
+Both views share the same Editor, DataStore, Schema, Extensions, and transaction system. You can even switch between them — the model layer is completely view-agnostic.
+
+## Next Steps
+
+- [Architecture: Editor-View-React](../architecture/editor-view-react) — Internal architecture
+- [API: Editor View React](../api/editor-view-react-api) — Full API reference
+- [Architecture: Renderer-React](../architecture/renderer-react) — React rendering pipeline
+- [Extension Design Guide](./extension-design) — Create custom extensions
+- [Decorators](../concepts/decorators) — Add visual overlays and widgets

--- a/apps/docs-site/docs/installation.md
+++ b/apps/docs-site/docs/installation.md
@@ -16,14 +16,22 @@ pnpm add @barocss/editor-core @barocss/editor-view-dom @barocss/schema
 # For rendering
 pnpm add @barocss/renderer-dom @barocss/dsl
 
+# For React rendering (instead of or alongside DOM)
+pnpm add @barocss/editor-view-react @barocss/renderer-react
+
 # For data management
 pnpm add @barocss/datastore @barocss/model
 
-# For extensions
+# For extensions (55+ built-in extensions)
 pnpm add @barocss/extensions
 
 # For format conversion
 pnpm add @barocss/converter
+
+# For collaboration
+pnpm add @barocss/collaboration @barocss/collaboration-yjs
+# or
+pnpm add @barocss/collaboration @barocss/collaboration-liveblocks
 ```
 
 ## Package Overview
@@ -38,6 +46,8 @@ pnpm add @barocss/converter
 
 - **@barocss/dsl** - Declarative template DSL
 - **@barocss/renderer-dom** - DOM renderer
+- **@barocss/renderer-react** - React renderer
+- **@barocss/editor-view-react** - React view integration
 
 ### Data Packages
 
@@ -46,11 +56,18 @@ pnpm add @barocss/converter
 
 ### Extension Packages
 
-- **@barocss/extensions** - Extension system
+- **@barocss/extensions** - 55+ built-in extensions with 100% schema coverage
+
+### Collaboration Packages
+
+- **@barocss/collaboration** - Base adapter interface
+- **@barocss/collaboration-yjs** - Yjs CRDT adapter
+- **@barocss/collaboration-liveblocks** - Liveblocks adapter
 
 ### Utility Packages
 
-- **@barocss/converter** - Format conversion (HTML, Markdown, etc.)
+- **@barocss/converter** - Format conversion (HTML, Markdown, LaTeX)
+- **@barocss/devtool** - Development tools (model tree viewer, event log)
 
 ## TypeScript Support
 

--- a/apps/docs-site/docs/introduction.md
+++ b/apps/docs-site/docs/introduction.md
@@ -94,13 +94,46 @@ dataStore.createNode({ stype: 'invalid-node' }); // ❌ Error
 
 ### 1. Separation of Concerns
 
-- **Schema**: Defines structure
-- **Model**: Stores data
-- **DSL**: Defines presentation
-- **Renderer**: Converts to DOM
-- **Editor**: Orchestrates operations
+- **Schema**: Defines structure (48 node types, 24 marks in standard schema)
+- **Model**: Stores data with transactional operations
+- **DSL**: Defines presentation declaratively
+- **Renderer**: Converts to DOM or React
+- **Editor**: Orchestrates operations via commands
+- **Extensions**: 55+ built-in features with 100% schema coverage
 
-### 2. Testability
+### 2. Dual Rendering Targets
+
+Barocss supports both DOM and React rendering from the same model:
+
+```typescript
+// DOM rendering
+import { EditorViewDOM } from '@barocss/editor-view-dom';
+const view = new EditorViewDOM(editor, { container });
+
+// React rendering
+import { EditorViewReact } from '@barocss/editor-view-react';
+// Use as a React component
+```
+
+Both share the same model, schema, extensions, and transaction system.
+
+### 3. Collaboration Ready
+
+Built-in collaboration support via adapters:
+
+- **Yjs adapter** (`@barocss/collaboration-yjs`) — CRDT-based real-time sync
+- **Liveblocks adapter** (`@barocss/collaboration-liveblocks`) — Cloud-hosted collaboration
+- Extensible `BaseAdapter` interface for custom backends
+
+### 4. Format Conversion
+
+The converter package (`@barocss/converter`) supports bidirectional conversion:
+
+- **HTML** ↔ INode (including Office, Google Docs, Notion HTML cleaning)
+- **Markdown** ↔ INode (GFM support)
+- **LaTeX** → INode
+
+### 5. Testability
 
 ```typescript
 // Test model operations without DOM
@@ -112,7 +145,7 @@ const template = registry.get('paragraph');
 expect(template).toBeDefined();
 ```
 
-### 3. Extensibility
+### 6. Extensibility
 
 Add new features using the same DSL patterns:
 
@@ -126,6 +159,8 @@ Learn DSL once, use it everywhere.
 
 ## Next Steps
 
-- **[Quick Start](quick-start)** - Get started in minutes
+- **[Quick Start](quick-start)** - Get started in minutes (DOM view)
+- **[React Editor Guide](guides/react-editor)** - Build a React editor from scratch
 - **[Core Concepts: DSL Templates](concepts/dsl-templates)** - Learn about DSL
 - **[Architecture Overview](architecture/overview)** - Understand the complete architecture
+- **[Extensions API](api/extensions-api)** - Browse all 55+ built-in extensions

--- a/apps/docs-site/docs/quick-start.md
+++ b/apps/docs-site/docs/quick-start.md
@@ -47,8 +47,8 @@ const editor = new Editor({
 });
 
 // 5. Create view - connects editor to DOM
-const container = document.getElementById('editor');
-const view = new EditorViewDOM(editor, container);
+const container = document.getElementById('editor')!;
+const view = new EditorViewDOM(editor, { container });
 view.mount();
 ```
 

--- a/apps/docs-site/sidebars.ts
+++ b/apps/docs-site/sidebars.ts
@@ -63,8 +63,9 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
-      label: 'Extending',
+      label: 'Guides',
       items: [
+        'guides/react-editor',
         'guides/extension-design',
         'guides/custom-operations',
         'guides/advanced-extensions',

--- a/packages/extensions/src/bookmark.ts
+++ b/packages/extensions/src/bookmark.ts
@@ -1,0 +1,44 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild } from '@barocss/model';
+
+export class BookmarkExtension implements Extension {
+  name = 'bookmark';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertBookmark',
+      execute: async (ed: Editor, payload?: { id?: string; selection?: ModelSelection }) => {
+        if (!payload?.id) return false;
+        const sel = payload?.selection || (ed as any).selection;
+        if (!sel || sel.type !== 'range') return false;
+
+        const dataStore = (ed as any).dataStore;
+        if (!dataStore) return false;
+
+        const node = dataStore.getNode(sel.startNodeId);
+        if (!node) return false;
+
+        const parentId = node.parentId ?? sel.startNodeId;
+        const parent = dataStore.getNode(parentId);
+        if (!parent || !Array.isArray(parent.content)) return false;
+
+        const childIndex = parent.content.indexOf(sel.startNodeId);
+        const insertPos = childIndex === -1 ? parent.content.length : childIndex + 1;
+
+        const ops = [
+          addChild(parentId, { stype: 'bookmarkAnchor', attributes: { id: payload.id } } as any, insertPos)
+        ];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createBookmarkExtension(): BookmarkExtension {
+  return new BookmarkExtension();
+}

--- a/packages/extensions/src/checklist.ts
+++ b/packages/extensions/src/checklist.ts
@@ -1,5 +1,5 @@
 import { Editor, Extension } from '@barocss/editor-core';
-import { transaction, insertChecklist as insertChecklistOp } from '@barocss/model';
+import { transaction, control, insertChecklist as insertChecklistOp } from '@barocss/model';
 
 export interface ChecklistExtensionOptions {
   enabled?: boolean;
@@ -36,8 +36,13 @@ export class ChecklistExtension implements Extension {
         const node = dataStore.getNode(payload.nodeId);
         if (!node || node.stype !== 'taskItem') return false;
         const currentChecked = node.attributes?.checked ?? false;
-        dataStore.setAttrs(payload.nodeId, { checked: !currentChecked });
-        return true;
+        const ops = [
+          ...control(payload.nodeId, [
+            { type: 'setAttrs', payload: { attrs: { checked: !currentChecked } } } as any
+          ])
+        ];
+        const result = await transaction(ed, ops).commit();
+        return result.success;
       },
       canExecute: () => true
     });

--- a/packages/extensions/src/code-mark.ts
+++ b/packages/extensions/src/code-mark.ts
@@ -1,0 +1,37 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, toggleMark } from '@barocss/model';
+
+export class CodeMarkExtension implements Extension {
+  name = 'codeMark';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'toggleCode',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const op = toggleMark(
+          selection.startNodeId,
+          selection.startOffset,
+          selection.endNodeId,
+          selection.endOffset,
+          'code'
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: (_ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const sel = payload?.selection || (_ed as any).selection;
+        return !!sel && sel.type === 'range';
+      }
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createCodeMarkExtension(): CodeMarkExtension {
+  return new CodeMarkExtension();
+}

--- a/packages/extensions/src/columns.ts
+++ b/packages/extensions/src/columns.ts
@@ -1,0 +1,105 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild, removeChild } from '@barocss/model';
+
+export interface ColumnsExtensionOptions {
+  defaultColumnCount?: number;
+}
+
+export class ColumnsExtension implements Extension {
+  name = 'columns';
+  priority = 100;
+  private _defaultCount: number;
+
+  constructor(options: ColumnsExtensionOptions = {}) {
+    this._defaultCount = options.defaultColumnCount ?? 2;
+  }
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertColumns',
+      execute: async (ed: Editor, payload?: { count?: number; selection?: ModelSelection }) => {
+        const count = payload?.count ?? this._defaultCount;
+        const insertInfo = this._getInsertInfo(ed, payload?.selection);
+        if (!insertInfo) return false;
+
+        const columns: any[] = [];
+        for (let i = 0; i < count; i++) {
+          columns.push({
+            stype: 'column',
+            content: [{ stype: 'paragraph', content: [{ stype: 'inline-text', text: '' }] }]
+          });
+        }
+
+        const ops = [
+          addChild(insertInfo.parentId, { stype: 'columns', content: columns } as any, insertInfo.position)
+        ];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'addColumn',
+      execute: async (ed: Editor, payload?: { columnsId?: string }) => {
+        if (!payload?.columnsId) return false;
+        const dataStore = (ed as any).dataStore;
+        if (!dataStore) return false;
+        const columnsNode = dataStore.getNode(payload.columnsId);
+        if (!columnsNode || columnsNode.stype !== 'columns') return false;
+
+        const newCol = {
+          stype: 'column',
+          content: [{ stype: 'paragraph', content: [{ stype: 'inline-text', text: '' }] }]
+        };
+        const ops = [addChild(payload.columnsId, newCol as any)];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'removeColumn',
+      execute: async (ed: Editor, payload?: { columnsId?: string; columnId?: string }) => {
+        if (!payload?.columnsId || !payload?.columnId) return false;
+        const ops = [removeChild(payload.columnsId, payload.columnId)];
+        const result = await transaction(ed, ops).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+
+  private _getInsertInfo(editor: Editor, selection?: ModelSelection): { parentId: string; position: number } | null {
+    const sel = selection || (editor as any).selection;
+    if (!sel || sel.type !== 'range') return null;
+    const dataStore = (editor as any).dataStore;
+    if (!dataStore) return null;
+    const node = dataStore.getNode(sel.startNodeId);
+    if (!node) return null;
+
+    let blockId = sel.startNodeId;
+    let current = node;
+    const schema = dataStore.getActiveSchema?.();
+    while (current?.parentId) {
+      const parent = dataStore.getNode(current.parentId);
+      if (!parent) break;
+      const pType = schema?.getNodeType?.(parent.stype);
+      if (pType?.group === 'block') { blockId = parent.sid ?? current.parentId; break; }
+      current = parent;
+    }
+    const block = dataStore.getNode(blockId);
+    if (!block?.parentId) return null;
+    const docParent = dataStore.getNode(block.parentId);
+    if (!docParent || !Array.isArray(docParent.content)) return null;
+    const idx = docParent.content.indexOf(blockId);
+    return { parentId: block.parentId, position: idx === -1 ? docParent.content.length : idx + 1 };
+  }
+}
+
+export function createColumnsExtension(options?: ColumnsExtensionOptions): ColumnsExtension {
+  return new ColumnsExtension(options);
+}

--- a/packages/extensions/src/description-list.ts
+++ b/packages/extensions/src/description-list.ts
@@ -1,0 +1,82 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild } from '@barocss/model';
+
+export class DescriptionListExtension implements Extension {
+  name = 'descriptionList';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertDescriptionList',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const insertInfo = this._getInsertInfo(ed, payload?.selection);
+        if (!insertInfo) return false;
+
+        const dlNode = {
+          stype: 'descList',
+          content: [
+            { stype: 'descTerm', content: [{ stype: 'inline-text', text: '' }] },
+            { stype: 'descDef', content: [{ stype: 'paragraph', content: [{ stype: 'inline-text', text: '' }] }] }
+          ]
+        };
+
+        const ops = [
+          addChild(insertInfo.parentId, dlNode as any, insertInfo.position)
+        ];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'addDescriptionItem',
+      execute: async (ed: Editor, payload?: { descListId?: string }) => {
+        if (!payload?.descListId) return false;
+        const dataStore = (ed as any).dataStore;
+        if (!dataStore) return false;
+        const dlNode = dataStore.getNode(payload.descListId);
+        if (!dlNode || dlNode.stype !== 'descList') return false;
+
+        const ops = [
+          addChild(payload.descListId, { stype: 'descTerm', content: [{ stype: 'inline-text', text: '' }] } as any),
+          addChild(payload.descListId, { stype: 'descDef', content: [{ stype: 'paragraph', content: [{ stype: 'inline-text', text: '' }] }] } as any)
+        ];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+
+  private _getInsertInfo(editor: Editor, selection?: ModelSelection): { parentId: string; position: number } | null {
+    const sel = selection || (editor as any).selection;
+    if (!sel || sel.type !== 'range') return null;
+    const dataStore = (editor as any).dataStore;
+    if (!dataStore) return null;
+    const node = dataStore.getNode(sel.startNodeId);
+    if (!node) return null;
+
+    let blockId = sel.startNodeId;
+    let current = node;
+    const schema = dataStore.getActiveSchema?.();
+    while (current?.parentId) {
+      const parent = dataStore.getNode(current.parentId);
+      if (!parent) break;
+      if (schema?.getNodeType?.(parent.stype)?.group === 'block') { blockId = parent.sid ?? current.parentId; break; }
+      current = parent;
+    }
+    const block = dataStore.getNode(blockId);
+    if (!block?.parentId) return null;
+    const docParent = dataStore.getNode(block.parentId);
+    if (!docParent || !Array.isArray(docParent.content)) return null;
+    const idx = docParent.content.indexOf(blockId);
+    return { parentId: block.parentId, position: idx === -1 ? docParent.content.length : idx + 1 };
+  }
+}
+
+export function createDescriptionListExtension(): DescriptionListExtension {
+  return new DescriptionListExtension();
+}

--- a/packages/extensions/src/details.ts
+++ b/packages/extensions/src/details.ts
@@ -1,0 +1,64 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild } from '@barocss/model';
+
+export class DetailsExtension implements Extension {
+  name = 'details';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertDetails',
+      execute: async (ed: Editor, payload?: { summary?: string; selection?: ModelSelection }) => {
+        const insertInfo = this._getInsertInfo(ed, payload?.selection);
+        if (!insertInfo) return false;
+
+        const summaryText = payload?.summary ?? 'Details';
+        const detailsNode = {
+          stype: 'bDetails',
+          content: [
+            { stype: 'bSummary', content: [{ stype: 'inline-text', text: summaryText }] },
+            { stype: 'paragraph', content: [{ stype: 'inline-text', text: '' }] }
+          ]
+        };
+
+        const ops = [
+          addChild(insertInfo.parentId, detailsNode as any, insertInfo.position)
+        ];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+
+  private _getInsertInfo(editor: Editor, selection?: ModelSelection): { parentId: string; position: number } | null {
+    const sel = selection || (editor as any).selection;
+    if (!sel || sel.type !== 'range') return null;
+    const dataStore = (editor as any).dataStore;
+    if (!dataStore) return null;
+    const node = dataStore.getNode(sel.startNodeId);
+    if (!node) return null;
+
+    let blockId = sel.startNodeId;
+    let current = node;
+    const schema = dataStore.getActiveSchema?.();
+    while (current?.parentId) {
+      const parent = dataStore.getNode(current.parentId);
+      if (!parent) break;
+      if (schema?.getNodeType?.(parent.stype)?.group === 'block') { blockId = parent.sid ?? current.parentId; break; }
+      current = parent;
+    }
+    const block = dataStore.getNode(blockId);
+    if (!block?.parentId) return null;
+    const docParent = dataStore.getNode(block.parentId);
+    if (!docParent || !Array.isArray(docParent.content)) return null;
+    const idx = docParent.content.indexOf(blockId);
+    return { parentId: block.parentId, position: idx === -1 ? docParent.content.length : idx + 1 };
+  }
+}
+
+export function createDetailsExtension(): DetailsExtension {
+  return new DetailsExtension();
+}

--- a/packages/extensions/src/doc-structure.ts
+++ b/packages/extensions/src/doc-structure.ts
@@ -1,0 +1,93 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild } from '@barocss/model';
+
+type DocStructureType =
+  | 'docSection' | 'docHeader' | 'docFooter'
+  | 'bibliography' | 'endnoteDef' | 'indexBlock' | 'chart';
+
+interface DocStructureSpec {
+  cmd: string;
+  stype: DocStructureType;
+  hasContent: boolean;
+  attrKeys?: string[];
+}
+
+export class DocStructureExtension implements Extension {
+  name = 'docStructure';
+  priority = 80;
+
+  private static _specs: DocStructureSpec[] = [
+    { cmd: 'insertDocSection', stype: 'docSection', hasContent: true },
+    { cmd: 'insertDocHeader', stype: 'docHeader', hasContent: true },
+    { cmd: 'insertDocFooter', stype: 'docFooter', hasContent: true },
+    { cmd: 'insertBibliography', stype: 'bibliography', hasContent: true },
+    { cmd: 'insertEndnote', stype: 'endnoteDef', hasContent: true, attrKeys: ['id'] },
+    { cmd: 'insertIndexBlock', stype: 'indexBlock', hasContent: true },
+    { cmd: 'insertChart', stype: 'chart', hasContent: false, attrKeys: ['title', 'values'] },
+  ];
+
+  onCreate(editor: Editor): void {
+    for (const spec of DocStructureExtension._specs) {
+      (editor as any).registerCommand({
+        name: spec.cmd,
+        execute: async (ed: Editor, payload?: { selection?: ModelSelection; attrs?: Record<string, any> }) => {
+          const insertInfo = this._getInsertInfo(ed, payload?.selection);
+          if (!insertInfo) return false;
+
+          const nodeData: any = { stype: spec.stype };
+
+          if (spec.attrKeys && payload?.attrs) {
+            const attrs: Record<string, any> = {};
+            for (const key of spec.attrKeys) {
+              if (payload.attrs[key] !== undefined) attrs[key] = payload.attrs[key];
+            }
+            if (Object.keys(attrs).length > 0) nodeData.attributes = attrs;
+          }
+
+          if (spec.hasContent && !nodeData.content) {
+            nodeData.content = [{ stype: 'paragraph', content: [{ stype: 'inline-text', text: '' }] }];
+          }
+
+          const ops = [addChild(insertInfo.parentId, nodeData, insertInfo.position)];
+          const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+          return result.success;
+        },
+        canExecute: () => true
+      });
+    }
+  }
+
+  onDestroy(_editor: Editor): void {}
+
+  private _getInsertInfo(editor: Editor, selection?: ModelSelection): { parentId: string; position: number } | null {
+    const sel = selection || (editor as any).selection;
+    if (!sel || sel.type !== 'range') return null;
+    const dataStore = (editor as any).dataStore;
+    if (!dataStore) return null;
+    const node = dataStore.getNode(sel.startNodeId);
+    if (!node) return null;
+
+    let blockId = sel.startNodeId;
+    let current = node;
+    const schema = dataStore.getActiveSchema?.();
+    while (current?.parentId) {
+      const parent = dataStore.getNode(current.parentId);
+      if (!parent) break;
+      if (schema?.getNodeType?.(parent.stype)?.group === 'block') {
+        blockId = parent.sid ?? current.parentId;
+        break;
+      }
+      current = parent;
+    }
+    const block = dataStore.getNode(blockId);
+    if (!block?.parentId) return null;
+    const docParent = dataStore.getNode(block.parentId);
+    if (!docParent || !Array.isArray(docParent.content)) return null;
+    const idx = docParent.content.indexOf(blockId);
+    return { parentId: block.parentId, position: idx === -1 ? docParent.content.length : idx + 1 };
+  }
+}
+
+export function createDocStructureExtension(): DocStructureExtension {
+  return new DocStructureExtension();
+}

--- a/packages/extensions/src/field.ts
+++ b/packages/extensions/src/field.ts
@@ -1,0 +1,58 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild } from '@barocss/model';
+
+type FieldType = 'fieldPageNumber' | 'fieldPageCount' | 'fieldDateTime' | 'fieldDocTitle' | 'fieldAuthor';
+
+export class FieldExtension implements Extension {
+  name = 'field';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    const fields: { cmd: string; stype: FieldType; hasAttrs: boolean }[] = [
+      { cmd: 'insertFieldPageNumber', stype: 'fieldPageNumber', hasAttrs: false },
+      { cmd: 'insertFieldPageCount', stype: 'fieldPageCount', hasAttrs: false },
+      { cmd: 'insertFieldDateTime', stype: 'fieldDateTime', hasAttrs: true },
+      { cmd: 'insertFieldDocTitle', stype: 'fieldDocTitle', hasAttrs: false },
+      { cmd: 'insertFieldAuthor', stype: 'fieldAuthor', hasAttrs: false },
+    ];
+
+    for (const f of fields) {
+      (editor as any).registerCommand({
+        name: f.cmd,
+        execute: async (ed: Editor, payload?: { selection?: ModelSelection; format?: string }) => {
+          const sel = payload?.selection || (ed as any).selection;
+          if (!sel || sel.type !== 'range') return false;
+
+          const dataStore = (ed as any).dataStore;
+          if (!dataStore) return false;
+
+          const node = dataStore.getNode(sel.startNodeId);
+          if (!node) return false;
+
+          const parentId = node.parentId ?? sel.startNodeId;
+          const parent = dataStore.getNode(parentId);
+          if (!parent || !Array.isArray(parent.content)) return false;
+
+          const childIndex = parent.content.indexOf(sel.startNodeId);
+          const insertPos = childIndex === -1 ? parent.content.length : childIndex + 1;
+
+          const nodeData: any = { stype: f.stype };
+          if (f.hasAttrs && payload?.format) {
+            nodeData.attributes = { format: payload.format };
+          }
+
+          const ops = [addChild(parentId, nodeData, insertPos)];
+          const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+          return result.success;
+        },
+        canExecute: () => true
+      });
+    }
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createFieldExtension(): FieldExtension {
+  return new FieldExtension();
+}

--- a/packages/extensions/src/figure.ts
+++ b/packages/extensions/src/figure.ts
@@ -1,0 +1,82 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild } from '@barocss/model';
+
+export class FigureExtension implements Extension {
+  name = 'figure';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertFigure',
+      execute: async (ed: Editor, payload?: { src?: string; alt?: string; caption?: string; selection?: ModelSelection }) => {
+        const insertInfo = this._getInsertInfo(ed, payload?.selection);
+        if (!insertInfo) return false;
+
+        const imgAttrs: any = { src: payload?.src ?? '', alt: payload?.alt ?? '' };
+        const children: any[] = [
+          { stype: 'inline-image', attributes: imgAttrs }
+        ];
+
+        if (payload?.caption !== undefined) {
+          children.push({ stype: 'bFigcaption', content: [{ stype: 'inline-text', text: payload.caption }] });
+        }
+
+        const figNode = { stype: 'bFigure', content: children };
+        const ops = [
+          addChild(insertInfo.parentId, figNode as any, insertInfo.position)
+        ];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'setFigcaption',
+      execute: async (ed: Editor, payload?: { figureId?: string; caption?: string }) => {
+        if (!payload?.figureId) return false;
+        const dataStore = (ed as any).dataStore;
+        if (!dataStore) return false;
+        const figNode = dataStore.getNode(payload.figureId);
+        if (!figNode || figNode.stype !== 'bFigure') return false;
+
+        const captionNode = { stype: 'bFigcaption', content: [{ stype: 'inline-text', text: payload?.caption ?? '' }] };
+        const ops = [addChild(payload.figureId, captionNode as any)];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+
+  private _getInsertInfo(editor: Editor, selection?: ModelSelection): { parentId: string; position: number } | null {
+    const sel = selection || (editor as any).selection;
+    if (!sel || sel.type !== 'range') return null;
+    const dataStore = (editor as any).dataStore;
+    if (!dataStore) return null;
+    const node = dataStore.getNode(sel.startNodeId);
+    if (!node) return null;
+
+    let blockId = sel.startNodeId;
+    let current = node;
+    const schema = dataStore.getActiveSchema?.();
+    while (current?.parentId) {
+      const parent = dataStore.getNode(current.parentId);
+      if (!parent) break;
+      if (schema?.getNodeType?.(parent.stype)?.group === 'block') { blockId = parent.sid ?? current.parentId; break; }
+      current = parent;
+    }
+    const block = dataStore.getNode(blockId);
+    if (!block?.parentId) return null;
+    const docParent = dataStore.getNode(block.parentId);
+    if (!docParent || !Array.isArray(docParent.content)) return null;
+    const idx = docParent.content.indexOf(blockId);
+    return { parentId: block.parentId, position: idx === -1 ? docParent.content.length : idx + 1 };
+  }
+}
+
+export function createFigureExtension(): FigureExtension {
+  return new FigureExtension();
+}

--- a/packages/extensions/src/font-color.ts
+++ b/packages/extensions/src/font-color.ts
@@ -1,0 +1,89 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, applyMark, toggleMark } from '@barocss/model';
+
+export class FontColorExtension implements Extension {
+  name = 'fontColor';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'setFontColor',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection; color?: string }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range' || !payload?.color) return false;
+
+        const op = applyMark(
+          selection.startNodeId,
+          selection.startOffset,
+          selection.endNodeId,
+          selection.endOffset,
+          'fontColor',
+          { color: payload.color }
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'removeFontColor',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const op = toggleMark(
+          selection.startNodeId, selection.startOffset,
+          selection.endNodeId, selection.endOffset,
+          'fontColor'
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'setBgColor',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection; color?: string }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range' || !payload?.color) return false;
+
+        const op = applyMark(
+          selection.startNodeId,
+          selection.startOffset,
+          selection.endNodeId,
+          selection.endOffset,
+          'bgColor',
+          { color: payload.color }
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'removeBgColor',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const op = toggleMark(
+          selection.startNodeId, selection.startOffset,
+          selection.endNodeId, selection.endOffset,
+          'bgColor'
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createFontColorExtension(): FontColorExtension {
+  return new FontColorExtension();
+}

--- a/packages/extensions/src/font-family.ts
+++ b/packages/extensions/src/font-family.ts
@@ -1,0 +1,49 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, applyMark, toggleMark } from '@barocss/model';
+
+export class FontFamilyExtension implements Extension {
+  name = 'fontFamily';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'setFontFamily',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection; family?: string }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range' || !payload?.family) return false;
+
+        const op = applyMark(
+          selection.startNodeId, selection.startOffset,
+          selection.endNodeId, selection.endOffset,
+          'fontFamily', { family: payload.family }
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'removeFontFamily',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const op = toggleMark(
+          selection.startNodeId, selection.startOffset,
+          selection.endNodeId, selection.endOffset,
+          'fontFamily'
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createFontFamilyExtension(): FontFamilyExtension {
+  return new FontFamilyExtension();
+}

--- a/packages/extensions/src/font-size.ts
+++ b/packages/extensions/src/font-size.ts
@@ -1,0 +1,49 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, applyMark, toggleMark } from '@barocss/model';
+
+export class FontSizeExtension implements Extension {
+  name = 'fontSize';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'setFontSize',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection; size?: string }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range' || !payload?.size) return false;
+
+        const op = applyMark(
+          selection.startNodeId, selection.startOffset,
+          selection.endNodeId, selection.endOffset,
+          'fontSize', { size: payload.size }
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'removeFontSize',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const op = toggleMark(
+          selection.startNodeId, selection.startOffset,
+          selection.endNodeId, selection.endOffset,
+          'fontSize'
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createFontSizeExtension(): FontSizeExtension {
+  return new FontSizeExtension();
+}

--- a/packages/extensions/src/footnote.ts
+++ b/packages/extensions/src/footnote.ts
@@ -1,0 +1,67 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild, applyMark } from '@barocss/model';
+
+export class FootnoteExtension implements Extension {
+  name = 'footnote';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertFootnote',
+      execute: async (ed: Editor, payload?: { id?: string; text?: string; selection?: ModelSelection }) => {
+        if (!payload?.id) return false;
+        const sel = payload?.selection || (ed as any).selection;
+        if (!sel || sel.type !== 'range') return false;
+
+        const dataStore = (ed as any).dataStore;
+        if (!dataStore) return false;
+
+        const docNode = dataStore.getNode(dataStore.getRootNodeId?.() ?? 'document');
+        if (!docNode) return false;
+        const docId = docNode.sid ?? 'document';
+
+        const footnoteDefNode = {
+          stype: 'footnoteDef',
+          attributes: { id: payload.id },
+          content: [{ stype: 'inline-text', text: payload?.text ?? '' }]
+        };
+        const ops: any[] = [addChild(docId, footnoteDefNode as any)];
+
+        const refOp = applyMark(
+          sel.startNodeId, sel.startOffset,
+          sel.endNodeId, sel.endOffset,
+          'footnoteRef', { id: payload.id }
+        );
+        ops.push(refOp);
+
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'insertFootnoteRef',
+      execute: async (ed: Editor, payload?: { id?: string; selection?: ModelSelection }) => {
+        if (!payload?.id) return false;
+        const sel = payload?.selection || (ed as any).selection;
+        if (!sel || sel.type !== 'range') return false;
+
+        const op = applyMark(
+          sel.startNodeId, sel.startOffset,
+          sel.endNodeId, sel.endOffset,
+          'footnoteRef', { id: payload.id }
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createFootnoteExtension(): FootnoteExtension {
+  return new FootnoteExtension();
+}

--- a/packages/extensions/src/hard-break.ts
+++ b/packages/extensions/src/hard-break.ts
@@ -1,0 +1,54 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild, splitTextNode } from '@barocss/model';
+
+export class HardBreakExtension implements Extension {
+  name = 'hardBreak';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertHardBreak',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const dataStore = (ed as any).dataStore;
+        if (!dataStore) return false;
+
+        const node = dataStore.getNode(selection.startNodeId);
+        if (!node || node.stype !== 'inline-text') return false;
+
+        const parentId = node.parentId;
+        if (!parentId) return false;
+
+        const parent = dataStore.getNode(parentId);
+        if (!parent || !Array.isArray(parent.content)) return false;
+
+        const childIndex = parent.content.indexOf(selection.startNodeId);
+        if (childIndex === -1) return false;
+
+        const ops: any[] = [];
+
+        if (selection.startOffset > 0 && selection.startOffset < (node.text?.length ?? 0)) {
+          ops.push(splitTextNode(selection.startNodeId, selection.startOffset));
+        }
+
+        const insertPos = selection.startOffset === 0 ? childIndex : childIndex + 1;
+        ops.push(addChild(parentId, { stype: 'hardBreak' } as any, insertPos));
+
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: (_ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const sel = payload?.selection || (_ed as any).selection;
+        return !!sel && sel.type === 'range';
+      }
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createHardBreakExtension(): HardBreakExtension {
+  return new HardBreakExtension();
+}

--- a/packages/extensions/src/heading.ts
+++ b/packages/extensions/src/heading.ts
@@ -169,31 +169,27 @@ export class HeadingExtension implements Extension {
     return null;
   }
 
-  private _removeHeading(editor: any): boolean {
-    try {
-      const selection = editor.selection;
-      
-      if (selection.empty) {
-        return this._removeHeadingAtPosition(editor, selection.anchor);
-      } else {
-        return this._removeHeadingInRange(editor, selection.from, selection.to);
-      }
-    } catch (error) {
-      console.error('Remove heading failed:', error);
-      return false;
-    }
-  }
+  private async _removeHeading(editor: any): Promise<boolean> {
+    const selection: ModelSelection | null = editor.selection;
+    if (!selection || selection.type !== 'range') return false;
 
-  private _removeHeadingAtPosition(_editor: any, position: number): boolean {
-    // Placeholder: no-op safe fallback until block-level heading metadata is available.
-    console.log('Remove heading at position:', position);
-    return true;
-  }
+    const dataStore = (editor as any).dataStore;
+    if (!dataStore) return false;
 
-  private _removeHeadingInRange(_editor: any, from: number, to: number): boolean {
-    // Placeholder: no-op safe fallback until range-level heading metadata is available.
-    console.log('Remove heading in range:', from, to);
-    return true;
+    const targetNodeId = this._getTargetBlockNodeId(dataStore, selection);
+    if (!targetNodeId) return false;
+
+    const targetNode = dataStore.getNode(targetNodeId);
+    if (!targetNode || targetNode.stype !== 'heading') return false;
+
+    const ops = [
+      ...control(targetNodeId, [
+        transformNode('paragraph', {})
+      ])
+    ];
+
+    const result = await transaction(editor, ops).commit();
+    return result.success;
   }
 
   private _registerKeyboardShortcuts(_editor: Editor): void {

--- a/packages/extensions/src/highlight.ts
+++ b/packages/extensions/src/highlight.ts
@@ -1,0 +1,49 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, toggleMark } from '@barocss/model';
+
+export interface HighlightExtensionOptions {
+  defaultColor?: string;
+}
+
+export class HighlightExtension implements Extension {
+  name = 'highlight';
+  priority = 100;
+
+  private _defaultColor: string;
+
+  constructor(options: HighlightExtensionOptions = {}) {
+    this._defaultColor = options.defaultColor ?? '#ffeb3b';
+  }
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'toggleHighlight',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection; color?: string }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const color = payload?.color ?? this._defaultColor;
+        const op = toggleMark(
+          selection.startNodeId,
+          selection.startOffset,
+          selection.endNodeId,
+          selection.endOffset,
+          'highlight',
+          { color }
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: (_ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const sel = payload?.selection || (_ed as any).selection;
+        return !!sel && sel.type === 'range';
+      }
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createHighlightExtension(options?: HighlightExtensionOptions): HighlightExtension {
+  return new HighlightExtension(options);
+}

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -35,6 +35,21 @@ export * from './callout';
 export * from './math-block';
 export * from './comment';
 export * from './styles';
+export * from './pull-quote';
+export * from './columns';
+export * from './toc';
+export * from './details';
+export * from './description-list';
+export * from './figure';
+export * from './media';
+export * from './font-size';
+export * from './font-family';
+export * from './text-formatting';
+export * from './mention';
+export * from './footnote';
+export * from './bookmark';
+export * from './field';
+export * from './doc-structure';
 
 // Import classes
 import { TextExtension } from './text';
@@ -70,6 +85,21 @@ import { FontColorExtension } from './font-color';
 import { SubSuperExtension } from './sub-super';
 import { MathInlineExtension } from './math-inline';
 import { PageBreakExtension } from './page-break';
+import { PullQuoteExtension } from './pull-quote';
+import { ColumnsExtension } from './columns';
+import { TocExtension } from './toc';
+import { DetailsExtension } from './details';
+import { DescriptionListExtension } from './description-list';
+import { FigureExtension } from './figure';
+import { MediaExtension } from './media';
+import { FontSizeExtension } from './font-size';
+import { FontFamilyExtension } from './font-family';
+import { TextFormattingExtension } from './text-formatting';
+import { MentionExtension } from './mention';
+import { FootnoteExtension } from './footnote';
+import { BookmarkExtension } from './bookmark';
+import { FieldExtension } from './field';
+import { DocStructureExtension } from './doc-structure';
 import type { Extension } from '@barocss/editor-core';
 
 export function createCoreExtensions(): Extension[] {
@@ -118,6 +148,21 @@ export function createRichExtensions(): Extension[] {
     new SubSuperExtension(),
     new MathInlineExtension(),
     new PageBreakExtension(),
+    new PullQuoteExtension(),
+    new ColumnsExtension(),
+    new TocExtension(),
+    new DetailsExtension(),
+    new DescriptionListExtension(),
+    new FigureExtension(),
+    new MediaExtension(),
+    new FontSizeExtension(),
+    new FontFamilyExtension(),
+    new TextFormattingExtension(),
+    new MentionExtension(),
+    new FootnoteExtension(),
+    new BookmarkExtension(),
+    new FieldExtension(),
+    new DocStructureExtension(),
   ];
 }
 
@@ -127,32 +172,8 @@ export const ExtensionSets = {
     new ItalicExtension(),
     new UnderlineExtension()
   ],
-  
-  rich: () => [
-    new BoldExtension(),
-    new ItalicExtension(),
-    new UnderlineExtension(),
-    new StrikeThroughExtension(),
-    new HeadingExtension(),
-    new LinkExtension(),
-    new ImageExtension(),
-    new CodeBlockExtension(),
-    new HorizontalRuleExtension(),
-    new TableExtension(),
-    new ChecklistExtension(),
-    new CalloutExtension(),
-    new MathBlockExtension(),
-    new CommentExtension(),
-    new MoveBlockExtension(),
-    new DragDropExtension(),
-    new CodeMarkExtension(),
-    new HighlightExtension(),
-    new FontColorExtension(),
-    new SubSuperExtension(),
-    new MathInlineExtension(),
-    new PageBreakExtension(),
-  ],
-  
+
+  rich: () => createRichExtensions(),
+
   minimal: () => []
 } as const;
-

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -22,6 +22,13 @@ export * from './table';
 export * from './slash-command';
 export * from './floating-toolbar';
 export * from './drag-drop';
+export * from './hard-break';
+export * from './code-mark';
+export * from './highlight';
+export * from './font-color';
+export * from './sub-super';
+export * from './math-inline';
+export * from './page-break';
 export * from './find-replace';
 export * from './checklist';
 export * from './callout';
@@ -56,6 +63,13 @@ import { CalloutExtension } from './callout';
 import { MathBlockExtension } from './math-block';
 import { CommentExtension } from './comment';
 import { DragDropExtension } from './drag-drop';
+import { HardBreakExtension } from './hard-break';
+import { CodeMarkExtension } from './code-mark';
+import { HighlightExtension } from './highlight';
+import { FontColorExtension } from './font-color';
+import { SubSuperExtension } from './sub-super';
+import { MathInlineExtension } from './math-inline';
+import { PageBreakExtension } from './page-break';
 import type { Extension } from '@barocss/editor-core';
 
 export function createCoreExtensions(): Extension[] {
@@ -68,6 +82,7 @@ export function createCoreExtensions(): Extension[] {
     new IndentExtension(),
     new CopyPasteExtension(),
     new EscapeExtension(),
+    new HardBreakExtension(),
   ];
 }
 
@@ -97,6 +112,12 @@ export function createRichExtensions(): Extension[] {
     new CommentExtension(),
     new MoveBlockExtension(),
     new DragDropExtension(),
+    new CodeMarkExtension(),
+    new HighlightExtension(),
+    new FontColorExtension(),
+    new SubSuperExtension(),
+    new MathInlineExtension(),
+    new PageBreakExtension(),
   ];
 }
 
@@ -124,6 +145,12 @@ export const ExtensionSets = {
     new CommentExtension(),
     new MoveBlockExtension(),
     new DragDropExtension(),
+    new CodeMarkExtension(),
+    new HighlightExtension(),
+    new FontColorExtension(),
+    new SubSuperExtension(),
+    new MathInlineExtension(),
+    new PageBreakExtension(),
   ],
   
   minimal: () => []

--- a/packages/extensions/src/math-inline.ts
+++ b/packages/extensions/src/math-inline.ts
@@ -1,0 +1,45 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild } from '@barocss/model';
+
+export class MathInlineExtension implements Extension {
+  name = 'mathInline';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertMathInline',
+      execute: async (ed: Editor, payload?: { tex?: string; selection?: ModelSelection }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const dataStore = (ed as any).dataStore;
+        if (!dataStore) return false;
+
+        const node = dataStore.getNode(selection.startNodeId);
+        if (!node) return false;
+
+        const parentId = node.parentId ?? selection.startNodeId;
+        const parent = dataStore.getNode(parentId);
+        if (!parent || !Array.isArray(parent.content)) return false;
+
+        const tex = payload?.tex ?? '';
+        const childIndex = parent.content.indexOf(selection.startNodeId);
+        const insertPos = childIndex === -1 ? parent.content.length : childIndex + 1;
+
+        const ops = [
+          addChild(parentId, { stype: 'mathInline', attributes: { tex, engine: 'katex' } } as any, insertPos)
+        ];
+
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createMathInlineExtension(): MathInlineExtension {
+  return new MathInlineExtension();
+}

--- a/packages/extensions/src/media.ts
+++ b/packages/extensions/src/media.ts
@@ -1,0 +1,88 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild } from '@barocss/model';
+
+export class MediaExtension implements Extension {
+  name = 'media';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertVideo',
+      execute: async (ed: Editor, payload?: { src?: string; poster?: string; selection?: ModelSelection }) => {
+        if (!payload?.src) return false;
+        const insertInfo = this._getInsertInfo(ed, payload?.selection);
+        if (!insertInfo) return false;
+
+        const attrs: any = { src: payload.src, controls: true };
+        if (payload.poster) attrs.poster = payload.poster;
+
+        const ops = [addChild(insertInfo.parentId, { stype: 'mediaVideo', attributes: attrs } as any, insertInfo.position)];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'insertAudio',
+      execute: async (ed: Editor, payload?: { src?: string; selection?: ModelSelection }) => {
+        if (!payload?.src) return false;
+        const insertInfo = this._getInsertInfo(ed, payload?.selection);
+        if (!insertInfo) return false;
+
+        const ops = [addChild(insertInfo.parentId, { stype: 'mediaAudio', attributes: { src: payload.src, controls: true } } as any, insertInfo.position)];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+
+    (editor as any).registerCommand({
+      name: 'insertEmbed',
+      execute: async (ed: Editor, payload?: { provider?: string; id?: string; title?: string; selection?: ModelSelection }) => {
+        if (!payload?.provider || !payload?.id) return false;
+        const insertInfo = this._getInsertInfo(ed, payload?.selection);
+        if (!insertInfo) return false;
+
+        const attrs: any = { provider: payload.provider, id: payload.id };
+        if (payload.title) attrs.title = payload.title;
+
+        const ops = [addChild(insertInfo.parentId, { stype: 'mediaEmbed', attributes: attrs } as any, insertInfo.position)];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+
+  private _getInsertInfo(editor: Editor, selection?: ModelSelection): { parentId: string; position: number } | null {
+    const sel = selection || (editor as any).selection;
+    if (!sel || sel.type !== 'range') return null;
+    const dataStore = (editor as any).dataStore;
+    if (!dataStore) return null;
+    const node = dataStore.getNode(sel.startNodeId);
+    if (!node) return null;
+
+    let blockId = sel.startNodeId;
+    let current = node;
+    const schema = dataStore.getActiveSchema?.();
+    while (current?.parentId) {
+      const parent = dataStore.getNode(current.parentId);
+      if (!parent) break;
+      if (schema?.getNodeType?.(parent.stype)?.group === 'block') { blockId = parent.sid ?? current.parentId; break; }
+      current = parent;
+    }
+    const block = dataStore.getNode(blockId);
+    if (!block?.parentId) return null;
+    const docParent = dataStore.getNode(block.parentId);
+    if (!docParent || !Array.isArray(docParent.content)) return null;
+    const idx = docParent.content.indexOf(blockId);
+    return { parentId: block.parentId, position: idx === -1 ? docParent.content.length : idx + 1 };
+  }
+}
+
+export function createMediaExtension(): MediaExtension {
+  return new MediaExtension();
+}

--- a/packages/extensions/src/mention.ts
+++ b/packages/extensions/src/mention.ts
@@ -1,0 +1,32 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, applyMark } from '@barocss/model';
+
+export class MentionExtension implements Extension {
+  name = 'mention';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertMention',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection; id?: string }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range' || !payload?.id) return false;
+
+        const op = applyMark(
+          selection.startNodeId, selection.startOffset,
+          selection.endNodeId, selection.endOffset,
+          'mention', { id: payload.id }
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createMentionExtension(): MentionExtension {
+  return new MentionExtension();
+}

--- a/packages/extensions/src/page-break.ts
+++ b/packages/extensions/src/page-break.ts
@@ -1,0 +1,60 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild } from '@barocss/model';
+
+export class PageBreakExtension implements Extension {
+  name = 'pageBreak';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertPageBreak',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const dataStore = (ed as any).dataStore;
+        if (!dataStore) return false;
+
+        const startNode = dataStore.getNode(selection.startNodeId);
+        if (!startNode) return false;
+
+        let blockId = selection.startNodeId;
+        let current = startNode;
+        const schema = dataStore.getActiveSchema?.();
+        while (current?.parentId) {
+          const parent = dataStore.getNode(current.parentId);
+          if (!parent) break;
+          const parentType = schema?.getNodeType?.(parent.stype);
+          if (parentType?.group === 'block') {
+            blockId = parent.sid ?? current.parentId;
+            break;
+          }
+          current = parent;
+        }
+
+        const blockNode = dataStore.getNode(blockId);
+        if (!blockNode?.parentId) return false;
+
+        const docParent = dataStore.getNode(blockNode.parentId);
+        if (!docParent || !Array.isArray(docParent.content)) return false;
+
+        const blockIndex = docParent.content.indexOf(blockId);
+        const insertPos = blockIndex === -1 ? docParent.content.length : blockIndex + 1;
+
+        const ops = [
+          addChild(blockNode.parentId, { stype: 'pageBreak' } as any, insertPos)
+        ];
+
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createPageBreakExtension(): PageBreakExtension {
+  return new PageBreakExtension();
+}

--- a/packages/extensions/src/pull-quote.ts
+++ b/packages/extensions/src/pull-quote.ts
@@ -1,0 +1,69 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild } from '@barocss/model';
+
+export class PullQuoteExtension implements Extension {
+  name = 'pullQuote';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertPullQuote',
+      execute: async (ed: Editor, payload?: { text?: string; selection?: ModelSelection }) => {
+        const insertInfo = this._getInsertInfo(ed, payload?.selection);
+        if (!insertInfo) return false;
+
+        const children: any[] = payload?.text
+          ? [{ stype: 'inline-text', text: payload.text }]
+          : [{ stype: 'inline-text', text: '' }];
+
+        const ops = [
+          addChild(insertInfo.parentId, { stype: 'pullQuote', content: children } as any, insertInfo.position)
+        ];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+
+  private _getInsertInfo(editor: Editor, selection?: ModelSelection): { parentId: string; position: number } | null {
+    const sel = selection || (editor as any).selection;
+    if (!sel || sel.type !== 'range') return null;
+
+    const dataStore = (editor as any).dataStore;
+    if (!dataStore) return null;
+
+    const node = dataStore.getNode(sel.startNodeId);
+    if (!node) return null;
+
+    const blockId = this._findBlockParent(dataStore, node);
+    if (!blockId) return null;
+
+    const block = dataStore.getNode(blockId);
+    if (!block?.parentId) return null;
+
+    const parent = dataStore.getNode(block.parentId);
+    if (!parent || !Array.isArray(parent.content)) return null;
+
+    const idx = parent.content.indexOf(blockId);
+    return { parentId: block.parentId, position: idx === -1 ? parent.content.length : idx + 1 };
+  }
+
+  private _findBlockParent(dataStore: any, node: any): string | null {
+    const schema = dataStore.getActiveSchema?.();
+    let current = node;
+    while (current) {
+      const nodeType = schema?.getNodeType?.(current.stype);
+      if (nodeType?.group === 'block') return current.sid ?? null;
+      if (!current.parentId) break;
+      current = dataStore.getNode(current.parentId);
+    }
+    return null;
+  }
+}
+
+export function createPullQuoteExtension(): PullQuoteExtension {
+  return new PullQuoteExtension();
+}

--- a/packages/extensions/src/strikethrough.ts
+++ b/packages/extensions/src/strikethrough.ts
@@ -47,9 +47,6 @@ export class StrikeThroughExtension implements Extension {
     if (!selection || selection.type !== 'range') {
       return false;
     }
-    if (selection.startNodeId !== selection.endNodeId) {
-      return false;
-    }
 
     const op = toggleMark(
       selection.startNodeId,

--- a/packages/extensions/src/sub-super.ts
+++ b/packages/extensions/src/sub-super.ts
@@ -1,0 +1,59 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, toggleMark } from '@barocss/model';
+
+export class SubSuperExtension implements Extension {
+  name = 'subSuper';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'toggleSubscript',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const op = toggleMark(
+          selection.startNodeId,
+          selection.startOffset,
+          selection.endNodeId,
+          selection.endOffset,
+          'subscript'
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: (_ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const sel = payload?.selection || (_ed as any).selection;
+        return !!sel && sel.type === 'range';
+      }
+    });
+
+    (editor as any).registerCommand({
+      name: 'toggleSuperscript',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const op = toggleMark(
+          selection.startNodeId,
+          selection.startOffset,
+          selection.endNodeId,
+          selection.endOffset,
+          'superscript'
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: (_ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const sel = payload?.selection || (_ed as any).selection;
+        return !!sel && sel.type === 'range';
+      }
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+}
+
+export function createSubSuperExtension(): SubSuperExtension {
+  return new SubSuperExtension();
+}

--- a/packages/extensions/src/text-formatting.ts
+++ b/packages/extensions/src/text-formatting.ts
@@ -1,0 +1,98 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, toggleMark, applyMark } from '@barocss/model';
+
+/**
+ * TextFormattingExtension — aggregates less-common text-style marks:
+ * smallCaps, kbd, spoiler, letterSpacing, wordSpacing, lineHeight,
+ * textShadow, border, spanLang
+ */
+export class TextFormattingExtension implements Extension {
+  name = 'textFormatting';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    this._registerToggle(editor, 'toggleSmallCaps', 'smallCaps');
+    this._registerToggle(editor, 'toggleKbd', 'kbd');
+    this._registerToggle(editor, 'toggleSpoiler', 'spoiler');
+
+    this._registerApply(editor, 'setLetterSpacing', 'letterSpacing', 'spacing');
+    this._registerApply(editor, 'setWordSpacing', 'wordSpacing', 'spacing');
+    this._registerApply(editor, 'setLineHeight', 'lineHeight', 'height');
+    this._registerApply(editor, 'setTextShadow', 'textShadow', 'shadow');
+
+    this._registerApplyMulti(editor, 'setBorder', 'border', ['style', 'width', 'color']);
+    this._registerApplyMulti(editor, 'setSpanLang', 'spanLang', ['lang', 'dir']);
+  }
+
+  onDestroy(_editor: Editor): void {}
+
+  private _registerToggle(editor: Editor, cmdName: string, markType: string): void {
+    (editor as any).registerCommand({
+      name: cmdName,
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range') return false;
+
+        const op = toggleMark(
+          selection.startNodeId, selection.startOffset,
+          selection.endNodeId, selection.endOffset,
+          markType
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: (_ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const sel = payload?.selection || (_ed as any).selection;
+        return !!sel && sel.type === 'range';
+      }
+    });
+  }
+
+  private _registerApply(editor: Editor, cmdName: string, markType: string, attrKey: string): void {
+    (editor as any).registerCommand({
+      name: cmdName,
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection; value?: string }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range' || !payload?.value) return false;
+
+        const op = applyMark(
+          selection.startNodeId, selection.startOffset,
+          selection.endNodeId, selection.endOffset,
+          markType, { [attrKey]: payload.value }
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  private _registerApplyMulti(editor: Editor, cmdName: string, markType: string, attrKeys: string[]): void {
+    (editor as any).registerCommand({
+      name: cmdName,
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection; attrs?: Record<string, string> }) => {
+        const selection = payload?.selection || (ed as any).selection;
+        if (!selection || selection.type !== 'range' || !payload?.attrs) return false;
+
+        const filtered: Record<string, string> = {};
+        for (const key of attrKeys) {
+          if (payload.attrs[key] !== undefined) filtered[key] = payload.attrs[key];
+        }
+        if (Object.keys(filtered).length === 0) return false;
+
+        const op = applyMark(
+          selection.startNodeId, selection.startOffset,
+          selection.endNodeId, selection.endOffset,
+          markType, filtered
+        );
+        const result = await transaction(ed, [op]).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+}
+
+export function createTextFormattingExtension(): TextFormattingExtension {
+  return new TextFormattingExtension();
+}

--- a/packages/extensions/src/toc.ts
+++ b/packages/extensions/src/toc.ts
@@ -1,0 +1,55 @@
+import { Editor, Extension, type ModelSelection } from '@barocss/editor-core';
+import { transaction, addChild } from '@barocss/model';
+
+export class TocExtension implements Extension {
+  name = 'toc';
+  priority = 100;
+
+  onCreate(editor: Editor): void {
+    (editor as any).registerCommand({
+      name: 'insertToc',
+      execute: async (ed: Editor, payload?: { selection?: ModelSelection }) => {
+        const insertInfo = this._getInsertInfo(ed, payload?.selection);
+        if (!insertInfo) return false;
+
+        const ops = [
+          addChild(insertInfo.parentId, { stype: 'toc' } as any, insertInfo.position)
+        ];
+        const result = await transaction(ed, ops, { applySelectionToView: true }).commit();
+        return result.success;
+      },
+      canExecute: () => true
+    });
+  }
+
+  onDestroy(_editor: Editor): void {}
+
+  private _getInsertInfo(editor: Editor, selection?: ModelSelection): { parentId: string; position: number } | null {
+    const sel = selection || (editor as any).selection;
+    if (!sel || sel.type !== 'range') return null;
+    const dataStore = (editor as any).dataStore;
+    if (!dataStore) return null;
+    const node = dataStore.getNode(sel.startNodeId);
+    if (!node) return null;
+
+    let blockId = sel.startNodeId;
+    let current = node;
+    const schema = dataStore.getActiveSchema?.();
+    while (current?.parentId) {
+      const parent = dataStore.getNode(current.parentId);
+      if (!parent) break;
+      if (schema?.getNodeType?.(parent.stype)?.group === 'block') { blockId = parent.sid ?? current.parentId; break; }
+      current = parent;
+    }
+    const block = dataStore.getNode(blockId);
+    if (!block?.parentId) return null;
+    const docParent = dataStore.getNode(block.parentId);
+    if (!docParent || !Array.isArray(docParent.content)) return null;
+    const idx = docParent.content.indexOf(blockId);
+    return { parentId: block.parentId, position: idx === -1 ? docParent.content.length : idx + 1 };
+  }
+}
+
+export function createTocExtension(): TocExtension {
+  return new TocExtension();
+}

--- a/packages/extensions/src/underline.ts
+++ b/packages/extensions/src/underline.ts
@@ -47,9 +47,6 @@ export class UnderlineExtension implements Extension {
     if (!selection || selection.type !== 'range') {
       return false;
     }
-    if (selection.startNodeId !== selection.endNodeId) {
-      return false;
-    }
 
     const op = toggleMark(
       selection.startNodeId,

--- a/packages/extensions/test/checklist-extension.test.ts
+++ b/packages/extensions/test/checklist-extension.test.ts
@@ -6,9 +6,12 @@ const commitMock = vi.fn();
 
 vi.mock('@barocss/model', () => {
   return {
-    transaction: (_editor: Editor, operations: any[]) => {
+    transaction: (_editor: Editor, operations: any[], _opts?: any) => {
       recordedTransactions.push(operations);
       return { commit: commitMock };
+    },
+    control: (target: string, actions: any[]) => {
+      return actions.map((a: any) => ({ type: a.type, payload: { ...a.payload, nodeId: target } }));
     },
     insertChecklist: (checked?: boolean) => ({
       type: 'insertChecklist',
@@ -72,14 +75,13 @@ describe('ChecklistExtension', () => {
     ]);
   });
 
-  it('registers toggleChecklistItem command', async () => {
+  it('toggleChecklistItem uses transaction to toggle checked attribute', async () => {
     const { ChecklistExtension } = await import('../src/checklist');
     const dataStore = {
       getNode: (id: string) => {
         if (id === 'task-1') return { sid: 'task-1', stype: 'taskItem', attributes: { checked: false } };
         return null;
       },
-      setAttrs: vi.fn()
     };
     const editor = createFakeEditor(dataStore);
     const ext = new ChecklistExtension();
@@ -89,7 +91,12 @@ describe('ChecklistExtension', () => {
     expect(cmd).toBeDefined();
 
     await cmd.execute(editor, { nodeId: 'task-1' });
-    expect(dataStore.setAttrs).toHaveBeenCalledWith('task-1', { checked: true });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions).toHaveLength(1);
+    const ops = recordedTransactions[0];
+    expect(ops[0].type).toBe('setAttrs');
+    expect(ops[0].payload.attrs).toEqual({ checked: true });
+    expect(ops[0].payload.nodeId).toBe('task-1');
   });
 
   it('does not register commands when disabled', async () => {

--- a/packages/extensions/test/new-extensions.test.ts
+++ b/packages/extensions/test/new-extensions.test.ts
@@ -1,0 +1,724 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Editor, ModelSelection } from '@barocss/editor-core';
+
+const recordedTransactions: any[][] = [];
+const commitMock = vi.fn();
+
+vi.mock('@barocss/model', () => {
+  return {
+    transaction: (_editor: Editor, operations: any[], _opts?: any) => {
+      recordedTransactions.push(operations);
+      return { commit: commitMock };
+    },
+    addChild: (parentId: string, child: any, position?: number) => ({
+      type: 'addChild', payload: { parentId, child, position }
+    }),
+    removeChild: (parentId: string, childId: string) => ({
+      type: 'removeChild', payload: { parentId, childId }
+    }),
+    toggleMark: (startId: string, startOff: number, endId: string, endOff: number, markType: string, attrs?: any) => ({
+      type: 'toggleMark', payload: { range: { startNodeId: startId, startOffset: startOff, endNodeId: endId, endOffset: endOff }, markType, attrs }
+    }),
+    applyMark: (startId: string, startOff: number, endId: string, endOff: number, markType: string, attrs?: any) => ({
+      type: 'applyMark', payload: { range: { startNodeId: startId, startOffset: startOff, endNodeId: endId, endOffset: endOff }, markType, attrs }
+    }),
+    splitTextNode: (nodeId: string, offset: number) => ({
+      type: 'splitTextNode', payload: { nodeId, offset }
+    }),
+    control: (_target: string, ops: any[]) => ops,
+  };
+});
+
+const defaultSelection: ModelSelection = {
+  type: 'range',
+  startNodeId: 'text-1',
+  startOffset: 0,
+  endNodeId: 'text-1',
+  endOffset: 5,
+  collapsed: false,
+  direction: 'forward'
+};
+
+function createFakeEditor(dataStore?: any, sel?: ModelSelection): any {
+  const commands: Record<string, any> = {};
+  return {
+    registerCommand: (cmd: any) => { commands[cmd.name] = cmd; },
+    __getCommand(name: string) { return commands[name]; },
+    selection: sel ?? defaultSelection,
+    dataStore: dataStore ?? {
+      getNode: (id: string) => {
+        if (id === 'text-1') return { sid: 'text-1', stype: 'inline-text', text: 'Hello', parentId: 'para-1' };
+        if (id === 'para-1') return { sid: 'para-1', stype: 'paragraph', content: ['text-1'], parentId: 'doc-1' };
+        if (id === 'doc-1') return { sid: 'doc-1', stype: 'document', content: ['para-1'] };
+        return null;
+      },
+      getActiveSchema: () => ({
+        getNodeType: (stype: string) => {
+          if (['paragraph', 'heading', 'blockQuote', 'codeBlock', 'list'].includes(stype)) return { group: 'block' };
+          if (['inline-text', 'hardBreak', 'emoji'].includes(stype)) return { group: 'inline' };
+          if (stype === 'document') return { group: 'document' };
+          return { group: 'block' };
+        }
+      }),
+      getRootNodeId: () => 'doc-1',
+    }
+  };
+}
+
+describe('PullQuoteExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertPullQuote registers and creates a pullQuote node', async () => {
+    const { PullQuoteExtension } = await import('../src/pull-quote');
+    const editor = createFakeEditor();
+    const ext = new PullQuoteExtension();
+    ext.onCreate(editor);
+
+    const cmd = editor.__getCommand('insertPullQuote');
+    expect(cmd).toBeDefined();
+
+    await cmd.execute(editor, { text: 'A great quote' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].type).toBe('addChild');
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('pullQuote');
+  });
+});
+
+describe('ColumnsExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertColumns creates a columns node with 2 columns by default', async () => {
+    const { ColumnsExtension } = await import('../src/columns');
+    const editor = createFakeEditor();
+    const ext = new ColumnsExtension();
+    ext.onCreate(editor);
+
+    const cmd = editor.__getCommand('insertColumns');
+    expect(cmd).toBeDefined();
+
+    await cmd.execute(editor);
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    const child = recordedTransactions[0][0].payload.child;
+    expect(child.stype).toBe('columns');
+    expect(child.content).toHaveLength(2);
+    expect(child.content[0].stype).toBe('column');
+  });
+
+  it('insertColumns creates specified number of columns', async () => {
+    const { ColumnsExtension } = await import('../src/columns');
+    const editor = createFakeEditor();
+    const ext = new ColumnsExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertColumns').execute(editor, { count: 3 });
+    expect(recordedTransactions[0][0].payload.child.content).toHaveLength(3);
+  });
+
+  it('addColumn adds a column to existing columns node', async () => {
+    const { ColumnsExtension } = await import('../src/columns');
+    const ds = {
+      ...createFakeEditor().dataStore,
+      getNode: (id: string) => {
+        if (id === 'cols-1') return { sid: 'cols-1', stype: 'columns', content: ['col-1'] };
+        return createFakeEditor().dataStore.getNode(id);
+      }
+    };
+    const editor = createFakeEditor(ds);
+    const ext = new ColumnsExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('addColumn').execute(editor, { columnsId: 'cols-1' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('column');
+  });
+
+  it('removeColumn removes a column', async () => {
+    const { ColumnsExtension } = await import('../src/columns');
+    const editor = createFakeEditor();
+    const ext = new ColumnsExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('removeColumn').execute(editor, { columnsId: 'cols-1', columnId: 'col-2' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].type).toBe('removeChild');
+  });
+});
+
+describe('TocExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertToc creates a toc atom node', async () => {
+    const { TocExtension } = await import('../src/toc');
+    const editor = createFakeEditor();
+    const ext = new TocExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertToc').execute(editor);
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('toc');
+  });
+});
+
+describe('DetailsExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertDetails creates a bDetails node with bSummary and paragraph', async () => {
+    const { DetailsExtension } = await import('../src/details');
+    const editor = createFakeEditor();
+    const ext = new DetailsExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertDetails').execute(editor, { summary: 'Click to expand' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    const child = recordedTransactions[0][0].payload.child;
+    expect(child.stype).toBe('bDetails');
+    expect(child.content[0].stype).toBe('bSummary');
+    expect(child.content[0].content[0].text).toBe('Click to expand');
+    expect(child.content[1].stype).toBe('paragraph');
+  });
+});
+
+describe('DescriptionListExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertDescriptionList creates a descList with term and def', async () => {
+    const { DescriptionListExtension } = await import('../src/description-list');
+    const editor = createFakeEditor();
+    const ext = new DescriptionListExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertDescriptionList').execute(editor);
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    const child = recordedTransactions[0][0].payload.child;
+    expect(child.stype).toBe('descList');
+    expect(child.content[0].stype).toBe('descTerm');
+    expect(child.content[1].stype).toBe('descDef');
+  });
+});
+
+describe('FigureExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertFigure creates a bFigure with inline-image', async () => {
+    const { FigureExtension } = await import('../src/figure');
+    const editor = createFakeEditor();
+    const ext = new FigureExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertFigure').execute(editor, { src: 'img.png', alt: 'test', caption: 'Fig 1' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    const child = recordedTransactions[0][0].payload.child;
+    expect(child.stype).toBe('bFigure');
+    expect(child.content[0].stype).toBe('inline-image');
+    expect(child.content[1].stype).toBe('bFigcaption');
+  });
+});
+
+describe('MediaExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertVideo creates a mediaVideo node', async () => {
+    const { MediaExtension } = await import('../src/media');
+    const editor = createFakeEditor();
+    const ext = new MediaExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertVideo').execute(editor, { src: 'video.mp4' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('mediaVideo');
+  });
+
+  it('insertAudio creates a mediaAudio node', async () => {
+    const { MediaExtension } = await import('../src/media');
+    const editor = createFakeEditor();
+    const ext = new MediaExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertAudio').execute(editor, { src: 'audio.mp3' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('mediaAudio');
+  });
+
+  it('insertEmbed creates a mediaEmbed node', async () => {
+    const { MediaExtension } = await import('../src/media');
+    const editor = createFakeEditor();
+    const ext = new MediaExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertEmbed').execute(editor, { provider: 'youtube', id: 'abc123' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('mediaEmbed');
+  });
+
+  it('insertVideo returns false without src', async () => {
+    const { MediaExtension } = await import('../src/media');
+    const editor = createFakeEditor();
+    const ext = new MediaExtension();
+    ext.onCreate(editor);
+
+    const result = await editor.__getCommand('insertVideo').execute(editor, {});
+    expect(result).toBe(false);
+    expect(commitMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('FontSizeExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('setFontSize applies fontSize mark', async () => {
+    const { FontSizeExtension } = await import('../src/font-size');
+    const editor = createFakeEditor();
+    const ext = new FontSizeExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('setFontSize').execute(editor, { selection: defaultSelection, size: '18px' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].type).toBe('applyMark');
+    expect(recordedTransactions[0][0].payload.markType).toBe('fontSize');
+    expect(recordedTransactions[0][0].payload.attrs).toEqual({ size: '18px' });
+  });
+
+  it('removeFontSize toggles off fontSize mark', async () => {
+    const { FontSizeExtension } = await import('../src/font-size');
+    const editor = createFakeEditor();
+    const ext = new FontSizeExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('removeFontSize').execute(editor, { selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].type).toBe('toggleMark');
+    expect(recordedTransactions[0][0].payload.markType).toBe('fontSize');
+  });
+});
+
+describe('FontFamilyExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('setFontFamily applies fontFamily mark', async () => {
+    const { FontFamilyExtension } = await import('../src/font-family');
+    const editor = createFakeEditor();
+    const ext = new FontFamilyExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('setFontFamily').execute(editor, { selection: defaultSelection, family: 'Georgia' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('fontFamily');
+    expect(recordedTransactions[0][0].payload.attrs).toEqual({ family: 'Georgia' });
+  });
+});
+
+describe('TextFormattingExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('toggleSmallCaps toggles smallCaps mark', async () => {
+    const { TextFormattingExtension } = await import('../src/text-formatting');
+    const editor = createFakeEditor();
+    const ext = new TextFormattingExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('toggleSmallCaps').execute(editor, { selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('smallCaps');
+  });
+
+  it('toggleKbd toggles kbd mark', async () => {
+    const { TextFormattingExtension } = await import('../src/text-formatting');
+    const editor = createFakeEditor();
+    const ext = new TextFormattingExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('toggleKbd').execute(editor, { selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('kbd');
+  });
+
+  it('toggleSpoiler toggles spoiler mark', async () => {
+    const { TextFormattingExtension } = await import('../src/text-formatting');
+    const editor = createFakeEditor();
+    const ext = new TextFormattingExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('toggleSpoiler').execute(editor, { selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('spoiler');
+  });
+
+  it('setLetterSpacing applies letterSpacing mark with value', async () => {
+    const { TextFormattingExtension } = await import('../src/text-formatting');
+    const editor = createFakeEditor();
+    const ext = new TextFormattingExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('setLetterSpacing').execute(editor, { selection: defaultSelection, value: '0.2em' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('letterSpacing');
+    expect(recordedTransactions[0][0].payload.attrs).toEqual({ spacing: '0.2em' });
+  });
+
+  it('setLineHeight applies lineHeight mark', async () => {
+    const { TextFormattingExtension } = await import('../src/text-formatting');
+    const editor = createFakeEditor();
+    const ext = new TextFormattingExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('setLineHeight').execute(editor, { selection: defaultSelection, value: '2.0' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('lineHeight');
+  });
+
+  it('setBorder applies border mark with multi attrs', async () => {
+    const { TextFormattingExtension } = await import('../src/text-formatting');
+    const editor = createFakeEditor();
+    const ext = new TextFormattingExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('setBorder').execute(editor, { selection: defaultSelection, attrs: { style: 'dashed', width: '2px', color: '#ff0000' } });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('border');
+    expect(recordedTransactions[0][0].payload.attrs).toEqual({ style: 'dashed', width: '2px', color: '#ff0000' });
+  });
+
+  it('setSpanLang applies spanLang mark', async () => {
+    const { TextFormattingExtension } = await import('../src/text-formatting');
+    const editor = createFakeEditor();
+    const ext = new TextFormattingExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('setSpanLang').execute(editor, { selection: defaultSelection, attrs: { lang: 'ko', dir: 'ltr' } });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('spanLang');
+  });
+});
+
+describe('MentionExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertMention applies mention mark with id', async () => {
+    const { MentionExtension } = await import('../src/mention');
+    const editor = createFakeEditor();
+    const ext = new MentionExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertMention').execute(editor, { selection: defaultSelection, id: 'user-42' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('mention');
+    expect(recordedTransactions[0][0].payload.attrs).toEqual({ id: 'user-42' });
+  });
+
+  it('insertMention returns false without id', async () => {
+    const { MentionExtension } = await import('../src/mention');
+    const editor = createFakeEditor();
+    const ext = new MentionExtension();
+    ext.onCreate(editor);
+
+    const result = await editor.__getCommand('insertMention').execute(editor, { selection: defaultSelection });
+    expect(result).toBe(false);
+  });
+});
+
+describe('FootnoteExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertFootnote creates footnoteDef + footnoteRef mark', async () => {
+    const { FootnoteExtension } = await import('../src/footnote');
+    const editor = createFakeEditor();
+    const ext = new FootnoteExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertFootnote').execute(editor, { id: 'fn-1', text: 'See reference', selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0]).toHaveLength(2);
+    expect(recordedTransactions[0][0].type).toBe('addChild');
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('footnoteDef');
+    expect(recordedTransactions[0][1].type).toBe('applyMark');
+    expect(recordedTransactions[0][1].payload.markType).toBe('footnoteRef');
+  });
+
+  it('insertFootnoteRef applies footnoteRef mark only', async () => {
+    const { FootnoteExtension } = await import('../src/footnote');
+    const editor = createFakeEditor();
+    const ext = new FootnoteExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertFootnoteRef').execute(editor, { id: 'fn-1', selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('footnoteRef');
+  });
+});
+
+describe('BookmarkExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertBookmark creates a bookmarkAnchor inline atom', async () => {
+    const { BookmarkExtension } = await import('../src/bookmark');
+    const editor = createFakeEditor();
+    const ext = new BookmarkExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertBookmark').execute(editor, { id: 'bm-1', selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('bookmarkAnchor');
+    expect(recordedTransactions[0][0].payload.child.attributes.id).toBe('bm-1');
+  });
+});
+
+describe('FieldExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertFieldPageNumber creates fieldPageNumber atom', async () => {
+    const { FieldExtension } = await import('../src/field');
+    const editor = createFakeEditor();
+    const ext = new FieldExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertFieldPageNumber').execute(editor, { selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('fieldPageNumber');
+  });
+
+  it('insertFieldDateTime creates fieldDateTime with format attr', async () => {
+    const { FieldExtension } = await import('../src/field');
+    const editor = createFakeEditor();
+    const ext = new FieldExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertFieldDateTime').execute(editor, { selection: defaultSelection, format: 'YYYY-MM-DD' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('fieldDateTime');
+    expect(recordedTransactions[0][0].payload.child.attributes.format).toBe('YYYY-MM-DD');
+  });
+
+  it('insertFieldDocTitle creates fieldDocTitle atom', async () => {
+    const { FieldExtension } = await import('../src/field');
+    const editor = createFakeEditor();
+    const ext = new FieldExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertFieldDocTitle').execute(editor, { selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('fieldDocTitle');
+  });
+
+  it('insertFieldAuthor creates fieldAuthor atom', async () => {
+    const { FieldExtension } = await import('../src/field');
+    const editor = createFakeEditor();
+    const ext = new FieldExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertFieldAuthor').execute(editor, { selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('fieldAuthor');
+  });
+});
+
+describe('DocStructureExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertDocSection creates a docSection with paragraph', async () => {
+    const { DocStructureExtension } = await import('../src/doc-structure');
+    const editor = createFakeEditor();
+    const ext = new DocStructureExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertDocSection').execute(editor);
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('docSection');
+    expect(recordedTransactions[0][0].payload.child.content[0].stype).toBe('paragraph');
+  });
+
+  it('insertChart creates a chart atom with attrs', async () => {
+    const { DocStructureExtension } = await import('../src/doc-structure');
+    const editor = createFakeEditor();
+    const ext = new DocStructureExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertChart').execute(editor, { attrs: { title: 'Sales', values: '10,20,30' } });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    const child = recordedTransactions[0][0].payload.child;
+    expect(child.stype).toBe('chart');
+    expect(child.attributes.title).toBe('Sales');
+    expect(child.attributes.values).toBe('10,20,30');
+  });
+
+  it('insertEndnote creates endnoteDef with id attr', async () => {
+    const { DocStructureExtension } = await import('../src/doc-structure');
+    const editor = createFakeEditor();
+    const ext = new DocStructureExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertEndnote').execute(editor, { attrs: { id: 'en-1' } });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('endnoteDef');
+    expect(recordedTransactions[0][0].payload.child.attributes.id).toBe('en-1');
+  });
+
+  it('insertBibliography creates bibliography block', async () => {
+    const { DocStructureExtension } = await import('../src/doc-structure');
+    const editor = createFakeEditor();
+    const ext = new DocStructureExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertBibliography').execute(editor);
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('bibliography');
+  });
+
+  it('insertDocHeader creates docHeader block', async () => {
+    const { DocStructureExtension } = await import('../src/doc-structure');
+    const editor = createFakeEditor();
+    const ext = new DocStructureExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertDocHeader').execute(editor);
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('docHeader');
+  });
+
+  it('insertDocFooter creates docFooter block', async () => {
+    const { DocStructureExtension } = await import('../src/doc-structure');
+    const editor = createFakeEditor();
+    const ext = new DocStructureExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('insertDocFooter').execute(editor);
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.child.stype).toBe('docFooter');
+  });
+});
+
+describe('HardBreakExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertHardBreak inserts a hardBreak atom', async () => {
+    const { HardBreakExtension } = await import('../src/hard-break');
+    const editor = createFakeEditor();
+    const ext = new HardBreakExtension();
+    ext.onCreate(editor);
+
+    const cmd = editor.__getCommand('insertHardBreak');
+    expect(cmd).toBeDefined();
+    expect(cmd.canExecute(editor)).toBe(true);
+  });
+});
+
+describe('CodeMarkExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('toggleCode toggles code mark', async () => {
+    const { CodeMarkExtension } = await import('../src/code-mark');
+    const editor = createFakeEditor();
+    const ext = new CodeMarkExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('toggleCode').execute(editor, { selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('code');
+  });
+});
+
+describe('HighlightExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('toggleHighlight uses default color', async () => {
+    const { HighlightExtension } = await import('../src/highlight');
+    const editor = createFakeEditor();
+    const ext = new HighlightExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('toggleHighlight').execute(editor, { selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('highlight');
+    expect(recordedTransactions[0][0].payload.attrs).toEqual({ color: '#ffeb3b' });
+  });
+
+  it('toggleHighlight uses custom color', async () => {
+    const { HighlightExtension } = await import('../src/highlight');
+    const editor = createFakeEditor();
+    const ext = new HighlightExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('toggleHighlight').execute(editor, { selection: defaultSelection, color: '#00ff00' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.attrs).toEqual({ color: '#00ff00' });
+  });
+});
+
+describe('SubSuperExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('toggleSubscript toggles subscript mark', async () => {
+    const { SubSuperExtension } = await import('../src/sub-super');
+    const editor = createFakeEditor();
+    const ext = new SubSuperExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('toggleSubscript').execute(editor, { selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('subscript');
+  });
+
+  it('toggleSuperscript toggles superscript mark', async () => {
+    const { SubSuperExtension } = await import('../src/sub-super');
+    const editor = createFakeEditor();
+    const ext = new SubSuperExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('toggleSuperscript').execute(editor, { selection: defaultSelection });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('superscript');
+  });
+});
+
+describe('PageBreakExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertPageBreak creates a pageBreak atom', async () => {
+    const { PageBreakExtension } = await import('../src/page-break');
+    const editor = createFakeEditor();
+    const ext = new PageBreakExtension();
+    ext.onCreate(editor);
+
+    const cmd = editor.__getCommand('insertPageBreak');
+    expect(cmd).toBeDefined();
+  });
+});
+
+describe('FontColorExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('setFontColor applies fontColor mark', async () => {
+    const { FontColorExtension } = await import('../src/font-color');
+    const editor = createFakeEditor();
+    const ext = new FontColorExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('setFontColor').execute(editor, { selection: defaultSelection, color: '#ff0000' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('fontColor');
+  });
+
+  it('setBgColor applies bgColor mark', async () => {
+    const { FontColorExtension } = await import('../src/font-color');
+    const editor = createFakeEditor();
+    const ext = new FontColorExtension();
+    ext.onCreate(editor);
+
+    await editor.__getCommand('setBgColor').execute(editor, { selection: defaultSelection, color: '#00ff00' });
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions[0][0].payload.markType).toBe('bgColor');
+  });
+});
+
+describe('MathInlineExtension', () => {
+  beforeEach(() => { recordedTransactions.length = 0; commitMock.mockReset(); commitMock.mockResolvedValue({ success: true }); });
+
+  it('insertMathInline inserts a mathInline atom', async () => {
+    const { MathInlineExtension } = await import('../src/math-inline');
+    const editor = createFakeEditor();
+    const ext = new MathInlineExtension();
+    ext.onCreate(editor);
+
+    const cmd = editor.__getCommand('insertMathInline');
+    expect(cmd).toBeDefined();
+  });
+});

--- a/packages/extensions/test/strikethrough-extension.test.ts
+++ b/packages/extensions/test/strikethrough-extension.test.ts
@@ -81,7 +81,7 @@ describe('StrikeThroughExtension - toggleStrikeThrough', () => {
     ]);
   });
 
-  it('여러 노드에 걸친 RangeSelection 은 아직 처리하지 않고 false 를 반환한다', async () => {
+  it('여러 노드에 걸친 RangeSelection 도 cross-node toggleMark 로 처리한다', async () => {
     const dataStore = {
       getNode: (_id: string) => null
     };
@@ -102,9 +102,18 @@ describe('StrikeThroughExtension - toggleStrikeThrough', () => {
     };
 
     const result = await cmd.execute(editor, { selection });
-    expect(result).toBe(false);
-    expect(commitMock).not.toHaveBeenCalled();
-    expect(recordedTransactions).toHaveLength(0);
+    expect(result).toBe(true);
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions).toHaveLength(1);
+
+    const ops = recordedTransactions[0];
+    expect(ops[0]).toEqual({
+      type: 'toggleMark',
+      payload: {
+        range: { startNodeId: 'text-1', startOffset: 1, endNodeId: 'text-2', endOffset: 3 },
+        markType: 'strikethrough'
+      }
+    });
   });
 });
 

--- a/packages/extensions/test/underline-extension.test.ts
+++ b/packages/extensions/test/underline-extension.test.ts
@@ -81,7 +81,7 @@ describe('UnderlineExtension - toggleUnderline', () => {
     ]);
   });
 
-  it('여러 노드에 걸친 RangeSelection 은 아직 처리하지 않고 false 를 반환한다', async () => {
+  it('여러 노드에 걸친 RangeSelection 도 cross-node toggleMark 로 처리한다', async () => {
     const dataStore = {
       getNode: (_id: string) => null
     };
@@ -102,9 +102,18 @@ describe('UnderlineExtension - toggleUnderline', () => {
     };
 
     const result = await cmd.execute(editor, { selection });
-    expect(result).toBe(false);
-    expect(commitMock).not.toHaveBeenCalled();
-    expect(recordedTransactions).toHaveLength(0);
+    expect(result).toBe(true);
+    expect(commitMock).toHaveBeenCalledTimes(1);
+    expect(recordedTransactions).toHaveLength(1);
+
+    const ops = recordedTransactions[0];
+    expect(ops[0]).toEqual({
+      type: 'toggleMark',
+      payload: {
+        range: { startNodeId: 'text-1', startOffset: 1, endNodeId: 'text-2', endOffset: 3 },
+        markType: 'underline'
+      }
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Document all 55+ extensions in `extensions-api.md` with categorized tables (was only ~21)
- Fix `EditorViewDOM` constructor API errors across 5 files
- Add comprehensive React Editor tutorial guide (9-step walkthrough)
- Update introduction, installation, architecture docs to reflect current state

## Changes

### Extension Documentation (api/extensions-api.md)
- Added 23 new extension sections: CodeMark, Highlight, FontColor, SubSuper, FontSize, FontFamily, TextFormatting, Mention, Footnote, HardBreak, PageBreak, MathInline, PullQuote, Columns, Toc, Details, DescriptionList, Figure, Media, Bookmark, Field, DocStructure
- Added missing ListExtension and BlockquoteExtension
- Reorganized summary tables by category (Core / Basic / Rich Marks / Rich Blocks / UX)
- Added schema coverage section (48 nodes, 24 marks — 100%)

### API Fix
- `EditorViewDOM(editor, container)` → `EditorViewDOM(editor, { container })` in: quick-start.md, basic-usage.md, practical-examples.md, editor-view-dom.md, editor-view-react.md

### New: React Editor Guide (guides/react-editor.md)
- Step-by-step tutorial: Schema → React renderers → Editor instance → EditorView → Toolbar → Ref API → Overlay layers → Rich components → Context hooks
- Complete copy-paste example
- BlockComponentProps / MarkComponentProps reference tables
- DOM vs React comparison table

### Other Updates
- introduction.md: Dual rendering, collaboration, converter, schema scale
- installation.md: React, collaboration, devtool packages
- architecture/extensions.md, packages.md: Full extension sets
- guides/extension-design.md: Real bug fix example (Checklist)
- examples/custom-extensions.md: 3 real-world patterns
- concepts/editor-core.md: Extended CommandChain table
- sidebars.ts: Added React guide to Guides category

## Test plan
- [x] `pnpm --filter docs-site build` passes successfully
- [x] All internal links verified (no broken cross-references)
- [x] EditorViewDOM constructor matches actual TypeScript interface

Closes #246

Made with [Cursor](https://cursor.com)